### PR TITLE
Removal of SDL dependency for linux dedicated server

### DIFF
--- a/Engine/source/platformX86UNIX/threads/semaphore.cpp
+++ b/Engine/source/platformX86UNIX/threads/semaphore.cpp
@@ -22,25 +22,31 @@
 
 #include "platformX86UNIX/platformX86UNIX.h"
 #include "platform/threads/semaphore.h"
-// Instead of that mess that was here before, lets use the SDL lib to deal
-// with the semaphores.
-
-#include <SDL/SDL.h>
-#include <SDL/SDL_thread.h>
+//MGT: converted SDL to OS semaphores to remove dependency on SDL in dedicated server
+#include <unistd.h>     
+#include <sys/types.h>  
+#include <errno.h>      
+#include <semaphore.h> 
+#include <time.h>
 
 struct PlatformSemaphore
 {
-   SDL_sem *semaphore;
+   sem_t semaphore;
+   bool initialized;
 
    PlatformSemaphore(S32 initialCount)
    {
-       semaphore = SDL_CreateSemaphore(initialCount);
-       AssertFatal(semaphore, "PlatformSemaphore constructor - Failed to create SDL Semaphore.");
+	   initialized = true;
+	   if (sem_init(&semaphore, 0, initialCount) == -1) {
+		   initialized = false;
+			AssertFatal(0, "PlatformSemaphore constructor - Failed to create Semaphore.");
+	   } 
    }
 
    ~PlatformSemaphore()
    {
-       SDL_DestroySemaphore(semaphore);
+       sem_destroy(&semaphore);
+	   initialized = false;
    }
 };
 
@@ -57,28 +63,37 @@ Semaphore::~Semaphore()
 
 bool Semaphore::acquire(bool block, S32 timeoutMS)
 {
-   AssertFatal(mData && mData->semaphore, "Semaphore::acquire - Invalid semaphore.");
+   AssertFatal(mData && mData->initialized, "Semaphore::acquire - Invalid semaphore.");
    if (block)
    {
+      //SDL was removed so I do not now if this still holds true or not with OS calls but my guess is they are used underneath SDL anyway 
       // Semaphore acquiring is different from the MacOS/Win realization because SDL_SemWaitTimeout() with "infinite" timeout can be too heavy on some platforms.
       // (see "man SDL_SemWaitTimeout(3)" for more info)
       // "man" states to avoid the use of SDL_SemWaitTimeout at all, but at current stage this looks like a valid and working solution, so keeping it this way.
       // [bank / Feb-2010]
       if (timeoutMS == -1)
       {
-         if (SDL_SemWait(mData->semaphore) < 0)
-            AssertFatal(false, "Semaphore::acquie - Wait failed.");
+         if (sem_wait(&mData->semaphore) < 0)
+            AssertFatal(false, "Semaphore::acquire - Wait failed.");
       }
       else
       {
-         if (SDL_SemWaitTimeout(mData->semaphore, timeoutMS) < 0)
-            AssertFatal(false, "Semaphore::acquie - Wait with timeout failed.");
+	     //convert timeoutMS to timespec
+         timespec ts;
+		 if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
+			 AssertFatal(false, "Semaphore::acquire - clock_realtime failed.");
+		 }
+		 ts.tv_sec += timeoutMS / 1000;
+		 ts.tv_nsec += (timeoutMS % 1000) * 1000;
+
+         if (sem_timedwait(&mData->semaphore, &ts) < 0)
+            AssertFatal(false, "Semaphore::acquire - Wait with timeout failed.");
       }
       return (true);
    }
    else
    {
-      int res = SDL_SemTryWait(mData->semaphore);
+      int res = sem_trywait(&mData->semaphore);
       return (res == 0);
    }
 }
@@ -86,5 +101,6 @@ bool Semaphore::acquire(bool block, S32 timeoutMS)
 void Semaphore::release()
 {
    AssertFatal(mData, "Semaphore::releaseSemaphore - Invalid semaphore.");
-   SDL_SemPost(mData->semaphore);
+   sem_post(&mData->semaphore);
 }
+//MGT: end

--- a/Engine/source/platformX86UNIX/x86UNIXProcessControl.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXProcessControl.cpp
@@ -80,7 +80,11 @@ void Cleanup(bool minimal)
    }
 
    StdConsole::destroy();
+//MGT: removed SDL from dedicated
+#ifndef TORQUE_DEDICATED   
    SDL_Quit();
+#endif
+//MGT: end
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/platformX86UNIX/x86UNIXRedbook.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXRedbook.cpp
@@ -19,7 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
-
+//MGT: not needed on dedicated and help removal of SDL
+#ifndef TORQUE_DEDICATED
 #include "console/console.h"
 #include "platformX86UNIX/platformX86UNIX.h"
 #include "platform/platformRedBook.h"
@@ -453,3 +454,5 @@ void PollRedbookDevices()
    }
 #endif	// !defined(__FreeBSD__)
 }
+#endif
+//MGT: end

--- a/Tools/projectGenerator/templates/makeApp.tpl
+++ b/Tools/projectGenerator/templates/makeApp.tpl
@@ -12,7 +12,7 @@ SOURCES := {foreach from=$dirWalk item=file key=key}
 {/foreach}
 
 LDFLAGS := -g -m32
-LDLIBS := -lstdc++ -lm -lSDL -lpthread -lrt
+LDLIBS := -lstdc++ -lm -lpthread -lrt
 {foreach item=def from=$projLibs}LDLIBS += -l{$def}
 {/foreach}
 

--- a/Tools/projectGenerator/templates/makeSo.tpl
+++ b/Tools/projectGenerator/templates/makeSo.tpl
@@ -15,7 +15,7 @@ SOURCES := {foreach from=$dirWalk item=file key=key}
 {/foreach}
 
 LDFLAGS_{$projName} := -g -m32 -shared
-LDLIBS_{$projName} := -lstdc++ -lSDL -lpthread
+LDLIBS_{$projName} := -lstdc++ -lpthread
 CFLAGS_{$projName} := -MMD -I. -m32 -mmmx -msse -march=i686 
 
 {foreach item=def from=$projIncludes}CFLAGS_{$projName} += -I{$def}


### PR DESCRIPTION
These are the changes to remove the need to have SDL installed to compile/run the linux dedicated server. One of the changes was to the project generator so you will need to regenerate make files afterwards.
