### PR TITLE
Fix for Issue #172 for Turret Crash on Dedicated Server

### DIFF
--- a/Templates/Full/game/art/datablocks/vehicles/cheetahCar.cs
+++ b/Templates/Full/game/art/datablocks/vehicles/cheetahCar.cs
@@ -55,7 +55,7 @@ datablock SFXProfile(DirtKickup)
    fileName = "art/sound/cheetah/softImpact.ogg";
 };
 
-datablock SFXProfile(TurretFireSound)
+datablock SFXProfile(CheetahTurretFireSound)
 {
    filename = "art/sound/cheetah/turret_firing.wav";
    description = BulletFireDesc;
@@ -220,7 +220,7 @@ datablock ShapeBaseImageData(TurretImage)
    stateSequence[3]                 = "Fire";
    stateSequenceRandomFlash[3]      = true;        // use muzzle flash sequence
    stateScript[3]                   = "onFire";
-   stateSound[3]                    = TurretFireSound;
+   stateSound[3]                    = CheetahTurretFireSound;
    stateEmitter[3]                  = TurretFireSmokeEmitter;
    stateEmitterTime[3]              = 0.025;
 


### PR DESCRIPTION
The Cheetah's turret fire sound datablock happened to be named the same
as the player's turret weapon's datablock.  This caused the sound
profile's description to be NULL on the dedicated server.
