### PR TITLE
RayInfo distance with ContainerRayCast

### DIFF
--- a/Engine/source/scene/sceneContainer.cpp
+++ b/Engine/source/scene/sceneContainer.cpp
@@ -1612,7 +1612,8 @@ DefineEngineFunction( containerRayCast, const char*,
    "@returns A string containing either null, if nothing was struck, or these fields:\n"
    "<ul><li>The ID of the object that was struck.</li>"
    "<li>The x, y, z position that it was struck.</li>"
-   "<li>The x, y, z of the normal of the face that was struck.</li></ul>" 
+   "<li>The x, y, z of the normal of the face that was struck.</li>"
+   "<li>The distance between the start point and the position we hit.</li></ul>" 
 
    "@ingroup Game")
 {


### PR DESCRIPTION
Added an 8th word to ContainerRayCast's return statement, which is the distance of the hit position.
