### PR TITLE
Compile Bullet library under Windows

### DIFF
--- a/Tools/projectGenerator/modules/bullet.inc
+++ b/Tools/projectGenerator/modules/bullet.inc
@@ -35,8 +35,7 @@ beginModule( 'bullet' );
    {
       addProjectDependency( 'libbullet' );
 
-      if (Generator::$platform != "win32")
-         addSolutionProjectRef( 'libbullet' );
+      addSolutionProjectRef( 'libbullet' );
    }
    
 endModule();


### PR DESCRIPTION
For some reason the Bullet physics library's project file was not being
included in the solution when the bullet module was added.  This change
makes sure that when you want to use Bullet, it will correctly be added
by the Project Generator.
