### PR TITLE
GroundCover fading when zoomed in

### DIFF
--- a/Engine/source/T3D/fx/groundCover.cpp
+++ b/Engine/source/T3D/fx/groundCover.cpp
@@ -1550,6 +1550,7 @@ void GroundCover::prepRenderImage( SceneRenderState *state )
    {
       PROFILE_SCOPE( GroundCover_RenderBillboards );
 
+      // Take zoom into account.
       F32 screenScale = state->getWorldToScreenScale().y / state->getViewport().extent.y;
 
       // Set the far distance for billboards.


### PR DESCRIPTION
Extends the visible distance of GroundCover when the camera is zoomed in. See [this thread](http://www.garagegames.com/community/forums/viewthread/132299/2#comment_form) for details.
