### PR TITLE
Change ShapeBase to only test if available meshes

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -2582,7 +2582,7 @@ void ShapeBase::_prepRenderImage(   SceneRenderState *state,
       return;
 
    // We don't need to render if all the meshes are forced hidden.
-   if ( mMeshHidden.testAll() )   
+   if ( mMeshHidden.getSize() > 0 && mMeshHidden.testAll() )   
       return;
       
    // If we're rendering shadows don't render the mounted


### PR DESCRIPTION
The ShapeBase class tests if all of its meshes are hidden and if so,
then it doesn't render during that frame.  However, if there are no
meshes in the ShapeBase and only nodes then rendering is also skipped.
Unfortunately, this also skips the rendering of any mounted images.
This change allows for a mesh-less skeleton to render any mounted
images.
