### PR TITLE
Bug fix for loading compiled dsos

### DIFF
--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -2023,8 +2023,10 @@ DefineEngineFunction( exec, bool, ( const char* fileName, bool noCalls, bool jou
    //}
 
    // If we had a DSO, let's check to see if we should be reading from it.
-   if(compiled && dsoFile != NULL && (scriptFile == NULL|| (scriptModifiedTime - dsoModifiedTime) > Torque::Time(0)))
-   {
+   //MGT: fixed bug with dsos not getting recompiled correctly
+   //Note: Using Nathan Martin's version from the forums since its easier to read and understand
+   if(compiled && dsoFile != NULL && (scriptFile == NULL|| (dsoModifiedTime >= scriptModifiedTime)))
+   { //MGT: end
       compiledStream = FileStream::createAndOpen( nameBuffer, Torque::FS::File::Read );
       if (compiledStream)
       {


### PR DESCRIPTION
This is a bug fix for loading compiled dsos.  The bug was that if you had dso compilation on, the dso had to be out of date before it would load it so you would end up making changes to scripts and it would still load the old out of date dso instead of recompiling the script.
