### PR TITLE
Compiling under Visual Studio 2012

### DIFF
--- a/Engine/source/platform/types.visualc.h
+++ b/Engine/source/platform/types.visualc.h
@@ -88,7 +88,9 @@ typedef unsigned _int64 U64;
 #  define FN_CDECL __cdecl            ///< Calling convention
 #endif
 
+#if _MSC_VER < 1700
 #define for if(false) {} else for   ///< Hack to work around Microsoft VC's non-C++ compliance on variable scoping
+#endif
 
 // disable warning caused by memory layer
 // see msdn.microsoft.com "Compiler Warning (level 1) C4291" for more details

--- a/Engine/source/platform/typesWin32.h
+++ b/Engine/source/platform/typesWin32.h
@@ -116,7 +116,9 @@ static const F32 F32_MAX = F32(3.402823466e+38F);                 ///< Constant 
 
 
 #ifdef _MSC_VER
+#if _MSC_VER < 1700
 #define for if(false) {} else for   ///< Hack to work around Microsoft VC's non-C++ compliance on variable scoping
+#endif
 #endif
 
 


### PR DESCRIPTION
VS2012 does not allow keywords to be macroized. Torque does this to 'for' to get around a scoping bug in previous versions of VS that appears to have been fixed. This patch does not alter code when compiling under VS < 2012.
