### PR TITLE
Fix for Issue #130 for Decals and Smoothing Groups

### DIFF
--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -827,6 +827,8 @@ bool TSStatic::buildPolyList(PolyListContext context, AbstractPolyList* polyList
          return false;
       else if ( meshType == Bounds )
          polyList->addBox( mObjBox );
+      else if ( meshType == VisibleMesh )
+          mShapeInstance->buildPolyList( polyList, 0 );
       else
       {
          // Everything else is done from the collision meshes

--- a/Engine/source/collision/abstractPolyList.h
+++ b/Engine/source/collision/abstractPolyList.h
@@ -157,6 +157,11 @@ public:
    /// an ID number for that point.
    virtual U32  addPoint(const Point3F& p) = 0;
 
+   /// Adds a point and normal to the poly list, and returns
+   /// an ID number for them.  Normals are ignored for polylists
+   /// that do not support them.
+   virtual U32  addPointAndNormal(const Point3F& p, const Point3F& normal) { return addPoint( p ); }
+
    /// Adds a plane to the poly list, and returns
    /// an ID number for that point.
    virtual U32  addPlane(const PlaneF& plane) = 0;

--- a/Engine/source/collision/clippedPolyList.h
+++ b/Engine/source/collision/clippedPolyList.h
@@ -119,6 +119,7 @@ public:
    // AbstractPolyList
    bool isEmpty() const;
    U32 addPoint(const Point3F& p);
+   U32 addPointAndNormal(const Point3F& p, const Point3F& normal);
    U32 addPlane(const PlaneF& plane);
    void begin(BaseMatInstance* material,U32 surfaceKey);
    void plane(U32 v1,U32 v2,U32 v3);

--- a/Engine/source/ts/tsMesh.cpp
+++ b/Engine/source/ts/tsMesh.cpp
@@ -322,9 +322,11 @@ bool TSMesh::buildPolyList( S32 frame, AbstractPolyList *polyList, U32 &surfaceK
          }
          else
          {
-            base = polyList->addPoint( mVertexData[firstVert].vert() );
+            base = polyList->addPointAndNormal( mVertexData[firstVert].vert(), mVertexData[firstVert].normal() );
             for ( i = 1; i < vertsPerFrame; i++ )
-               polyList->addPoint( mVertexData[ i + firstVert ].vert() );
+            {
+               polyList->addPointAndNormal( mVertexData[ i + firstVert ].vert(), mVertexData[ i + firstVert ].normal() );
+            }
          }
       }
       else
@@ -348,9 +350,9 @@ bool TSMesh::buildPolyList( S32 frame, AbstractPolyList *polyList, U32 &surfaceK
          }
          else
          {
-            base = polyList->addPoint( verts[firstVert] );
+            base = polyList->addPointAndNormal( verts[firstVert], norms[firstVert] );
             for ( i = 1; i < vertsPerFrame; i++ )
-               polyList->addPoint( verts[ i + firstVert ] );
+               polyList->addPointAndNormal( verts[ i + firstVert ], norms[ i + firstVert ] );
          }
       }
    }


### PR DESCRIPTION
Decals use the correct visual geometry normals when clipped against TSStatic meshes.
