### PR TITLE
Fix crash caused by type clash in missing/unavailable/warning texture paths

### DIFF
--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -41,9 +41,9 @@
 
 S32 GFXTextureManager::smTextureReductionLevel = 0;
 
-StringTableEntry GFXTextureManager::smMissingTexturePath = 0;
-StringTableEntry GFXTextureManager::smUnavailableTexturePath = 0;
-StringTableEntry GFXTextureManager::smWarningTexturePath = 0;
+String GFXTextureManager::smMissingTexturePath("core/art/missingTexture");
+String GFXTextureManager::smUnavailableTexturePath("core/art/unavailable");
+String GFXTextureManager::smWarningTexturePath("core/art/warnmat");
 
 GFXTextureManager::EventSignal GFXTextureManager::smEventSignal;
 
@@ -51,26 +51,22 @@ static const String  sDDSExt( "dds" );
 
 void GFXTextureManager::init()
 {
-   smMissingTexturePath = StringTable->insert("core/art/missingTexture");
-   smUnavailableTexturePath = StringTable->insert("core/art/unavailable");
-   smWarningTexturePath = StringTable->insert("core/art/warnmat");
-
    Con::addVariable( "$pref::Video::textureReductionLevel", TypeS32, &smTextureReductionLevel,
       "The number of mipmap levels to drop on loaded textures to reduce "
       "video memory usage.  It will skip any textures that have been defined "
       "as not allowing down scaling.\n"
       "@ingroup GFX\n" );
 
-   Con::addVariable( "$pref::Video::missingTexturePath", TypeString, &smMissingTexturePath,
+   Con::addVariable( "$pref::Video::missingTexturePath", TypeRealString, &smMissingTexturePath,
       "The file path of the texture to display when the requested texture is missing.\n"
       "@ingroup GFX\n" );
 
-   Con::addVariable( "$pref::Video::unavailableTexturePath", TypeString, &smUnavailableTexturePath,
+   Con::addVariable( "$pref::Video::unavailableTexturePath", TypeRealString, &smUnavailableTexturePath,
       "@brief The file path of the texture to display when the requested texture is unavailable.\n\n"
       "Often this texture is used by GUI controls to indicate that the request image is unavailable.\n"
       "@ingroup GFX\n" );
 
-   Con::addVariable( "$pref::Video::warningTexturePath", TypeString, &smWarningTexturePath,
+   Con::addVariable( "$pref::Video::warningTexturePath", TypeRealString, &smWarningTexturePath,
       "The file path of the texture used to warn the developer.\n"
       "@ingroup GFX\n" );
 }

--- a/Engine/source/gfx/gfxTextureManager.h
+++ b/Engine/source/gfx/gfxTextureManager.h
@@ -66,13 +66,13 @@ public:
    static void init();
 
    /// Provide the path to the texture to use when the requested one is missing
-   static const StringTableEntry& getMissingTexturePath() { return smMissingTexturePath; }
+   static const String& getMissingTexturePath() { return smMissingTexturePath; }
 
    /// Provide the path to the texture to use when the requested one is unavailable.
-   static const StringTableEntry& getUnavailableTexturePath() { return smUnavailableTexturePath; }
+   static const String& getUnavailableTexturePath() { return smUnavailableTexturePath; }
 
    /// Provide the path to the texture used to warn the developer
-   static const StringTableEntry& getWarningTexturePath() { return smWarningTexturePath; }
+   static const String& getWarningTexturePath() { return smWarningTexturePath; }
 
    /// Update width and height based on available resources.
    ///
@@ -187,14 +187,14 @@ protected:
    static S32 smTextureReductionLevel;
 
    /// File path to the missing texture
-   static StringTableEntry smMissingTexturePath;
+   static String smMissingTexturePath;
 
    /// File path to the unavailable texture.  Often used by GUI controls
    /// when the requested image is not available.
-   static StringTableEntry smUnavailableTexturePath;
+   static String smUnavailableTexturePath;
 
    /// File path to the warning texture
-   static StringTableEntry smWarningTexturePath;
+   static String smWarningTexturePath;
 
    GFXTextureObject *mListHead;
    GFXTextureObject *mListTail;


### PR DESCRIPTION
Recent change to remove hard coded texture paths caused 'const char *' to be cast to 'String *' causing crash.
