### PR TITLE
Remove hard coded paths pass 1

### DIFF
--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -1579,13 +1579,13 @@ DefineEngineFunction( gotoWebPage, void, ( const char* address ),,
 
 //-----------------------------------------------------------------------------
 
-DefineEngineFunction( displaySplashWindow, bool, (),,
+DefineEngineFunction( displaySplashWindow, bool, (const char* path), ("art/gui/splash.bmp"),
    "Display a startup splash window suitable for showing while the engine still starts up.\n\n"
    "@note This is currently only implemented on Windows.\n\n"
    "@return True if the splash window could be successfully initialized.\n\n"
    "@ingroup Platform" )
 {
-   return Platform::displaySplashWindow();
+   return Platform::displaySplashWindow(path);
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/environment/basicClouds.cpp
+++ b/Engine/source/environment/basicClouds.cpp
@@ -26,6 +26,7 @@
 #include "basicClouds.h"
 
 #include "gfx/gfxTransformSaver.h"
+#include "gfx/gfxTextureManager.h"
 #include "core/stream/fileStream.h"
 #include "core/stream/bitStream.h"
 #include "scene/sceneRenderState.h"
@@ -336,7 +337,7 @@ void BasicClouds::_initTexture()
       mTexture[i].set( mTexName[i], &GFXDefaultStaticDiffuseProfile, "BasicClouds" );
 
       if ( mTexture[i].isNull() )
-         mTexture[i].set( "core/art/warnmat", &GFXDefaultStaticDiffuseProfile, "BasicClouds" );
+         mTexture[i].set( GFXTextureManager::getWarningTexturePath(), &GFXDefaultStaticDiffuseProfile, "BasicClouds" );
    }
 }
 

--- a/Engine/source/environment/cloudLayer.cpp
+++ b/Engine/source/environment/cloudLayer.cpp
@@ -26,6 +26,7 @@
 #include "cloudLayer.h"
 
 #include "gfx/gfxTransformSaver.h"
+#include "gfx/gfxTextureManager.h"
 #include "core/stream/fileStream.h"
 #include "core/stream/bitStream.h"
 #include "scene/sceneRenderState.h"
@@ -387,7 +388,7 @@ void CloudLayer::_initTexture()
       mTexture.set( mTextureName, &GFXDefaultStaticDiffuseProfile, "CloudLayer" );
 
    if ( mTexture.isNull() )
-      mTexture.set( "core/art/warnmat", &GFXDefaultStaticDiffuseProfile, "CloudLayer" );
+      mTexture.set( GFXTextureManager::getWarningTexturePath(), &GFXDefaultStaticDiffuseProfile, "CloudLayer" );
 }
 
 void CloudLayer::_initBuffers()

--- a/Engine/source/environment/waterObject.cpp
+++ b/Engine/source/environment/waterObject.cpp
@@ -38,6 +38,7 @@
 #include "T3D/gameBase/gameConnection.h"
 #include "T3D/shapeBase.h"
 #include "gfx/gfxOcclusionQuery.h"
+#include "gfx/gfxTextureManager.h"
 #include "gfx/sim/cubemapData.h"
 #include "math/util/matrixSet.h"
 #include "sfx/sfxAmbience.h"
@@ -1152,12 +1153,12 @@ void WaterObject::initTextures()
    if ( mRippleTexName.isNotEmpty() )
       mRippleTex.set( mRippleTexName, &GFXDefaultStaticDiffuseProfile, "WaterObject::mRippleTex" );
    if ( mRippleTex.isNull() )
-      mRippleTex.set( "core/art/warnmat", &GFXDefaultStaticDiffuseProfile, "WaterObject::mRippleTex" );
+      mRippleTex.set( GFXTextureManager::getWarningTexturePath(), &GFXDefaultStaticDiffuseProfile, "WaterObject::mRippleTex" );
 
    if ( mDepthGradientTexName.isNotEmpty() )
       mDepthGradientTex.set( mDepthGradientTexName, &GFXDefaultStaticDiffuseProfile, "WaterObject::mDepthGradientTex" );
    if ( mDepthGradientTex.isNull() )
-      mDepthGradientTex.set( "core/art/warnmat", &GFXDefaultStaticDiffuseProfile, "WaterObject::mDepthGradientTex" );
+      mDepthGradientTex.set( GFXTextureManager::getWarningTexturePath(), &GFXDefaultStaticDiffuseProfile, "WaterObject::mDepthGradientTex" );
    
    if ( mNamedDepthGradTex.isRegistered() )
       mNamedDepthGradTex.setTexture( mDepthGradientTex );
@@ -1165,7 +1166,7 @@ void WaterObject::initTextures()
    if ( mFoamTexName.isNotEmpty() )
       mFoamTex.set( mFoamTexName, &GFXDefaultStaticDiffuseProfile, "WaterObject::mFoamTex" );
    if ( mFoamTex.isNull() )
-      mFoamTex.set( "core/art/warnmat", &GFXDefaultStaticDiffuseProfile, "WaterObject::mFoamTex" );
+      mFoamTex.set( GFXTextureManager::getWarningTexturePath(), &GFXDefaultStaticDiffuseProfile, "WaterObject::mFoamTex" );
 
    if ( mCubemapName.isNotEmpty() )
       Sim::findObject( mCubemapName, mCubemap );   

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -41,6 +41,10 @@
 
 S32 GFXTextureManager::smTextureReductionLevel = 0;
 
+String GFXTextureManager::smMissingTexturePath("core/art/missingTexture");
+String GFXTextureManager::smUnavailableTexturePath("core/art/unavailable");
+String GFXTextureManager::smWarningTexturePath("core/art/warnmat");
+
 GFXTextureManager::EventSignal GFXTextureManager::smEventSignal;
 
 static const String  sDDSExt( "dds" );
@@ -51,6 +55,19 @@ void GFXTextureManager::init()
       "The number of mipmap levels to drop on loaded textures to reduce "
       "video memory usage.  It will skip any textures that have been defined "
       "as not allowing down scaling.\n"
+      "@ingroup GFX\n" );
+
+   Con::addVariable( "$pref::Video::missingTexturePath", TypeString, &smMissingTexturePath,
+      "The file path of the texture to display when the requested texture is missing.\n"
+      "@ingroup GFX\n" );
+
+   Con::addVariable( "$pref::Video::unavailableTexturePath", TypeString, &smUnavailableTexturePath,
+      "@brief The file path of the texture to display when the requested texture is unavailable.\n\n"
+      "Often this texture is used by GUI controls to indicate that the request image is unavailable.\n"
+      "@ingroup GFX\n" );
+
+   Con::addVariable( "$pref::Video::warningTexturePath", TypeString, &smWarningTexturePath,
+      "The file path of the texture used to warn the developer.\n"
       "@ingroup GFX\n" );
 }
 

--- a/Engine/source/gfx/gfxTextureManager.h
+++ b/Engine/source/gfx/gfxTextureManager.h
@@ -65,6 +65,15 @@ public:
    /// Set up some global script interface stuff.
    static void init();
 
+   /// Provide the path to the texture to use when the requested one is missing
+   static const String& getMissingTexturePath() { return smMissingTexturePath; }
+
+   /// Provide the path to the texture to use when the requested one is unavailable.
+   static const String& getUnavailableTexturePath() { return smUnavailableTexturePath; }
+
+   /// Provide the path to the texture used to warn the developer
+   static const String& getWarningTexturePath() { return smWarningTexturePath; }
+
    /// Update width and height based on available resources.
    ///
    /// We provide a simple interface for managing texture memory usage. Specifically,
@@ -176,6 +185,16 @@ protected:
    /// @see GFXTextureProfile::PreserveSize
    /// 
    static S32 smTextureReductionLevel;
+
+   /// File path to the missing texture
+   static String smMissingTexturePath;
+
+   /// File path to the unavailable texture.  Often used by GUI controls
+   /// when the requested image is not available.
+   static String smUnavailableTexturePath;
+
+   /// File path to the warning texture
+   static String smWarningTexturePath;
 
    GFXTextureObject *mListHead;
    GFXTextureObject *mListTail;

--- a/Engine/source/gui/buttons/guiBitmapButtonCtrl.cpp
+++ b/Engine/source/gui/buttons/guiBitmapButtonCtrl.cpp
@@ -29,6 +29,7 @@
 #include "gui/core/guiCanvas.h"
 #include "gui/core/guiDefaultControlRender.h"
 #include "gfx/gfxDrawUtil.h"
+#include "gfx/gfxTextureManager.h"
 
 
 ImplementEnumType( GuiBitmapMode,
@@ -327,7 +328,7 @@ void GuiBitmapButtonCtrl::setBitmap( const String& name )
             if( i == 0 && mTextures[ i ].mTextureNormal.isNull() && mTextures[ i ].mTextureHilight.isNull() && mTextures[ i ].mTextureDepressed.isNull() && mTextures[ i ].mTextureInactive.isNull() )
             {
                Con::warnf( "GuiBitmapButtonCtrl::setBitmap - Unable to load texture: %s", mBitmapName.c_str() );
-               this->setBitmap( "core/art/unavailable" );
+               this->setBitmap( GFXTextureManager::getUnavailableTexturePath() );
                return;
             }
          }
@@ -372,7 +373,7 @@ void GuiBitmapButtonCtrl::setBitmapHandles(GFXTexHandle normal, GFXTexHandle hig
       if (mTextures[ i ].mTextureNormal.isNull() && mTextures[ i ].mTextureHilight.isNull() && mTextures[ i ].mTextureDepressed.isNull() && mTextures[ i ].mTextureInactive.isNull())
       {
          Con::warnf("GuiBitmapButtonCtrl::setBitmapHandles() - Invalid texture handles");
-         setBitmap("core/art/unavailable");
+         setBitmap( GFXTextureManager::getUnavailableTexturePath() );
          
          return;
       }

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -30,8 +30,8 @@
 #include "materials/materialManager.h"
 #include "scene/sceneRenderState.h"
 #include "gfx/gfxPrimitiveBuffer.h"
+#include "gfx/gfxTextureManager.h"
 #include "gfx/sim/cubemapData.h"
-
 
 RenderPassData::RenderPassData()
 {
@@ -394,7 +394,7 @@ void ProcessedMaterial::_setStageData()
             
             // Load a debug texture to make it clear to the user 
             // that the texture for this stage was missing.
-            mStages[i].setTex( MFT_DiffuseMap, _createTexture( "core/art/missingTexture", &GFXDefaultStaticDiffuseProfile ) );
+            mStages[i].setTex( MFT_DiffuseMap, _createTexture( GFXTextureManager::getMissingTexturePath(), &GFXDefaultStaticDiffuseProfile ) );
          }
       }
 

--- a/Engine/source/platform/platform.h
+++ b/Engine/source/platform/platform.h
@@ -336,7 +336,7 @@ namespace Platform
    bool openWebBrowser( const char* webAddress );
 
    // display Splash Window
-   bool displaySplashWindow( );
+   bool displaySplashWindow( String path );
 
    void openFolder( const char* path );
 

--- a/Engine/source/terrain/terrMaterial.cpp
+++ b/Engine/source/terrain/terrMaterial.cpp
@@ -23,6 +23,7 @@
 #include "platform/platform.h"
 #include "terrain/terrMaterial.h"
 #include "console/consoleTypes.h"
+#include "gfx/gfxTextureManager.h"
 #include "gfx/bitmap/gBitmap.h"
 
 
@@ -152,9 +153,9 @@ TerrainMaterial* TerrainMaterial::findOrCreate( const char *nameOrPath )
       // fallback here just in case it gets "lost".
       mat = new TerrainMaterial();
       mat->setInternalName( "warning_material" );
-      mat->mDiffuseMap = "core/art/warnMat.png";
+      mat->mDiffuseMap = GFXTextureManager::getWarningTexturePath();
       mat->mDiffuseSize = 500;
-      mat->mDetailMap = "core/art/warnMat.png";
+      mat->mDetailMap = GFXTextureManager::getWarningTexturePath();
       mat->mDetailSize = 5;
       mat->registerObject();
       

--- a/Engine/source/windowManager/win32/win32SplashScreen.cpp
+++ b/Engine/source/windowManager/win32/win32SplashScreen.cpp
@@ -22,6 +22,7 @@
 
 #define _WIN32_WINNT 0x0500
 #include <windows.h>
+#include <tchar.h>
 
 #include "platform/platform.h"
 #include "console/console.h"
@@ -120,12 +121,20 @@ void CloseSplashWindow(HINSTANCE hinst)
 	
 }
 
-bool Platform::displaySplashWindow()
+bool Platform::displaySplashWindow( String path )
 {
+   if(path.isEmpty())
+      return false;
 
-	gSplashImage = (HBITMAP) ::LoadImage(0, L"art\\gui\\splash.bmp", 
+#ifdef UNICODE
+   const UTF16 *lFileName = path.utf16();
+#else
+   const UTF8  *lFileName = path.c_str();
+#endif
+
+	gSplashImage = (HBITMAP) ::LoadImage(0, lFileName, 
 		IMAGE_BITMAP, 0, 0, LR_LOADFROMFILE);
-	
+
 	if (!gSplashImage)
 		return false;
 


### PR DESCRIPTION
- displaySplashWindow() now takes an optional path to a bitmap file.
- Missing, unavailable and warning texture paths now come from GFXTextureManager static methods.
