### PR TITLE
Bug fixes for alternative zip layout and define to toggle it on

### DIFF
--- a/Engine/source/platform/platform.cpp
+++ b/Engine/source/platform/platform.cpp
@@ -29,6 +29,9 @@
 #include "app/mainLoop.h"
 #include "platform/event.h"
 #include "platform/typetraits.h"
+//MGT: fixes for zip support
+#include "core/volume.h"
+//MGT: end
 
 
 const F32 TypeTraits< F32 >::MIN = - F32_MAX;
@@ -132,8 +135,12 @@ const bool Platform::KeyboardInputExclusion::checkAgainstInput( const InputEvent
 S32 Platform::compareModifiedTimes( const char *firstPath, const char *secondPath )
 {
    FileTime firstModTime;
-   if ( !getFileTimes( firstPath, NULL, &firstModTime ) )
-      return -1;
+   if ( !getFileTimes( firstPath, NULL, &firstModTime ) ) {
+      //MGT: fixes for zip support
+	  //The reason we failed to get file times could be cause it is in a zip.  Lets check.
+	  return Torque::FS::CompareModifiedTimes(firstPath, secondPath);
+	  //MGT: end
+   }
 
    FileTime secondModTime;
    if ( !getFileTimes( secondPath, NULL, &secondModTime ) )

--- a/Engine/source/platform/platformVolume.cpp
+++ b/Engine/source/platform/platformVolume.cpp
@@ -22,6 +22,11 @@
 
 #include "platform/platform.h"
 
+//Uncomment this define if you want to use the alternative zip support where you can 
+//define your directories and files inside the zip just like you would on disk
+//instead of the default zip support that treats the zip as an extra directory.
+//#define TORQUE_ZIP_DISK_LAYOUT
+
 #if defined(TORQUE_OS_WIN32) || defined(TORQUE_OS_XBOX) || defined(TORQUE_OS_XENON)
 #include <sys/utime.h>
 #else
@@ -70,7 +75,13 @@ bool MountZips(const String &root)
    for(S32 i = 0;i < outList.size();++i)
    {
       String &zipfile = outList[i];
+      //MGT: added a define to set which zip support style is used.
+#ifdef TORQUE_ZIP_DISK_LAYOUT
+      mounted += (S32)Mount(root, new ZipFileSystem(zipfile, false));
+#else 
       mounted += (S32)Mount(root, new ZipFileSystem(zipfile, true));
+#endif
+      //MGT: end
    }
 
    return mounted == outList.size();

--- a/Engine/source/platformMac/macCarbFileio.mm
+++ b/Engine/source/platformMac/macCarbFileio.mm
@@ -49,6 +49,10 @@
 #include "platform/profiler.h"
 #include "cinterface/cinterface.h";
 
+//MGT: fixes for zip support
+#include "core/volume.h"
+//MGT: end
+
 //TODO: file io still needs some work...
 
 #define MAX_MAC_PATH_LONG     2048
@@ -633,8 +637,12 @@ bool Platform::isFile(const char *path)
    
    // make sure we can stat the file
    struct stat statData;
-   if( stat(path, &statData) < 0 )
-      return false;
+   if( stat(path, &statData) < 0 ) {
+   
+      //MGT: since file does not exist on disk lets see if it exists in a zip file loaded
+      return Torque::FS::IsFile(path);
+      //MGT: end
+   }
    
    // now see if it's a regular file
    if( (statData.st_mode & S_IFMT) == S_IFREG)

--- a/Engine/source/platformWin32/winFileio.cpp
+++ b/Engine/source/platformWin32/winFileio.cpp
@@ -29,6 +29,9 @@
 #include "core/strings/unicode.h"
 #include "util/tempAlloc.h"
 #include "core/util/safeDelete.h"
+//MGT: fixes for zip support
+#include "core/volume.h"
+//MGT: end
 
 // Microsoft VC++ has this POSIX header in the wrong directory
 #if defined(TORQUE_COMPILER_VISUALC)
@@ -945,8 +948,12 @@ bool Platform::isFile(const char *pFilePath)
    HANDLE handle = FindFirstFile(buf, &findData);
    FindClose(handle);
 
-   if(handle == INVALID_HANDLE_VALUE)
-      return false;
+   if(handle == INVALID_HANDLE_VALUE) {
+    
+	   //MGT: since file does not exist on disk lets see if it exists in a zip file loaded
+	   return Torque::FS::IsFile(pFilePath);
+	   //MGT: end
+   }
 
    // if the file is a Directory, Offline, System or Temporary then FALSE
    if (findData.dwFileAttributes &

--- a/Engine/source/platformX86UNIX/x86UNIXFileio.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXFileio.cpp
@@ -57,6 +57,10 @@
  #include "util/tempAlloc.h"
  #include "cinterface/cinterface.h"
 
+//MGT: fixes for zip support
+#include "core/volume.h"
+//MGT: end
+
  #if defined(__FreeBSD__)
     #include <sys/types.h>
  #endif
@@ -979,8 +983,13 @@ bool dPathCopy(const char *fromName, const char *toName, bool nooverwrite)
        return false;
     // Get file info
     struct stat fStat;
-    if (stat(pFilePath, &fStat) < 0)
-       return false;
+	if (stat(pFilePath, &fStat) < 0) {
+     
+		//MGT: since file does not exist on disk lets see if it exists in a zip file loaded
+	   return Torque::FS::IsFile(pFilePath);
+	   //MGT: end
+
+	}
 
     // if the file is a "regular file" then true
     if ( (fStat.st_mode & S_IFMT) == S_IFREG)


### PR DESCRIPTION
Fixes a couple of bugs with the zip system and adds a define to use the alternative zip support where you can define your directories and files inside the zip just like you would on disk instead of the default zip support that treats the zip as an extra directory.  Just uncomment #define TORQUE_ZIP_DISK_LAYOUT at the top of platform/platformVolume.cpp or add the define to torqueConfig.h
