### PR TITLE
Fixed Item networking in editor.

### DIFF
--- a/Engine/source/T3D/item.cpp
+++ b/Engine/source/T3D/item.cpp
@@ -457,6 +457,11 @@ void Item::onDeleteNotify( SimObject *obj )
    Parent::onDeleteNotify( obj );
 }
 
+void Item::inspectPostApply() 
+{ 
+   setMaskBits(InitialUpdateMask); 
+} 
+
 // Lighting: -----------------------------------------------------------------
 
 void Item::registerLights(LightManager * lightManager, bool lightingScene)

--- a/Engine/source/T3D/item.h
+++ b/Engine/source/T3D/item.h
@@ -149,6 +149,7 @@ class Item: public ShapeBase
    bool buildPolyList(PolyListContext context, AbstractPolyList* polyList, const Box3F &box, const SphereF &sphere);
    void buildConvex(const Box3F& box, Convex* convex);
    void onDeleteNotify(SimObject*);
+   void inspectPostApply();
 
   protected:
    void _updatePhysics();


### PR DESCRIPTION
When checking/unchecking 'rotate' for an Item in the editor, the Item would not update on the client. This solves the issue by calling setMaskBits in inspectPostApply.
