### PR TITLE
New RigidShape method to force client

### DIFF
--- a/Engine/source/T3D/rigidShape.cpp
+++ b/Engine/source/T3D/rigidShape.cpp
@@ -1003,6 +1003,11 @@ void RigidShape::setTransform(const MatrixF& newMat)
    mContacts.clear();
 }
 
+void RigidShape::forceClientTransform()
+{
+   setMaskBits(ForceMoveMask);
+}
+
 
 //-----------------------------------------------------------------------------
 
@@ -1456,6 +1461,8 @@ U32 RigidShape::packUpdate(NetConnection *con, U32 mask, BitStream *stream)
 
    if (stream->writeFlag(mask & PositionMask))
    {
+      stream->writeFlag(mask & ForceMoveMask);
+
       stream->writeCompressedPoint(mRigid.linPosition);
       mathWrite(*stream, mRigid.angPosition);
       mathWrite(*stream, mRigid.linMomentum);
@@ -1480,6 +1487,10 @@ void RigidShape::unpackUpdate(NetConnection *con, BitStream *stream)
 
    if (stream->readFlag()) 
    {
+      // Check if we need to jump to the given transform
+      // rather than interpolate to it.
+      bool forceUpdate = stream->readFlag();
+
       mPredictionCount = sMaxPredictionTicks;
       F32 speed = mRigid.linVelocity.len();
       mDelta.warpRot[0] = mRigid.angPosition;
@@ -1492,7 +1503,7 @@ void RigidShape::unpackUpdate(NetConnection *con, BitStream *stream)
       mRigid.atRest = stream->readFlag();
       mRigid.updateVelocity();
 
-      if (isProperlyAdded()) 
+      if (!forceUpdate && isProperlyAdded()) 
       {
          // Determine number of ticks to warp based on the average
          // of the client and server velocities.
@@ -1709,4 +1720,13 @@ DefineEngineMethod( RigidShape, freezeSim, void, (bool isFrozen),,
    "@see ShapeBaseData")
 {
    object->freezeSim(isFrozen);
+}
+
+DefineEngineMethod( RigidShape, forceClientTransform, void, (),,
+   "@brief Forces the client to jump to the RigidShape's transform rather then warp to it.\n\n")
+{
+   if(object->isServerObject())
+   {
+      object->forceClientTransform();
+   }
 }

--- a/Engine/source/T3D/rigidShape.h
+++ b/Engine/source/T3D/rigidShape.h
@@ -152,10 +152,11 @@ class RigidShape: public ShapeBase
       WheelCollision = BIT(1),
    };
    enum MaskBits {
-      PositionMask = Parent::NextFreeMask << 0,
-      EnergyMask   = Parent::NextFreeMask << 1,
-      FreezeMask   = Parent::NextFreeMask << 2,
-      NextFreeMask = Parent::NextFreeMask << 3
+      PositionMask   = Parent::NextFreeMask << 0,
+      EnergyMask     = Parent::NextFreeMask << 1,
+      FreezeMask     = Parent::NextFreeMask << 2,
+      ForceMoveMask  = Parent::NextFreeMask << 3,
+      NextFreeMask = Parent::NextFreeMask << 4
    };
 
    void updateDustTrail( F32 dt );
@@ -282,6 +283,10 @@ public:
    /// @param   r   Point on the object to apply impulse to, r is relative to Center of Mass
    /// @param   impulse   Impulse vector to apply.
    void applyImpulse(const Point3F &r, const Point3F &impulse);
+
+   /// Forces the client to jump to the RigidShape's transform rather
+   /// then warp to it.
+   void forceClientTransform();
 
    void getCameraParameters(F32 *min, F32* max, Point3F* offset, MatrixF* rot);
    void getCameraTransform(F32* pos, MatrixF* mat);


### PR DESCRIPTION
New forceClientTransform() console method to force a RigidShape's transform on the client.  This is used when you transform a RigidShape on the server and want the client to immediately transform rather than interpolate to the transform.
