### PR TITLE
Feature: "externalCommand" for Torque3D.

### DIFF
--- a/Engine/source/main/main.cpp
+++ b/Engine/source/main/main.cpp
@@ -45,6 +45,26 @@ bool getDllName(std::wstring& dllName)
    return true;
 }
 
+BOOL CALLBACK enumWindowsProc (HWND hwnd, LPARAM lParam)
+{
+   // The className used here should be equal to:
+   // 1. Engine/source/windowManager/win32/win32Window.cpp: const UTF16* _MainWindowClassName = L"TorqueJuggernaughtWindow";
+   // 2. Engine/source/windowManager/win32/winDispatch.cpp: dStrcmp(classBuf, L"TorqueJuggernaughtWindow")
+   // So if you change it there, don't forget to update it here too.
+   // [2012/09/25 bank]
+   const char* className       = "TorqueJuggernaughtWindow";
+   int         classNameLength = strlen(className)+1;
+   char*       classNameOut    = new char[classNameLength];
+
+   GetClassNameA(hwnd, classNameOut, classNameLength);
+
+   if(!strcmp(className, classNameOut))
+      SendMessageA(hwnd, WM_COPYDATA, NULL, lParam);
+
+   delete [] classNameOut;
+   return TRUE;
+}
+
 int PASCAL WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdLine, int nCommandShow)
 {
    std::wstring dllName = std::wstring();
@@ -53,6 +73,22 @@ int PASCAL WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdL
       MessageBoxW(NULL, L"Unable to find game dll", L"Error",  MB_OK|MB_ICONWARNING);
       return -1;
    }
+   const char* externalCommand       = "externalCommand";
+   const int   externalCommandLength = strlen(externalCommand);
+   if(!memcmp(lpszCmdLine, externalCommand, externalCommandLength))
+   {
+      LPSTR path = lpszCmdLine + externalCommandLength + 1;
+
+      COPYDATASTRUCT cds;
+      cds.dwData = 100500; // externalCommand
+      cds.lpData = path;
+      cds.cbData = strlen(path) + 1;
+
+      EnumWindows(enumWindowsProc, (LPARAM)&cds);
+      return 0;
+   }
+   char filename[4096];
+   char gameLib[4096];
 
    HMODULE hGame = LoadLibraryW(dllName.c_str());
    if (!hGame)

--- a/Engine/source/windowManager/win32/win32Window.cpp
+++ b/Engine/source/windowManager/win32/win32Window.cpp
@@ -665,6 +665,19 @@ LRESULT PASCAL Win32Window::WindowProc( HWND hWnd, UINT message, WPARAM wParam, 
 
 	switch (message)
 	{
+#ifndef TORQUE_SHIPPING
+   case WM_COPYDATA:
+      {
+         COPYDATASTRUCT* cds = (COPYDATASTRUCT*)lParam;
+
+         if(cds->dwData != 100500) // externalCommand
+            break;
+
+         char* message = (char*)cds->lpData;
+         Con::executef("parseExternalCommand", message);
+      }
+      break;
+#endif
 
 	case WM_DISPLAYCHANGE:
       // Update the monitor list

--- a/Templates/Empty/game/tools/main.cs
+++ b/Templates/Empty/game/tools/main.cs
@@ -38,6 +38,47 @@ $Tools::materialEditorList = "";
 //---------------------------------------------------------------------------------------------
 package Tools
 {
+   //---------------------------------------------------------------------------
+   // How to use "externalCommand" it in Torsion:
+   // (instructions for other IDE should be similar)
+   // 1. In Torsion open "Tools" menu and select "External Tools"
+   // 2. Select first empty slot and enter following:
+   // Title: &Reload current script
+   // Command: $(ConfigExe)
+   // Arguments: externalCommand 1 $(FilePath)
+   // Initial Directory: $(ProjectWorkingDir)
+   // Press OK
+   //---------------------------------------------------------------------------
+   // Follow the same routine to add another command as desired. More examples:
+   // Title: E&xit Torque3D
+   // Command: $(ConfigExe)
+   // Arguments: externalCommand 2 quit
+   // Initial Directory: $(ProjectWorkingDir)
+   //---------------------------------------------------------------------------
+   // Title: &Toggle Editor
+   // Command: $(ConfigExe)
+   // Arguments: externalCommand 2 toggleEditor 1
+   // Initial Directory: $(ProjectWorkingDir)
+   function parseExternalCommand(%msg)
+   {
+      %cmd  = firstWord(%msg);
+      %data = restWords(%msg);
+      switch(%cmd)
+      {
+         case 1: // Exec script
+            %filename = strreplace(%data, "\\", "/");
+            exec(%filename);
+         case 2: // Call function
+            %funcName = firstWord(%data);
+            %params = restWords(%data);
+            if(%params !$= "")
+               call(%funcName, %params);
+            else
+               call(%funcName);
+      }
+   }
+   //---------------------------------------------------------------------------
+
    function loadKeybindings()
    {
       Parent::loadKeybindings();

--- a/Templates/Full/game/tools/main.cs
+++ b/Templates/Full/game/tools/main.cs
@@ -38,6 +38,47 @@ $Tools::materialEditorList = "";
 //---------------------------------------------------------------------------------------------
 package Tools
 {
+   //---------------------------------------------------------------------------
+   // How to use "externalCommand" it in Torsion:
+   // (instructions for other IDE should be similar)
+   // 1. In Torsion open "Tools" menu and select "External Tools"
+   // 2. Select first empty slot and enter following:
+   // Title: &Reload current script
+   // Command: $(ConfigExe)
+   // Arguments: externalCommand 1 $(FilePath)
+   // Initial Directory: $(ProjectWorkingDir)
+   // Press OK
+   //---------------------------------------------------------------------------
+   // Follow the same routine to add another command as desired. More examples:
+   // Title: E&xit Torque3D
+   // Command: $(ConfigExe)
+   // Arguments: externalCommand 2 quit
+   // Initial Directory: $(ProjectWorkingDir)
+   //---------------------------------------------------------------------------
+   // Title: &Toggle Editor
+   // Command: $(ConfigExe)
+   // Arguments: externalCommand 2 toggleEditor 1
+   // Initial Directory: $(ProjectWorkingDir)
+   function parseExternalCommand(%msg)
+   {
+      %cmd  = firstWord(%msg);
+      %data = restWords(%msg);
+      switch(%cmd)
+      {
+         case 1: // Exec script
+            %filename = strreplace(%data, "\\", "/");
+            exec(%filename);
+         case 2: // Call function
+            %funcName = firstWord(%data);
+            %params = restWords(%data);
+            if(%params !$= "")
+               call(%funcName, %params);
+            else
+               call(%funcName);
+      }
+   }
+   //---------------------------------------------------------------------------
+
    function loadKeybindings()
    {
       Parent::loadKeybindings();


### PR DESCRIPTION
A new feature for Torque3D: "externalCommand".

How to use "externalCommand" it in Torsion:
(instructions for other IDE should be similar)
1. In Torsion open "Tools" menu and select "External Tools"
2. Select first empty slot and enter following:
Title: &Reload current script
Command: $(ConfigExe)
Arguments: externalCommand 1 $(FilePath)
Initial Directory: $(ProjectWorkingDir)
Press OK

Now you can reload the currently-edited script directly from Torsion with two mouse-clicks!
Click **Tools**, then **Reload current script**.

See comments in Templates/Full/game/tools/main.cs for more examples.

As a protection (for shipped games), the ectual execution is wrapped with TORQUE_SHIPPING and the scripted function "parseExternalCommand" is placed under "tools" folder.
