### PR TITLE
Prevented looking up incorrect object handles

### DIFF
--- a/Engine/source/console/simManager.cpp
+++ b/Engine/source/console/simManager.cpp
@@ -367,6 +367,8 @@ SimObject* findObject(const char* name)
                return NULL;
             return obj->findObject(temp);
          }
+         else if (c < '0' || c > '9')
+            return NULL;
       }
    }
    S32 len;


### PR DESCRIPTION
Previously, `dAtoi` would be called on arbitrary strings, which resulted in weird things like `"7.2 3 4.529"` being cast to `7`. Now, `Sim::findObject` checks that object handles (strings starting with a digit) actually only contain digits and slashes.

Refer to [this thread](http://www.garagegames.com/community/forums/viewthread/132371) and [this one](http://www.garagegames.com/community/forums/viewthread/117065).
