### PR TITLE
Fix for Issue #166 for Client Not Loading

### DIFF
--- a/Engine/source/core/dnet.cpp
+++ b/Engine/source/core/dnet.cpp
@@ -83,7 +83,15 @@ void ConnectionProtocol::buildSendPacketHeader(BitStream *stream, S32 packetType
    stream->writeInt(mLastSeqRecvd & 0x1FF, 9);
    stream->writeInt(packetType & 0x3, 2);
    stream->writeInt(ackByteCount & 0x7, 3);
-   stream->writeInt(mAckMask & (~(0xFFFFFFFF << ackByteCount*8)), ackByteCount * 8);
+   U32 bitmask = ~(0xFFFFFFFF << (ackByteCount*8));
+   if(ackByteCount == 4)
+   {
+      // Performing a bit shift that is the same size as the variable being shifted
+      // is undefined in the C/C++ standard.  Handle that exception here when
+      // ackByteCount*8 == 4*8 == 32
+      bitmask = 0xFFFFFFFF;
+   }
+   stream->writeInt(mAckMask & bitmask, ackByteCount * 8);
 
    // if we're resending this header, we can't advance the
    // sequence recieved (in case this packet drops and the prev one


### PR DESCRIPTION
The issue was with sending the ack mask to the client when the ack byte
count was 4.
