### PR TITLE
ScatterSky Fixes and Improvements

### DIFF
--- a/Engine/source/environment/scatterSky.cpp
+++ b/Engine/source/environment/scatterSky.cpp
@@ -159,7 +159,7 @@ ScatterSky::ScatterSky()
    mFlareState.clear();
    mFlareScale = 1.0f;
 
-   mMoonEnabled = true;
+mMoonEnabled = true;
    mMoonScale = 0.2f;
    mMoonTint.set( 0.192157f, 0.192157f, 0.192157f, 1.0f );
    MathUtils::getVectorFromAngles( mMoonLightDir, 0.0f, 45.0f );
@@ -169,6 +169,7 @@ ScatterSky::ScatterSky()
    mNightColor.set( 0.0196078f, 0.0117647f, 0.109804f, 1.0f );
    mNightFogColor = mNightColor;
    mUseNightCubemap = false;
+   mSunSize = 1.0f;
 
    mMoonMatInst = NULL;
 
@@ -179,6 +180,10 @@ ScatterSky::ScatterSky()
 
    mMatrixSet = reinterpret_cast<MatrixSet *>(dMalloc_aligned(sizeof(MatrixSet), 16));
    constructInPlace(mMatrixSet);
+   //added for color scatter sky
+   mColorizeAmt = 0;  
+   mColorize.set(0,0,0); 
+   //END addition
 }
 
 ScatterSky::~ScatterSky()
@@ -318,9 +323,25 @@ void ScatterSky::initPersistFields()
 
       addField( "skyBrightness",       TypeF32,    Offset( mSkyBrightness, ScatterSky ),
          "Global brightness and intensity applied to the sky and objects in the level." );
-      
-      addField( "mieScattering",       TypeF32,    Offset( mMieScattering, ScatterSky ),
-         "Affects the size and intensity of light scattering around the sun." );
+
+     addField( "sunSize",       TypeF32,    Offset( mSunSize, ScatterSky ),
+         "Affects the size of the sun's disk." );
+
+	 //Added for Color Scatter Sky--RK
+
+	 addField( "colorizeAmount",       TypeF32,   Offset( mColorizeAmt, ScatterSky ),
+         "Controls how much the the alpha component of colorize brigthens the sky. Setting to 0 returns default behavior." );
+
+	  addField( "colorize",            TypeColorF,    Offset( mColorize, ScatterSky ),
+         "Tints the sky the color specified, the alpha controls the brigthness. The brightness is multipled by the value of colorizeAmt." );
+	  //END ADDED CODE --RK
+
+	  //Removed for ScatterSky fix--RK
+
+      //addField( "mieScattering",       TypeF32,    Offset( mMieScattering, ScatterSky ),
+      //   "Affects the size and intensity of light scattering around the sun." );
+
+	  //END Remove --RK
       
       addField( "rayleighScattering",  TypeF32,    Offset( mRayleighScattering, ScatterSky ),
          "Controls how blue the atmosphere is during the day." );      
@@ -436,7 +457,9 @@ U32 ScatterSky::packUpdate(NetConnection *con, U32 mask, BitStream *stream)
       mMieScattering4PI = mMieScattering * 4.0f * M_PI_F;
 
       stream->write( mMieScattering4PI );
-      
+
+      stream->write( mSunSize ); 
+
       stream->write( mSkyBrightness );
       
       stream->write( mMiePhaseAssymetry );
@@ -460,6 +483,10 @@ U32 ScatterSky::packUpdate(NetConnection *con, U32 mask, BitStream *stream)
       stream->write( mAmbientScale );
       stream->write( mSunScale );
       stream->write( mFogScale );
+	  //Added for Color ScatterSky --RK
+	  stream->write( mColorizeAmt );  
+       stream->write( mColorize );
+	   //End Added Code --RK
 
       stream->write( mExposure );
 
@@ -513,7 +540,9 @@ void ScatterSky::unpackUpdate(NetConnection *con, BitStream *stream)
 
       stream->read( &mMieScattering );
       stream->read( &mMieScattering4PI );
-      
+
+      stream->read( &mSunSize );
+
       stream->read( &mSkyBrightness );
       
       stream->read( &mMiePhaseAssymetry );
@@ -539,6 +568,18 @@ void ScatterSky::unpackUpdate(NetConnection *con, BitStream *stream)
       stream->read( &mAmbientScale );
       stream->read( &mSunScale );
       stream->read( &mFogScale );
+	  //Added for Color ScatterSky --RK
+	  F32 colorizeAmt;  
+      stream->read( &colorizeAmt );  
+  
+      if(mColorizeAmt != colorizeAmt) {  
+         mColorizeAmt = colorizeAmt;  
+         mShader = NULL; //forces shader refresh  
+      }  
+  
+      stream->read( &mColorize );
+
+	  //End Added Code--RK
 
       if ( tmpColor != mWavelength )
       {
@@ -663,8 +704,15 @@ bool ScatterSky::_initShader()
       Con::warnf( "ScatterSky::_initShader - failed to locate shader ScatterSkyShaderData!" );
       return false;
    }
+   //Altered and Added Code for Color ScatterSky --RK
+   //mShader = shaderData->getShader();--commented out-RK
+      Vector<GFXShaderMacro> macros;  
+   if ( mColorizeAmt )     
+      macros.push_back( GFXShaderMacro( "USE_COLORIZE" ) );  
+  
+   mShader = shaderData->getShader( macros );
+   //END Code Altered-RK
 
-   mShader = shaderData->getShader();
    if ( !mShader )
       return false;
 
@@ -698,6 +746,9 @@ bool ScatterSky::_initShader()
    mInverseWavelengthSC = mShader->getShaderConstHandle( "$invWaveLength" );
    mNightInterpolantAndExposureSC = mShader->getShaderConstHandle( "$nightInterpAndExposure" );
    mUseCubemapSC = mShader->getShaderConstHandle( "$useCubemap" );
+   //Added for Color ScatterSky --RK
+   mColorizeSC = mShader->getShaderConstHandle( "$colorize" );
+   //END Added Code --RK
 
    return true;
 }
@@ -790,72 +841,79 @@ void ScatterSky::_initCurves()
    if ( mCurves->getSampleCount() > 0 )
       return;
 
-   // Takes time of day (0-2) and returns
+   // Takes time of day (0-2) and returns      
    // the night interpolant (0-1) day/night factor.
+   // moonlight = 0, sunlight > 0
    mCurves[0].clear();
-   mCurves[0].addPoint( 0.0f, 0.5f );
-   mCurves[0].addPoint( 0.1f, 1.0f );
-   mCurves[0].addPoint( 0.9f, 1.0f );
-   mCurves[0].addPoint( 1.0f, 0.5f );
-   mCurves[0].addPoint( 1.1f, 0.0f );
-   mCurves[0].addPoint( 1.9f, 0.0f );
-   mCurves[0].addPoint( 2.0f, 0.5f );
-   //mCurves[0].addPoint( 0.0f, 0.25f );
-   //mCurves[0].addPoint( 0.05f, 0.5f );
-   //mCurves[0].addPoint( 0.1f, 1.0f );
-   //mCurves[0].addPoint( 0.6f, 1.0f );
-   //mCurves[0].addPoint( 0.98f, 0.895f );
-   //mCurves[0].addPoint( 1.0f, 0.15f );
-   //mCurves[0].addPoint( 1.15f, 0.0f );
-   //mCurves[0].addPoint( 1.9f, 0.0f );
-   //mCurves[0].addPoint( 2.0f, 0.15f );
-
-   
-   // Takes time of day (0-2) and returns
-   // the moon light brightness.
+   mCurves[0].addPoint( 0.0f, 0.5f );// Sunrise
+   mCurves[0].addPoint( 0.025f, 1.0f );//
+   mCurves[0].addPoint( 0.975f, 1.0f );//
+   mCurves[0].addPoint( 1.0f, 0.5f );//Sunset
+   mCurves[0].addPoint( 1.02f, 0.0f );//Sunlight ends
+   mCurves[0].addPoint( 1.98f, 0.0f );//Sunlight begins
+   mCurves[0].addPoint( 2.0f, 0.5f );// Sunrise
+     
+    //  Takes time of day (0-2) and returns mieScattering factor 
+   //   Regulates the size of the sun's disk
    mCurves[1].clear();
-   mCurves[1].addPoint( 0.0f, 0.0f );
-   mCurves[1].addPoint( 1.0f, 0.0f );
-   mCurves[1].addPoint( 1.1f, 0.0f );
-   mCurves[1].addPoint( 1.2f, 0.5f );   
-   mCurves[1].addPoint( 1.3f, 1.0f );
-   mCurves[1].addPoint( 1.8f, 0.5f );
-   mCurves[1].addPoint( 1.9f, 0.0f );
-   mCurves[1].addPoint( 2.0f, 0.0f );
+   mCurves[1].addPoint( 0.0f, 0.0006f );
+   mCurves[1].addPoint( 0.01f, 0.00035f );
+   mCurves[1].addPoint( 0.03f, 0.00023f );
+   mCurves[1].addPoint( 0.1f, 0.00022f );
+   mCurves[1].addPoint( 0.2f, 0.00043f );
+   mCurves[1].addPoint( 0.3f, 0.00062f );
+   mCurves[1].addPoint( 0.4f, 0.0008f );
+   mCurves[1].addPoint( 0.5f, 0.00086f );// High noon
+   mCurves[1].addPoint( 0.6f, 0.0008f );
+   mCurves[1].addPoint( 0.7f, 0.00062f );
+   mCurves[1].addPoint( 0.8f, 0.00043f );
+   mCurves[1].addPoint( 0.9f, 0.00022f );
+   mCurves[1].addPoint( 0.97f, 0.00023f );
+   mCurves[1].addPoint( 0.99f, 0.00035f );
+   mCurves[1].addPoint( 1.0f, 0.0006f );
+   mCurves[1].addPoint( 2.0f, 0.0006f ); 
 
    // Takes time of day and returns brightness
+   // Controls sunlight and moonlight brightness
    mCurves[2].clear();
-   mCurves[2].addPoint( 0.0f, 0.4f );
-   mCurves[2].addPoint( 0.25f, 1.0f );
-   mCurves[2].addPoint( 0.5f, 1.0f );
-   mCurves[2].addPoint( 0.75f, 0.9f );
-   mCurves[2].addPoint( 1.0f, 0.3f );
-   mCurves[2].addPoint( 1.02877f, 0.0f );
-   mCurves[2].addPoint( 1.05f, 0.0f );
-   mCurves[2].addPoint( 1.15f, 0.0f );   
-   mCurves[2].addPoint( 1.2f, 0.0f );
-   mCurves[2].addPoint( 1.3f, 0.3f );
-   mCurves[2].addPoint( 1.85f, 0.4f );
-   mCurves[2].addPoint( 1.9f, 0.0f );
-   mCurves[2].addPoint( 2.0f, 0.0f );   
-
-
+   mCurves[2].addPoint( 0.0f, 0.2f );// Sunrise
+   mCurves[2].addPoint( 0.1f, 1.0f );
+   mCurves[2].addPoint( 0.9f, 1.0f );// Sunset
+   mCurves[2].addPoint( 1.008f, 0.0f );//Adjust end of sun's reflection
+   mCurves[2].addPoint( 1.02001f, 0.0f );
+   mCurves[2].addPoint( 1.05f, 0.5f );// Turn brightness up for moonlight
+   mCurves[2].addPoint( 1.93f, 0.5f ); 
+   mCurves[2].addPoint( 1.97999f, 0.0f );// No brightness when sunlight starts
+   mCurves[2].addPoint( 1.992f, 0.0f );//Adjust start of sun's reflection
+   mCurves[2].addPoint( 2.0f, 0.2f ); // Sunrise  
+     
+   // Interpolation of day/night color sets
+   // 0/1  ambient/nightcolor
+   // 0 = day colors only anytime
+   // 1 = night colors only anytime
+   // between 0 and 1 renders both color sets anytime
    mCurves[3].clear();
-   mCurves[3].addPoint( 0.0f, 0.01f );
-   mCurves[3].addPoint( 0.05f, 0.0f );
+   mCurves[3].addPoint( 0.0f, 0.8f );//Sunrise
    mCurves[3].addPoint( 0.1f, 0.0f );
-   mCurves[3].addPoint( 0.6f, 0.0f );
-   mCurves[3].addPoint( 0.98f, 0.75f );
-   mCurves[3].addPoint( 1.0f, 1.0f );
-   mCurves[3].addPoint( 1.02877f, 1.0f );
-   mCurves[3].addPoint( 1.05f, 1.0f );
-   mCurves[3].addPoint( 1.2f, 1.0f );   
-   mCurves[3].addPoint( 1.3f, 1.0f );
-   mCurves[3].addPoint( 1.85f, 1.0f );
-   mCurves[3].addPoint( 1.9f, 1.0f );
-   mCurves[3].addPoint( 2.0f, 1.0f );  
-}
+   mCurves[3].addPoint( 0.99f, 0.0f );
+   mCurves[3].addPoint( 1.0f, 0.8f );// Sunset
+   mCurves[3].addPoint( 1.01999f, 1.0f );//
+   mCurves[3].addPoint( 1.98001f, 1.0f );// Sunlight begins with full night colors
+   mCurves[3].addPoint( 2.0f, 0.8f );  //Sunrise
 
+     //  Takes time of day (0-2) and returns smoothing factor 
+   //  Interpolates between mMoonTint color and mNightColor 
+   mCurves[4].clear();
+   mCurves[4].addPoint( 0.0f, 1.0f );
+   mCurves[4].addPoint( 0.96f, 1.0f );
+   mCurves[4].addPoint( 1.01999f, 0.5f );
+   mCurves[4].addPoint( 1.02001f, 0.5f );
+   mCurves[4].addPoint( 1.08f, 1.0f );
+   mCurves[4].addPoint( 1.92f, 1.0f );
+   mCurves[4].addPoint( 1.97999f, 0.5f );
+   mCurves[4].addPoint( 1.98001f, 0.5f ); 
+   mCurves[4].addPoint( 2.0f, 1.0f );
+}
 void ScatterSky::_updateTimeOfDay( TimeOfDay *timeOfDay, F32 time )
 {
    setElevation( timeOfDay->getElevationDegrees() );
@@ -922,6 +980,7 @@ void ScatterSky::_render( ObjectRenderInst *ri, SceneRenderState *state, BaseMat
    mShaderConsts->setSafe( mNightColorSC, mNightColor );
    mShaderConsts->setSafe( mInverseWavelengthSC, invWavelength );
    mShaderConsts->setSafe( mNightInterpolantAndExposureSC, Point2F( mExposure, mNightInterpolant ) );
+   mShaderConsts->setSafe( mColorizeSC, mColorize*mColorizeAmt );
 
    if ( GFXDevice::getWireframe() )
    {
@@ -1119,6 +1178,14 @@ void ScatterSky::_interpolateColors()
    mAmbientColor *= mAmbientScale;
    mSunColor *= mSunScale;
    mFogColor *= mFogScale;
+
+   mMieScattering = (mCurves[1].getVal( mTimeOfDay) * mSunSize ); //Scale the size of the sun's disk  
+ 
+   ColorF moonTemp = mMoonTint;
+   ColorF nightTemp = mNightColor;
+   
+   moonTemp.interpolate( mNightColor, mMoonTint, mCurves[4].getVal( mTimeOfDay ) );
+   nightTemp.interpolate( mMoonTint, mNightColor, mCurves[4].getVal( mTimeOfDay ) );
 
    mFogColor.interpolate( mFogColor, mNightFogColor, mCurves[3].getVal( mTimeOfDay ) );//mNightInterpolant );   
    mFogColor.alpha = 1.0f;

--- a/Engine/source/environment/scatterSky.h
+++ b/Engine/source/environment/scatterSky.h
@@ -152,7 +152,7 @@ protected:
    static const F32 smAtmosphereRadius;
    static const F32 smViewerHeight;
 
-#define CURVE_COUNT 4
+#define CURVE_COUNT 5
 
    FloatCurve mCurves[CURVE_COUNT];
 
@@ -161,7 +161,7 @@ protected:
 
    F32 mRayleighScattering;
    F32 mRayleighScattering4PI;
-
+   F32 mSunSize;
    F32 mMieScattering;
    F32 mMieScattering4PI;
 
@@ -246,6 +246,12 @@ protected:
    GFXShaderConstHandle *mInverseWavelengthSC;
    GFXShaderConstHandle *mNightInterpolantAndExposureSC;
    GFXShaderConstHandle *mUseCubemapSC;
+   //added for scatter sky color
+   F32 mColorizeAmt;  
+   ColorF mColorize;  
+  
+   GFXShaderConstHandle *mColorizeSC;
+   //end addition
 };
 
 #endif // _SCATTERSKY_H_

--- a/Templates/Empty PhysX/game/core/scripts/client/postFx/fog.cs
+++ b/Templates/Empty PhysX/game/core/scripts/client/postFx/fog.cs
@@ -62,9 +62,51 @@ singleton PostEffect( FogPostFx )
    
    renderPriority = 5;
    
-   isEnabled = true;
+   isEnabled = false;
 };
 
+//-----------------------------------------------------------------
+// Fog2
+//-----------------------------------------------------------------
+
+singleton ShaderData( FogPassShader2 )
+{
+DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
+DXPixelShaderFile = "shaders/common/postFx/fogP.hlsl";
+
+samplerNames[0] = "$prepassTex";
+samplerNames[0] = "$backBuffer";
+
+pixVersion = 2.0;
+};
+
+singleton GFXStateBlockData( FogPassStateBlock : PFX_DefaultStateBlock )
+{
+blendDefined = true;
+blendEnable = true;
+blendSrc = GFXBlendSrcAlpha;
+blendDest = GFXBlendInvSrcAlpha;
+};
+
+singleton PostEffect( FogPostFx2 )
+{
+// Let the fog effect render during the
+// reflection pass.
+allowReflectPass = true;
+
+renderTime = "PFXBeforeBin";
+renderBin = "ObjTranslucentBin";
+requirements = "PrePassDepth";
+
+shader = FogPassShader2;
+stateBlock = FogPassStateBlock;
+texture[0] = "#prepass";
+texture[1] = "$backBuffer";
+
+renderPriority = 5;
+
+isEnabled = true;
+};
 
 //------------------------------------------------------------------------------
 // UnderwaterFog

--- a/Templates/Empty PhysX/game/shaders/common/postFx/fogP.hlsl
+++ b/Templates/Empty PhysX/game/shaders/common/postFx/fogP.hlsl
@@ -38,7 +38,7 @@ float4 main( PFXVertToPix IN ) : COLOR
    
    // Skip fogging the extreme far plane so that 
    // the canvas clear color always appears.
-   clip( 0.9999 - depth );
+   //clip( 0.9999 - depth ); --changed RK for Fog fix
    
    float factor = computeSceneFog( eyePosWorld,
                                    eyePosWorld + ( IN.wsEyeRay * depth ),

--- a/Templates/Empty PhysX/game/shaders/common/scatterSkyV.hlsl
+++ b/Templates/Empty PhysX/game/shaders/common/scatterSkyV.hlsl
@@ -55,6 +55,14 @@ struct Conn
    float3 pos : TEXCOORD3;
 };
  
+float3 desaturate(const float3 color, const float desaturation) 
+{  
+   const float3 gray_conv = float3 (0.30, 0.59, 0.11);  
+   return lerp(color, dot(gray_conv , color), desaturation);  
+}  
+  
+uniform float4 colorize;  
+
 Conn main(  Vert In,
             uniform float4x4 modelView          : register(C0),
             uniform float4 misc                 : register(C4),
@@ -138,6 +146,16 @@ Conn main(  Vert In,
    Out.rayleighColor.a = 1.0f;
    Out.v3Direction = newCamPos - v3Pos.xyz;
    Out.pos = In.position.xyz;
+
+#ifdef USE_COLORIZE  
+  
+   Out.rayleighColor.rgb = desaturate(Out.rayleighColor.rgb, 1) * colorize.a;  
+     
+   Out.rayleighColor.r *= colorize.r;  
+   Out.rayleighColor.g *= colorize.g;  
+   Out.rayleighColor.b *= colorize.b;  
+     
+#endif  
 
    return Out;
 }

--- a/Templates/Empty/game/core/scripts/client/postFx/fog.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/fog.cs
@@ -62,9 +62,51 @@ singleton PostEffect( FogPostFx )
    
    renderPriority = 5;
    
-   isEnabled = true;
+   isEnabled = false;
 };
 
+//-----------------------------------------------------------------
+// Fog2
+//-----------------------------------------------------------------
+
+singleton ShaderData( FogPassShader2 )
+{
+DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
+DXPixelShaderFile = "shaders/common/postFx/fogP.hlsl";
+
+samplerNames[0] = "$prepassTex";
+samplerNames[0] = "$backBuffer";
+
+pixVersion = 2.0;
+};
+
+singleton GFXStateBlockData( FogPassStateBlock : PFX_DefaultStateBlock )
+{
+blendDefined = true;
+blendEnable = true;
+blendSrc = GFXBlendSrcAlpha;
+blendDest = GFXBlendInvSrcAlpha;
+};
+
+singleton PostEffect( FogPostFx2 )
+{
+// Let the fog effect render during the
+// reflection pass.
+allowReflectPass = true;
+
+renderTime = "PFXBeforeBin";
+renderBin = "ObjTranslucentBin";
+requirements = "PrePassDepth";
+
+shader = FogPassShader2;
+stateBlock = FogPassStateBlock;
+texture[0] = "#prepass";
+texture[1] = "$backBuffer";
+
+renderPriority = 5;
+
+isEnabled = true;
+};
 
 //------------------------------------------------------------------------------
 // UnderwaterFog

--- a/Templates/Empty/game/shaders/common/postFx/fogP.hlsl
+++ b/Templates/Empty/game/shaders/common/postFx/fogP.hlsl
@@ -38,7 +38,7 @@ float4 main( PFXVertToPix IN ) : COLOR
    
    // Skip fogging the extreme far plane so that 
    // the canvas clear color always appears.
-   clip( 0.9999 - depth );
+   //clip( 0.9999 - depth ); --changed RK for Fog fix
    
    float factor = computeSceneFog( eyePosWorld,
                                    eyePosWorld + ( IN.wsEyeRay * depth ),

--- a/Templates/Empty/game/shaders/common/scatterSkyV.hlsl
+++ b/Templates/Empty/game/shaders/common/scatterSkyV.hlsl
@@ -55,6 +55,14 @@ struct Conn
    float3 pos : TEXCOORD3;
 };
  
+float3 desaturate(const float3 color, const float desaturation) 
+{  
+   const float3 gray_conv = float3 (0.30, 0.59, 0.11);  
+   return lerp(color, dot(gray_conv , color), desaturation);  
+}  
+  
+uniform float4 colorize;  
+
 Conn main(  Vert In,
             uniform float4x4 modelView          : register(C0),
             uniform float4 misc                 : register(C4),
@@ -138,6 +146,16 @@ Conn main(  Vert In,
    Out.rayleighColor.a = 1.0f;
    Out.v3Direction = newCamPos - v3Pos.xyz;
    Out.pos = In.position.xyz;
+
+#ifdef USE_COLORIZE  
+  
+   Out.rayleighColor.rgb = desaturate(Out.rayleighColor.rgb, 1) * colorize.a;  
+     
+   Out.rayleighColor.r *= colorize.r;  
+   Out.rayleighColor.g *= colorize.g;  
+   Out.rayleighColor.b *= colorize.b;  
+     
+#endif  
 
    return Out;
 }

--- a/Templates/Full PhysX/game/core/scripts/client/postFx/fog.cs
+++ b/Templates/Full PhysX/game/core/scripts/client/postFx/fog.cs
@@ -62,9 +62,51 @@ singleton PostEffect( FogPostFx )
    
    renderPriority = 5;
    
-   isEnabled = true;
+   isEnabled = false;
 };
 
+//-----------------------------------------------------------------
+// Fog2
+//-----------------------------------------------------------------
+
+singleton ShaderData( FogPassShader2 )
+{
+DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
+DXPixelShaderFile = "shaders/common/postFx/fogP.hlsl";
+
+samplerNames[0] = "$prepassTex";
+samplerNames[0] = "$backBuffer";
+
+pixVersion = 2.0;
+};
+
+singleton GFXStateBlockData( FogPassStateBlock : PFX_DefaultStateBlock )
+{
+blendDefined = true;
+blendEnable = true;
+blendSrc = GFXBlendSrcAlpha;
+blendDest = GFXBlendInvSrcAlpha;
+};
+
+singleton PostEffect( FogPostFx2 )
+{
+// Let the fog effect render during the
+// reflection pass.
+allowReflectPass = true;
+
+renderTime = "PFXBeforeBin";
+renderBin = "ObjTranslucentBin";
+requirements = "PrePassDepth";
+
+shader = FogPassShader2;
+stateBlock = FogPassStateBlock;
+texture[0] = "#prepass";
+texture[1] = "$backBuffer";
+
+renderPriority = 5;
+
+isEnabled = true;
+};
 
 //------------------------------------------------------------------------------
 // UnderwaterFog

--- a/Templates/Full PhysX/game/shaders/common/postFx/fogP.hlsl
+++ b/Templates/Full PhysX/game/shaders/common/postFx/fogP.hlsl
@@ -38,7 +38,7 @@ float4 main( PFXVertToPix IN ) : COLOR
    
    // Skip fogging the extreme far plane so that 
    // the canvas clear color always appears.
-   clip( 0.9999 - depth );
+   //clip( 0.9999 - depth ); --changed RK for Fog fix
    
    float factor = computeSceneFog( eyePosWorld,
                                    eyePosWorld + ( IN.wsEyeRay * depth ),

--- a/Templates/Full PhysX/game/shaders/common/scatterSkyV.hlsl
+++ b/Templates/Full PhysX/game/shaders/common/scatterSkyV.hlsl
@@ -55,6 +55,14 @@ struct Conn
    float3 pos : TEXCOORD3;
 };
  
+float3 desaturate(const float3 color, const float desaturation) 
+{  
+   const float3 gray_conv = float3 (0.30, 0.59, 0.11);  
+   return lerp(color, dot(gray_conv , color), desaturation);  
+}  
+  
+uniform float4 colorize;  
+
 Conn main(  Vert In,
             uniform float4x4 modelView          : register(C0),
             uniform float4 misc                 : register(C4),
@@ -138,6 +146,16 @@ Conn main(  Vert In,
    Out.rayleighColor.a = 1.0f;
    Out.v3Direction = newCamPos - v3Pos.xyz;
    Out.pos = In.position.xyz;
+
+#ifdef USE_COLORIZE  
+  
+   Out.rayleighColor.rgb = desaturate(Out.rayleighColor.rgb, 1) * colorize.a;  
+     
+   Out.rayleighColor.r *= colorize.r;  
+   Out.rayleighColor.g *= colorize.g;  
+   Out.rayleighColor.b *= colorize.b;  
+     
+#endif  
 
    return Out;
 }

--- a/Templates/Full/game/core/scripts/client/postFx/fog.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/fog.cs
@@ -62,9 +62,51 @@ singleton PostEffect( FogPostFx )
    
    renderPriority = 5;
    
-   isEnabled = true;
+   isEnabled = false;
 };
 
+//-----------------------------------------------------------------
+// Fog2
+//-----------------------------------------------------------------
+
+singleton ShaderData( FogPassShader2 )
+{
+DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
+DXPixelShaderFile = "shaders/common/postFx/fogP.hlsl";
+
+samplerNames[0] = "$prepassTex";
+samplerNames[0] = "$backBuffer";
+
+pixVersion = 2.0;
+};
+
+singleton GFXStateBlockData( FogPassStateBlock : PFX_DefaultStateBlock )
+{
+blendDefined = true;
+blendEnable = true;
+blendSrc = GFXBlendSrcAlpha;
+blendDest = GFXBlendInvSrcAlpha;
+};
+
+singleton PostEffect( FogPostFx2 )
+{
+// Let the fog effect render during the
+// reflection pass.
+allowReflectPass = true;
+
+renderTime = "PFXBeforeBin";
+renderBin = "ObjTranslucentBin";
+requirements = "PrePassDepth";
+
+shader = FogPassShader2;
+stateBlock = FogPassStateBlock;
+texture[0] = "#prepass";
+texture[1] = "$backBuffer";
+
+renderPriority = 5;
+
+isEnabled = true;
+};
 
 //------------------------------------------------------------------------------
 // UnderwaterFog

--- a/Templates/Full/game/shaders/common/postFx/fogP.hlsl
+++ b/Templates/Full/game/shaders/common/postFx/fogP.hlsl
@@ -38,7 +38,7 @@ float4 main( PFXVertToPix IN ) : COLOR
    
    // Skip fogging the extreme far plane so that 
    // the canvas clear color always appears.
-   clip( 0.9999 - depth );
+   //clip( 0.9999 - depth ); --changed RK for Fog fix
    
    float factor = computeSceneFog( eyePosWorld,
                                    eyePosWorld + ( IN.wsEyeRay * depth ),

--- a/Templates/Full/game/shaders/common/scatterSkyV.hlsl
+++ b/Templates/Full/game/shaders/common/scatterSkyV.hlsl
@@ -55,6 +55,14 @@ struct Conn
    float3 pos : TEXCOORD3;
 };
  
+float3 desaturate(const float3 color, const float desaturation) 
+{  
+   const float3 gray_conv = float3 (0.30, 0.59, 0.11);  
+   return lerp(color, dot(gray_conv , color), desaturation);  
+}  
+  
+uniform float4 colorize;  
+
 Conn main(  Vert In,
             uniform float4x4 modelView          : register(C0),
             uniform float4 misc                 : register(C4),
@@ -138,6 +146,16 @@ Conn main(  Vert In,
    Out.rayleighColor.a = 1.0f;
    Out.v3Direction = newCamPos - v3Pos.xyz;
    Out.pos = In.position.xyz;
+
+#ifdef USE_COLORIZE  
+  
+   Out.rayleighColor.rgb = desaturate(Out.rayleighColor.rgb, 1) * colorize.a;  
+     
+   Out.rayleighColor.r *= colorize.r;  
+   Out.rayleighColor.g *= colorize.g;  
+   Out.rayleighColor.b *= colorize.b;  
+     
+#endif  
 
    return Out;
 }


### PR DESCRIPTION
Added changes that fix errors associated with Sun Size and ScatterSky
color when using the Time of Day object. Additionally, added the ability
to colorize ScatterSky. Additional fixes apply to correcting Fogging
errors (these fixes work with both ScatterSky and Skybox objects.)
