### PR TITLE
Fix for Issue #190

### DIFF
--- a/Engine/source/platformWin32/winDInputDevice.cpp
+++ b/Engine/source/platformWin32/winDInputDevice.cpp
@@ -66,7 +66,8 @@ DInputDevice::DInputDevice( const DIDEVICEINSTANCE* dii )
    switch ( GET_DIDEVICE_TYPE( mDeviceInstance.dwDevType ) )
    {
       // [rene, 12/09/2008] why do we turn a gamepad into a joystick here?
-
+	  
+	  case DI8DEVTYPE_DRIVING:
       case DI8DEVTYPE_GAMEPAD:
       case DI8DEVTYPE_JOYSTICK:
          deviceTypeName    = "joystick";


### PR DESCRIPTION
Without having DI8DEVTYPE_DRIVING here, many steering wheel's will show
up as "unknown" and cannot be mapped to actions. Driving and gamepad
both map to joystick for consistency, since they all can have buttons,
axes, sliders, and pov hat's.
