### PR TITLE
Fixes the dllmain.h template file to include MIT header

### DIFF
--- a/Tools/projectGenerator/templates/web/activex_dllmain_h.tpl
+++ b/Tools/projectGenerator/templates/web/activex_dllmain_h.tpl
@@ -1,3 +1,25 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2012 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
 // dllmain.h : Declaration of module class.
 
 class CIEWebGamePluginModule : public CAtlDllModuleT< CIEWebGamePluginModule >


### PR DESCRIPTION
This fixes an issue with generating the dllmain.h header when using the projectGenerator. This was brought to attention by DaveMB's commit: https://github.com/DaveMB/Torque3D/commit/0aca5b815871e0086cb18d1585782e38cc3876ba#commitcomment-1891583

As a side note, and this may just be me, but anything generated from a template like this (so Templates/*/web/source/activex/dllmain.h as an example here) probably shouldn't be included in the source repo since the files are generated. That's almost a separate issue though.
