### PR TITLE
Fix some PHP 5.3.0 errors and warnings

### DIFF
--- a/Tools/projectGenerator/classes/FileUtil.php
+++ b/Tools/projectGenerator/classes/FileUtil.php
@@ -81,7 +81,7 @@ class FileUtil
 	      if( !is_array( $v ) )
 	         continue;
 	
-	      FileUtil::trimFileList( &$list[ $k ] );
+	      FileUtil::trimFileList( $list[ $k ] );
 	   }
 	}
 	

--- a/Tools/projectGenerator/classes/Project.php
+++ b/Tools/projectGenerator/classes/Project.php
@@ -303,7 +303,7 @@ class Project
             }
         }
 
-        FileUtil::trimFileList( &$projectFiles );
+        FileUtil::trimFileList( $projectFiles );
 
         // Uncomment me to see the structure the file lister is returning.
         //print_r($projectFiles);
@@ -316,6 +316,7 @@ class Project
         // Set the template delimiters
         $tpl->left_delimiter  = $output->ldelim  ? $output->ldelim  : '{';
         $tpl->right_delimiter = $output->rdelim ? $output->rdelim : '}';
+        $gameProjectName = getGameProjectName();
 
         // Evaluate template into a file.
         $tpl->assign_by_ref( 'projSettings', $this );
@@ -331,7 +332,7 @@ class Project
         $tpl->assign_by_ref( 'projLibs',     $this->libs );
         $tpl->assign_by_ref( 'projLibDirs',  $this->lib_dirs );
         $tpl->assign_by_ref( 'projDepend',   $this->dependencies );
-        $tpl->assign_by_ref( 'gameProjectName', getGameProjectName() );
+        $tpl->assign_by_ref( 'gameProjectName', $gameProjectName );
         $tpl->assign_by_ref( 'projModuleDefinitionFile',   $this->moduleDefinitionFile );
         $tpl->assign_by_ref( 'projSubSystem', $this->projSubSystem );
         


### PR DESCRIPTION
This fixes a couple errors with PHP 5.3.0 onward with regards to pass-by-reference. I haven't tested this on PHP < 5.4.5, but everything _should_ work with versions before that as well.
