### PR TITLE
Torque Smart ptr: Shared, Weak & Scoped

### DIFF
--- a/Engine/source/core/util/tScopedPtr.h
+++ b/Engine/source/core/util/tScopedPtr.h
@@ -1,0 +1,113 @@
+#ifndef _T3T_SCOPED_PTR_H_
+#define _T3T_SCOPED_PTR_H_
+
+//
+//  Copyright (c) 2001, 2002, 2003 Peter Dimov
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+//  See http://www.boost.org/libs/smart_ptr/WeakPtr.htm for documentation.
+//
+
+#include "platform\platformAssert.h"
+
+namespace Torque
+{
+	template<class T> 
+	class ScopedPtr // noncopyable
+	{
+	private:
+
+		T * px;
+
+		ScopedPtr(ScopedPtr const &);
+		ScopedPtr & operator=(ScopedPtr const &);
+
+		typedef ScopedPtr<T> this_type;
+
+		void operator==( ScopedPtr const& ) const;
+		void operator!=( ScopedPtr const& ) const;
+
+	public:
+
+		typedef T element_type;
+
+		typedef ScopedPtr<T> type;
+
+		explicit ScopedPtr( T * p = 0 ): px( p ) // never throws
+		{	
+		}	
+
+		//Not valid
+		template< class Y>
+		explicit ScopedPtr( Y * p ): px( p ) // never throws
+		{	
+			Y* _y = px; //Forced error
+		}	
+
+		~ScopedPtr() // never throws
+		{
+			if( px )
+				delete px;
+		}
+
+		void reset(T * p = 0) // never throws
+		{
+			AssertFatal( p == 0 || p != px ,""); // catch self-reset errors
+			this_type(p).swap(*this);
+		}
+
+		T & operator*() const // never throws
+		{
+			AssertFatal( px != 0, "");
+			return *px;
+		}
+
+		T * operator->() const // never throws
+		{
+			AssertFatal( px != 0, "");
+			return px;
+		}
+
+		T * get() const // never throws
+		{
+			return px;
+		}
+
+		// implicit conversion to "bool"
+		typedef T * this_type::*unspecified_bool_type;
+
+		operator unspecified_bool_type() const // never throws
+		{
+			return px == 0? 0: &this_type::px;
+		}
+
+		void swap(ScopedPtr & b) // never throws
+		{
+			T * tmp = b.px;
+			b.px = px;
+			px = tmp;
+		}
+	};
+	
+};
+
+	
+
+template<class T>
+inline void swap( Torque::ScopedPtr<T> & a, Torque::ScopedPtr<T> & b) // never throws
+{
+    a.swap(b);
+}
+
+// get_pointer(p) is a generic way to say p.get()
+
+template<class T>
+inline T * get_pointer( Torque::ScopedPtr<T> const & p)
+{
+    return p.get();
+}
+
+#endif

--- a/Engine/source/core/util/tSharedPtr.h
+++ b/Engine/source/core/util/tSharedPtr.h
@@ -1,0 +1,380 @@
+#ifndef _T3D_SHARED_PTR_H_
+#define _T3D_SHARED_PTR_H_
+
+//
+//  Copyright (c) 2001, 2002, 2003 Peter Dimov
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+//  See http://www.boost.org/libs/smart_ptr/WeakPtr.htm for documentation.
+//
+
+#include "core/util/refBase.h"
+#include "platform\platformAssert.h"
+#include "core\util\autoPtr.h"
+
+namespace Torque
+{
+	template<class T> class WeakPtr;
+	template<typename T> class AnyWeakRefPtr;
+	
+	namespace detail {
+		struct dynamic_cast_tag {};
+		struct static_cast_tag {};
+	};	
+
+	class AnyStrongRefBase : public StrongRefBase
+	{		
+	protected:
+		AnyStrongRefBase() : _px(NULL) {}
+	public:
+		void* _px;
+	};
+
+	template<typename Y>
+	class AnyStrongRef : public AnyStrongRefBase
+	{	
+	public:
+		AnyStrongRef() : AnyStrongRefBase(), _destructor(NULL) {}
+		virtual void destroySelf() 
+		{ 
+			if(_px && _destructor)
+				_destructor(( Y*)_px );
+			else delete (Y*)(_px); 
+
+			delete this; 
+		}
+		Y* get_ptr() const { return (Y*)_px; }		
+
+		void (*_destructor)(Y*);
+	};
+
+	template<typename T>
+	class AnyStrongRefPtr : protected StrongRefPtr< AnyStrongRefBase >
+	{
+		void set(StrongRefPtr< AnyStrongRefBase > const & n_ref)
+		{
+			StrongRefPtr< AnyStrongRefBase >::operator=( n_ref );		
+		}		
+
+	public:	
+
+		typedef WeakRefPtr<AnyStrongRefBase> weak_ptr_internal_ptr_type;
+
+		~AnyStrongRefPtr()
+		{
+			set( StrongRefPtr< AnyStrongRefBase >() );
+		}
+
+		AnyStrongRefPtr() {}
+
+		template<typename Y>
+		AnyStrongRefPtr(Y* p)
+		{	
+			this->set( new AnyStrongRef<Y>() );
+			this->getPointer()->_px = p;	
+		}	
+
+		template<typename Y, typename D>
+		AnyStrongRefPtr(Y* p, D* d)
+		{	
+			auto new_ref = new AnyStrongRef<Y>();
+			new_ref->_px = p;	
+			new_ref->_destructor = d;
+			this->set( new_ref );
+		}	
+
+		template<typename Y>
+		AnyStrongRefPtr( AnyStrongRefPtr<Y> const & p) 
+		{			
+			set( p.getPointer() );
+		}
+
+	
+		AnyStrongRefPtr( AnyStrongRefPtr const & p) 
+		{		
+			set( p.getPointer() );
+		}
+
+		template<typename Y>
+		AnyStrongRefPtr( AnyWeakRefPtr<Y> const &p) 
+		{		
+			if( !p.use_count() )
+				throw( bad_weak_ptr() );
+			
+			set( p.getPointer() );
+		}
+		
+		AnyStrongRefBase* getPointer() const 
+		{ 
+			return StrongRefPtr< AnyStrongRefBase >::getPointer();
+		}
+
+		T* get_real_ptr() const 
+		{
+			if( getPointer() )
+				return (T*)getPointer()->_px;
+			else
+				return NULL;
+		}
+
+		void swap( AnyStrongRefPtr<T>& p)
+		{
+			AnyStrongRefPtr<T> temp = *this;
+			*this = p;
+			p = temp;
+		}
+	
+		AnyStrongRefPtr& operator=( const AnyStrongRefPtr& p )
+		{
+			set( p.getPointer() );
+
+			return *this;
+		}
+
+		template<typename Y>
+		AnyStrongRefPtr<T>& operator=( const AnyStrongRefPtr<Y>& p )
+		{
+			set( p.getPointer() );
+
+			return *this;
+		}
+
+		template<typename Y>
+		bool operator<( const AnyStrongRefPtr<Y>& p ) const
+		{			
+			return getPointer()->getWeakReference() < p.getPointer()->getWeakReference();
+		}
+
+		long use_count() const
+		{
+			return getPointer()->getRefCount();
+		}
+
+	};
+
+
+	template<class T> class SharedPtr
+	{
+	private:
+   
+		typedef SharedPtr<T> this_type;
+
+		template<typename Y>
+		struct return_reference
+		{
+			typedef Y & reference;
+		};
+
+		template<>
+		struct return_reference<void>
+		{
+			typedef void reference;
+		};
+
+		typedef typename return_reference<T>::reference reference;
+		typedef T * this_type::*unspecified_bool_type;
+	
+
+		template<class Y> friend class SharedPtr;
+		template<class Y> friend class WeakPtr;
+
+		T * __px;                     // contained pointer
+		AnyStrongRefPtr<T> pn;		  // reference counter
+
+	public:
+
+		typedef T element_type;
+		typedef T value_type;
+		typedef T * pointer;
+    
+
+		SharedPtr():  pn() // never throws in 1.30+
+		{
+		}
+
+		SharedPtr( const AnyStrongRefPtr<T> &r ): pn( r ) // never throws
+		{
+		} 
+
+		template<class Y>
+		explicit SharedPtr( Y * p ): pn( p ) // Y must be complete
+		{       
+		}   
+
+		template<class Y, class D>
+		SharedPtr( Y * p, D* d ): pn( p, d ) // Y must be complete
+		{       
+		} 
+
+		SharedPtr( SharedPtr const & r ): pn( r.pn ) // never throws
+		{
+		}  
+
+		template<typename Y>
+		SharedPtr( SharedPtr<Y> const & r ): pn( r.pn ) // never throws
+		{
+		}  
+
+		template<class Y>
+		explicit SharedPtr(WeakPtr<Y> const & r): pn(r.pn) // may throw
+		{
+			
+		}
+
+		template<class Y>
+		explicit SharedPtr( AutoPtr<Y> & r ) : pn( SharedPtr<Y>( r.release() ).pn )
+		{
+
+		}
+
+		//dynamic_cast_tag
+		template<class Y>
+		SharedPtr(SharedPtr<Y> const & r, detail::dynamic_cast_tag): pn(r.pn)
+		{		
+			// need to allocate new counter -- the cast failed
+			if( !dynamic_cast<T*>( r.pn.get_real_ptr() ) )
+			{
+				pn = AnyStrongRefPtr<T>();
+			}		
+		}
+
+		template<class Y>
+		SharedPtr(SharedPtr<Y> const & r, detail::static_cast_tag) 
+		{
+			pn = static_cast< AnyStrongRefPtr<Y> >(r.pn);		
+		}	 
+
+		// assignment
+		SharedPtr & operator=( SharedPtr const & r ) // never throws
+		{
+			this_type(r).swap(*this);
+			return *this;
+		}	
+
+		template<class Y>
+		SharedPtr & operator=( AutoPtr<Y> & r )
+		{
+			this_type(r).swap(*this);
+			return *this;
+		}
+
+		template<class Y>
+		SharedPtr & operator=( Torque::WeakPtr<Y> & r )
+		{
+			this_type(r).swap(*this);
+			return *this;
+		}
+
+		void reset() // never throws in 1.30+
+		{
+			this_type().swap(*this);
+		}
+
+		template<class Y> void reset(Y * p) // Y must be complete
+		{
+			AssertFatal(p == 0 || p != px, ""); // catch self-reset errors
+			this_type(p).swap(*this);
+		}
+
+		template<class Y, class D> void reset( Y * p, D d )
+		{
+			this_type( p, d ).swap( *this );
+		}
+
+		template<class Y, class D, class A> void reset( Y * p, D d, A a )
+		{
+			this_type( p, d, a ).swap( *this );
+		}
+
+		template<class Y> void reset( SharedPtr<Y> const & r, T * p )
+		{
+			this_type( r, p ).swap( *this );
+		}
+
+		reference operator* () const // never throws
+		{
+			AssertFatal(pn.get_real_ptr() != 0, "");
+			return *(pn.get_real_ptr());
+		}
+
+		T * operator-> () const // never throws
+		{
+			AssertFatal(pn.get_real_ptr() != 0,"");
+			return pn.get_real_ptr();
+		}
+
+		T * get() const // never throws
+		{
+			return pn.get_real_ptr();
+		}
+		
+		operator unspecified_bool_type() const // never throws
+		{		
+			return pn.get_real_ptr() == 0? 0: &this_type::__px;
+		}
+
+		bool unique() const // never throws
+		{
+			return pn.unique();
+		}
+
+		long use_count() const // never throws
+		{
+			return pn.use_count();
+		}
+
+		void swap(SharedPtr<T> & other) // never throws
+		{  
+			pn.swap(other.pn);
+		}
+
+		void swap(Torque::WeakPtr<T> & other) // never throws
+		{    
+			pn.swap(other.pn);
+		}
+
+		template<class Y> bool owner_before( SharedPtr<Y> const & rhs ) const
+		{
+			return pn < rhs.pn;
+		}
+
+		bool _internal_equiv( SharedPtr const & r ) const
+		{
+		
+			return px == r.px && pn == r.pn;
+		}		
+
+	};  // SharedPtr
+
+
+	template<class T, class U> inline bool operator==(SharedPtr<T> const & a, SharedPtr<U> const & b)
+	{
+		return a.get() == b.get();
+	}
+
+	template<class T, class U> inline bool operator!=(SharedPtr<T> const & a, SharedPtr<U> const & b)
+	{
+		return a.get() != b.get();
+	}
+
+	template<class T, class U> SharedPtr<T> dynamic_pointer_cast(SharedPtr<U> const & r)
+	{
+		return SharedPtr<T>(r, Torque::detail::dynamic_cast_tag());
+	}
+
+	template<class T, class U> SharedPtr<T> static_pointer_cast(SharedPtr<U> const & r)
+	{
+		return SharedPtr<T>(r, Torque::detail::static_cast_tag());
+	}
+
+	template<class T, class U> inline bool operator<(SharedPtr<T> const & a, SharedPtr<U> const & b)
+	{
+		return a.owner_before( b );
+	}
+
+};
+
+#endif 

--- a/Engine/source/core/util/tWeakPtr.h
+++ b/Engine/source/core/util/tWeakPtr.h
@@ -1,0 +1,254 @@
+#ifndef _TORQUE_WEAK_PTR_H_
+#define _TORQUE_WEAK_PTR_H_
+
+//
+//  Copyright (c) 2001, 2002, 2003 Peter Dimov
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+//  See http://www.boost.org/libs/smart_ptr/WeakPtr.htm for documentation.
+//
+
+#include "core\util\refBase.h"
+#include "core\util\tSharedPtr.h"
+
+namespace Torque
+{
+	template<typename T>
+	class AnyWeakRefPtr : protected WeakRefPtr<AnyStrongRefBase>
+	{
+		void set( const WeakRefPtr<AnyStrongRefBase> &_ref)
+		{			
+			WeakRefPtr<AnyStrongRefBase>::operator=( _ref );
+			if( _ref.isValid() )
+			_last_ref = _ref->getWeakReference();
+			else
+				_last_ref = NULL;
+	   }
+
+		void* _last_ref; 
+
+		template<class Y> friend class AnyWeakRefPtr;
+	public:				
+
+		~AnyWeakRefPtr()
+		{
+			
+		}
+
+		AnyWeakRefPtr() :  _last_ref(NULL) {}			
+
+		template<typename Y>
+		AnyWeakRefPtr(AnyWeakRefPtr<Y> const &p)
+		{		
+			set( p );
+		}
+
+		template< typename Y >
+		AnyWeakRefPtr(AnyStrongRefPtr<Y> const &p) 
+		{		
+			(T*)p.get_real_ptr();			
+			set( p.getPointer() );
+		}
+
+		AnyStrongRefBase* getPointer() const 
+		{ 
+			return WeakRefPtr<AnyStrongRefBase>::getPointer(); 
+		}
+		
+		WeakRefBase::WeakReference* get_weak_ref() const 
+		{
+			if(isValid()) 
+				return getPointer()->getWeakReference();
+			
+			return NULL;
+		}
+
+		T* get_real_ptr() const 
+		{ 
+			if(isValid() ) 
+				return (T*)this->_px; 
+
+			return NULL;
+		}
+
+		bool is_valid() const 
+		{
+			return isValid();
+		}
+
+		void swap( AnyWeakRefPtr<T>& p)
+		{
+			AnyWeakRefPtr<T> temp = *this;			
+			*this = p;
+			p = temp;
+		}
+
+		template<typename Y>
+		AnyWeakRefPtr<T>& operator=( const AnyStrongRefPtr<Y>& p )
+		{			
+			set( p.getPointer() );
+			return *this;
+		}
+
+		template<typename Y>
+		AnyWeakRefPtr<T>& operator=( const AnyWeakRefPtr<Y>& p )
+		{
+			set( p );
+			return *this;
+		}
+
+		template<typename Y>
+		bool operator<( const AnyWeakRefPtr<Y>& p ) const
+		{
+			return _last_ref < p._last_ref;
+		}
+
+		long use_count() const
+		{
+			if( isNull() )
+				return 0;
+
+			return getPointer()->getRefCount();
+		}
+
+	};
+
+	struct bad_weak_ptr {};
+
+
+	template<class T> 
+	class WeakPtr
+	{
+	private:
+    
+		typedef WeakPtr<T> this_type;
+
+		template<class Y> friend class SharedPtr;
+		template<class Y> friend class WeakPtr;
+
+		AnyWeakRefPtr<T> pn; // reference counter
+
+	public:
+
+		typedef T element_type;
+		typedef WeakPtr<T> type;	
+
+		WeakPtr(): pn()
+		{
+		}
+
+		template<class Y>
+		WeakPtr( WeakPtr<Y> const & r ) : pn( r.lock().pn ) // never throws
+		{		
+		}
+
+		template<class Y>
+		WeakPtr( WeakPtr<Y> && r ) : pn(  r.lock().pn  ) // never throws
+		{
+			r.px = NULL;
+		}
+
+		// for better efficiency in the T == Y case
+		WeakPtr( WeakPtr && r ): pn( r.pn ) // never throws
+		{
+			r.px = NULL;
+		}
+
+		template< typename Y >
+		WeakPtr( Torque::SharedPtr<Y> const & r ) :  pn( r.pn ) // never throws
+		{
+		}
+
+		// for better efficiency in the T == Y case
+		WeakPtr & operator=( WeakPtr && r ) // never throws
+		{
+			this_type( static_cast< WeakPtr && >( r ) ).swap( *this );
+			return *this;
+		}		
+
+		template<class Y>
+		WeakPtr & operator=(WeakPtr<Y> const & r) // never throws
+		{      
+			pn = r.lock().pn;
+			return *this;
+		}
+
+		template<class Y>
+		WeakPtr & operator=(SharedPtr<Y> const & r) // never throws
+		{        
+			pn = r.pn;
+			return *this;
+		}
+
+		SharedPtr<T> lock() const // never throws
+		{
+			if( !pn.get_weak_ref() )
+				return SharedPtr<T>();
+		
+			return SharedPtr<T>( AnyStrongRefPtr<T>(pn) );
+		}
+
+		long use_count() const // never throws
+		{		
+			return pn.use_count();
+		}
+
+		bool expired() const // never throws
+		{
+			return !pn.is_valid();
+		}
+
+		bool _empty() const // extension, not in std::WeakPtr
+		{
+			return pn.empty();
+		}
+
+		void reset() // never throws in 1.30+
+		{
+			this_type().swap(*this);
+		}
+
+		void swap(this_type & other) // never throws
+		{      
+			pn.swap(other.pn);
+		}
+
+		void _internal_assign(T * px2, AnyWeakRefPtr<T> const & pn2)
+		{       
+			pn = pn2;
+		}
+
+		template<class Y> bool owner_before( WeakPtr<Y> const & rhs ) const
+		{
+			return pn < rhs.pn;
+		}
+
+		template<class Y> bool owner_before( SharedPtr<Y> const & rhs ) const
+		{
+			return pn < rhs.pn;
+		} 
+		
+
+	};  // WeakPtr
+
+	template<class T, class U> inline bool operator<(WeakPtr<T> const & a, WeakPtr<U> const & b)
+	{
+		return a.owner_before( b );
+	}
+
+	template<class T> void swap(WeakPtr<T> & a, WeakPtr<T> & b)
+	{
+		a.swap(b);
+	}
+
+}; // namespace Torque
+
+
+
+
+#endif  // #ifndef _TORQUE_WEAK_PTR_H_
+
+

--- a/Engine/source/unit/smartPtrTester.h
+++ b/Engine/source/unit/smartPtrTester.h
@@ -1,0 +1,14 @@
+#ifndef _TORQUE_SMART_PTR_TESTER_H
+#define _TORQUE_SMART_PTR_TESTER_H
+
+namespace Torque 
+{ 
+	namespace Test_Unit 
+	{
+
+		bool test_shared_ptr();
+
+	};
+};
+
+#endif //#ifndef _TORQUE_SMART_PTR_TESTER_H

--- a/Engine/source/unit/tests/test_smart_ptr_basic.cpp
+++ b/Engine/source/unit/tests/test_smart_ptr_basic.cpp
@@ -1,0 +1,360 @@
+//
+//  shared_ptr_basic_test.cpp
+//
+//  Copyright (c) 2001, 2002 Peter Dimov and Multi Media Ltd.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "core\util\tSharedPtr.h"
+#include "core\util\tWeakPtr.h"
+#include "core\util\tScopedPtr.h"
+
+#define TEST_ASSERT(b) AssertFatal(b,"")
+
+namespace {
+
+int cnt = 0;
+
+struct X
+{
+    X()
+    {
+        ++cnt;
+    }
+
+    ~X() // virtual destructor deliberately omitted
+    {
+        --cnt;
+    }
+
+    virtual int id() const
+    {
+        return 1;
+    }
+
+private:
+
+    //X(X const &);
+    X & operator= (X const &);
+};
+
+struct Y: public X
+{
+    Y()
+    {
+        ++cnt;
+    }
+
+    ~Y()
+    {
+        --cnt;
+    }
+
+    virtual int id() const
+    {
+        return 2;
+    }
+
+private:
+
+    Y(Y const &);
+    Y & operator= (Y const &);
+};
+
+int * get_object()
+{
+    ++cnt;
+    return &cnt;
+}
+
+void release_object(int * p)
+{
+    TEST_ASSERT(p == &cnt);
+    --cnt;
+}
+
+template<class T> void test_is_X(Torque::SharedPtr<T> const & p)
+{
+    TEST_ASSERT(p->id() == 1);
+    TEST_ASSERT((*p).id() == 1);
+}
+
+template<class T> void test_is_X(Torque::WeakPtr<T> const & p)
+{
+    TEST_ASSERT(p.get() != 0);
+    TEST_ASSERT(p.get()->id() == 1);
+}
+
+template<class T> void test_is_Y(Torque::SharedPtr<T> const & p)
+{
+    TEST_ASSERT(p->id() == 2);
+    TEST_ASSERT((*p).id() == 2);
+}
+
+template<class T> void test_is_Y(Torque::WeakPtr<T> const & p)
+{
+    Torque::SharedPtr<T> q = p.lock();
+    TEST_ASSERT(q.get() != 0);
+    TEST_ASSERT(q->id() == 2);
+}
+
+template<class T> void test_eq(T const & a, T const & b)
+{
+    TEST_ASSERT(a == b);
+    TEST_ASSERT(!(a != b));
+    TEST_ASSERT(!(a < b));
+    TEST_ASSERT(!(b < a));
+}
+
+template<class T> void test_ne(T const & a, T const & b)
+{
+    TEST_ASSERT(!(a == b));
+    TEST_ASSERT(a != b);
+    TEST_ASSERT(a < b || b < a);
+    TEST_ASSERT(!(a < b && b < a));
+}
+
+template<class T, class U> void test_shared(Torque::WeakPtr<T> const & a, Torque::WeakPtr<U> const & b)
+{
+    TEST_ASSERT(!(a < b));
+    TEST_ASSERT(!(b < a));
+}
+
+template<class T, class U> void test_nonshared(Torque::WeakPtr<T> const & a, Torque::WeakPtr<U> const & b)
+{
+    TEST_ASSERT(a < b || b < a);
+    TEST_ASSERT(!(a < b && b < a));
+}
+
+template<class T, class U> void test_eq2(T const & a, U const & b)
+{
+    TEST_ASSERT(a == b);
+    TEST_ASSERT(!(a != b));
+}
+
+template<class T, class U> void test_ne2(T const & a, U const & b)
+{
+    TEST_ASSERT(!(a == b));
+    TEST_ASSERT(a != b);
+}
+
+template<class T> void test_is_zero(Torque::SharedPtr<T> const & p)
+{
+    TEST_ASSERT(!p);
+    TEST_ASSERT(p.get() == 0);
+}
+
+template<class T> void test_is_nonzero(Torque::SharedPtr<T> const & p)
+{
+    // p? true: false is used to test p in a boolean context.
+    // TEST_ASSERT(p) is not guaranteed to test the conversion,
+    // as the macro might test !!p instead.
+    TEST_ASSERT(p? true: false);
+    TEST_ASSERT(p.get() != 0);
+}
+
+};
+
+namespace Torque{ namespace Test_Unit {
+
+bool test_shared_ptr()
+{
+	TEST_ASSERT(cnt == 0);
+    {		
+        Torque::SharedPtr<X> p(new Y);
+        Torque::SharedPtr<X> p2(new X);
+
+        test_is_nonzero(p);
+        test_is_nonzero(p2);
+        test_is_Y(p);
+        test_is_X(p2);
+        test_ne(p, p2);
+
+        {
+            Torque::SharedPtr<X> q(p);
+            test_eq(p, q);
+        }
+		
+
+        Torque::SharedPtr<Y> p3 = Torque::dynamic_pointer_cast<Y>(p);
+        Torque::SharedPtr<Y> p4 = Torque::dynamic_pointer_cast<Y>(p2);
+
+        test_is_nonzero(p3);
+        test_is_zero(p4);
+
+        TEST_ASSERT(p.use_count() == 2);
+        TEST_ASSERT(p2.use_count() == 1);
+        TEST_ASSERT(p3.use_count() == 2);
+
+        test_is_Y(p3);
+        test_eq2(p, p3);
+        test_ne2(p2, p4);
+
+        Torque::SharedPtr<void> p5(p);
+
+        test_is_nonzero(p5);
+        test_eq2(p, p5);
+
+        Torque::WeakPtr<X> wp1(p2);
+
+        TEST_ASSERT(!wp1.expired());
+        TEST_ASSERT(wp1.use_count() != 0);
+
+        p.reset();
+        p2.reset();
+
+        p3.reset();
+        p4.reset();
+
+
+        test_is_zero(p);
+        test_is_zero(p2);
+
+        test_is_zero(p3);
+        test_is_zero(p4);
+
+        TEST_ASSERT(p5.use_count() == 1);
+
+        TEST_ASSERT(wp1.expired());
+        TEST_ASSERT(wp1.use_count() == 0);
+
+        try
+        {
+            Torque::SharedPtr<X> sp1(wp1);
+            AssertFatal(0,"Torque::SharedPtr<X> sp1(wp1) failed to throw");
+        }
+        catch(Torque::bad_weak_ptr const &)
+        {
+        }
+
+        test_is_zero(wp1.lock());
+
+
+        Torque::WeakPtr<X> wp2 = Torque::static_pointer_cast<X>(p5);
+
+        TEST_ASSERT(wp2.use_count() == 1);
+        test_is_Y(wp2);
+        test_nonshared(wp1, wp2);
+
+        // Scoped to not affect the subsequent use_count() tests.
+        {
+            Torque::SharedPtr<X> sp2(wp2);
+            test_is_nonzero(wp2.lock());
+        }
+
+
+
+        Torque::WeakPtr<Y> wp3 = Torque::dynamic_pointer_cast<Y>(wp2.lock());
+
+        TEST_ASSERT(wp3.use_count() == 1);
+        test_shared(wp2, wp3);
+
+        Torque::WeakPtr<X> wp4(wp3);
+
+        TEST_ASSERT(wp4.use_count() == 1);
+        test_shared(wp2, wp4);
+
+
+        wp1 = p2;
+        test_is_zero(wp1.lock());
+
+
+        wp1 = p4;
+        wp1 = wp3;
+
+
+        wp1 = wp2;
+
+
+        TEST_ASSERT(wp1.use_count() == 1);
+        test_shared(wp1, wp2);
+
+        Torque::WeakPtr<X> wp5;
+
+
+        bool b1 = wp1 < wp5;
+        bool b2 = wp5 < wp1;
+
+        p5.reset();
+
+        TEST_ASSERT(wp1.use_count() == 0);
+        TEST_ASSERT(wp2.use_count() == 0);
+
+        TEST_ASSERT(wp3.use_count() == 0);
+
+        // Test operator< stability for std::set< Torque::WeakPtr<> >
+        // Thanks to Joe Gottman for pointing this out
+
+        TEST_ASSERT(b1 == (wp1 < wp5));
+        TEST_ASSERT(b2 == (wp5 < wp1));
+
+
+        {
+            // note that both get_object and release_object deal with int*
+
+            Torque::SharedPtr<void> p6(get_object(), release_object);
+
+        }
+
+		
+
+    }
+
+    TEST_ASSERT(cnt == 0);
+
+    return true;
+}
+
+//AutoPtr
+bool test_SharedPtr_AutoPtr()
+{
+	TEST_ASSERT(cnt == 0);
+	{
+		AutoPtr<Y> auto_ptr( new Y );
+		Torque::SharedPtr<void> p( auto_ptr );
+		TEST_ASSERT( auto_ptr.isNull() );
+	
+		AutoPtr<Y> auto_ptr2( new Y );
+		Torque::SharedPtr<void> p2;
+		p2 = auto_ptr2;
+		TEST_ASSERT( auto_ptr2.isNull() );
+	}
+	TEST_ASSERT(cnt == 0);
+	return true;
+}
+
+bool test_ScopedPtr()
+{
+	TEST_ASSERT(cnt == 0);
+	{
+		Torque::ScopedPtr<X> sp1 ( new X );
+		//Torque::ScopedPtr<X> sp2 ( new Y ); //Error
+		
+		AutoPtr<Y> auto_ptr( new Y );
+		Torque::ScopedPtr<Y> sp4( auto_ptr.release() );
+		TEST_ASSERT( auto_ptr.isNull() );	
+	}
+	TEST_ASSERT(cnt == 0);
+	return true;
+}
+
+}; };
+
+#if 1
+
+namespace {
+struct module
+{
+	module() 
+	{ 
+		Torque::Test_Unit::test_shared_ptr();
+		Torque::Test_Unit::test_SharedPtr_AutoPtr();
+		Torque::Test_Unit::test_ScopedPtr();
+	}
+} module_;
+};
+
+#endif


### PR DESCRIPTION
This pull include smart pointers in 3 files without external dependencies(No STD/No BOOST):
*[ScopedPtr](https://github.com/Luis-Anton/Torque3D/tree/smart_ptr2/Engine/source/core/util/tScopedPtr.h)
*[SharedPtr](https://github.com/Luis-Anton/Torque3D/tree/smart_ptr2/Engine/source/core/util/tSharedPtr.h)
*[WeakPtr](https://github.com/Luis-Anton/Torque3D/tree/smart_ptr2/Engine/source/core/util/tWeakPtr.h)

All are based on Boost smart pointer with very similar interface ( [see Boost documentation](http://www.boost.org/doc/libs/1_51_0/libs/smart_ptr/smart_ptr.htm) )

Simple test unit and example on: https://github.com/Luis-Anton/Torque3D/tree/smart_ptr2/Engine/source/unit/tests/test_smart_ptr_basic.cpp

NOTE: Only tested on Windows7/VS2010. NOT THREAD-SAFE.
