### PR TITLE
Elastic ease fix

### DIFF
--- a/Engine/source/math/mEase.h
+++ b/Engine/source/math/mEase.h
@@ -278,7 +278,7 @@ inline F32 mEaseOutElastic(F32 t, F32 b, F32 c, F32 d, F32 a, F32 p) {
 	F32 s;
 	if (a < mFabs(c)) { a=c; s=p/4; }
 	else s = p/(2*M_PI_F) * mAsin (c/a);
-	return a*mPow(2,-10*t) * mAsin( (t*d-s)*(2*M_PI_F)/p ) + c + b;
+	return a*mPow(2,-10*t) * mSin( (t*d-s)*(2*M_PI_F)/p ) + c + b;
 };
 
 inline F32 mEaseInOutElastic(F32 t, F32 b, F32 c, F32 d, F32 a, F32 p) {


### PR DESCRIPTION
Elastic ease used an arcsinus function where it should have used a sinus
function.
