### PR TITLE
Updated logic in MissionArea::getServerObject

### DIFF
--- a/Engine/source/T3D/missionArea.cpp
+++ b/Engine/source/T3D/missionArea.cpp
@@ -52,6 +52,8 @@ ConsoleDocClass( MissionArea,
 
 RectI MissionArea::smMissionArea(Point2I(768, 768), Point2I(512, 512));
 
+MissionArea * MissionArea::smServerObject = NULL;
+
 //------------------------------------------------------------------------------
 
 MissionArea::MissionArea()
@@ -79,27 +81,24 @@ void MissionArea::setArea(const RectI & area)
 
 MissionArea * MissionArea::getServerObject()
 {
-   SimSet * scopeAlwaysSet = Sim::getGhostAlwaysSet();
-   for(SimSet::iterator itr = scopeAlwaysSet->begin(); itr != scopeAlwaysSet->end(); itr++)
-   {
-      MissionArea * ma = dynamic_cast<MissionArea*>(*itr);
-      if(ma)
-      {
-         AssertFatal(ma->isServerObject(), "MissionArea::getServerObject: found client object in ghost always set!");
-         return(ma);
-      }
-   }
-   return(0);
+   return smServerObject;
 }
 
 //------------------------------------------------------------------------------
 
 bool MissionArea::onAdd()
 {
-   if(isServerObject() && MissionArea::getServerObject())
+   if(isServerObject())
    {
-      Con::errorf(ConsoleLogEntry::General, "MissionArea::onAdd - MissionArea already instantiated!");
-      return(false);
+      if(MissionArea::getServerObject())
+      {
+         Con::errorf(ConsoleLogEntry::General, "MissionArea::onAdd - MissionArea already instantiated!");
+         return(false);
+      }
+      else
+      {
+         smServerObject = this;
+      }
    }
 
    if(!Parent::onAdd())
@@ -107,6 +106,14 @@ bool MissionArea::onAdd()
 
    setArea(mArea);
    return(true);
+}
+
+void MissionArea::onRemove()
+{
+   if (smServerObject == this)
+      smServerObject = NULL;
+
+   Parent::onRemove();
 }
 
 //------------------------------------------------------------------------------

--- a/Engine/source/T3D/missionArea.h
+++ b/Engine/source/T3D/missionArea.h
@@ -36,6 +36,8 @@ class MissionArea : public NetObject
    F32 mFlightCeiling;
    F32 mFlightCeilingRange;
 
+   static MissionArea * smServerObject;
+
   public:
    MissionArea();
 
@@ -53,6 +55,7 @@ class MissionArea : public NetObject
    /// @name SimObject Inheritance
    /// @{
    bool onAdd();
+   void onRemove();
 
    void inspectPostApply();
 


### PR DESCRIPTION
As noted in [this thread](http://www.garagegames.com/community/forums/viewthread/125744), `MissionArea::getServerObject` has some awful performance implications. This function iterates through every server-side object to find a MissionArea.

This commit adds a new static member to MissionArea, `smServerObject`, which is used in place of the old brute-force search. This member is updated in `onAdd` and `onRemove`, and returned by `getServerObject`, which is now a guaranteed constant-time function call.

NOTE: The commit message is slightly wrong. The old function didn't iterate over every server-side object; it iterated over all scope-always objects, a subset of the world. Still, not good news.
