### PR TITLE
Resolve issue #163: Material Editor Crash- Opening the material editor with a mesh selected doesn't open a custom material.

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -5127,8 +5127,8 @@ DefineEngineMethod( ShapeBase, changeMaterial, void, ( const char* mapTo, Materi
 
    newMat->mMapTo = mapTo;
 
-   // Map the material in the in the matmgr
-   MATMGR->mapMaterial( mapTo, newMat->mMapTo );
+   // Map the material by name in the matmgr
+   MATMGR->mapMaterial( mapTo, newMat->getName() );
 
    // Replace instances with the new material being traded in. For ShapeBase
    // class we have to update the server/client objects separately so both

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -1120,8 +1120,8 @@ DefineEngineMethod( TSStatic, changeMaterial, void, ( const char* mapTo, Materia
 
    newMat->mMapTo = mapTo;
 
-   // Map the material in the in the matmgr
-   MATMGR->mapMaterial( mapTo, newMat->mMapTo );
+   // Map the material by name in the matmgr
+   MATMGR->mapMaterial( mapTo, newMat->getName() );
 
    // Replace instances with the new material being traded in. Lets make sure that we only
    // target the specific targets per inst, this is actually doing more than we thought

--- a/Engine/source/core/tokenizer.cpp
+++ b/Engine/source/core/tokenizer.cpp
@@ -384,6 +384,30 @@ bool Tokenizer::advanceToken(const bool crossLine, const bool assertAvail)
                   cont = false;
                }
             }
+            else if (c == '/' && mpBuffer[mCurrPos+1] == '*')
+            {
+               // Block quote...
+               if (currPosition == 0)
+               {
+                  // continue to end of block, then let crossLine determine on the next pass
+                  while (mCurrPos < mBufferSize - 1 && (mpBuffer[mCurrPos] != '*' || mpBuffer[mCurrPos + 1] != '/'))
+                     mCurrPos++;
+
+                  if (mCurrPos < mBufferSize - 1)
+                     mCurrPos += 2;
+               }
+               else
+               {
+                  // This is the end of the token.  Continue to EOL
+                  while (mCurrPos < mBufferSize - 1 && (mpBuffer[mCurrPos] != '*' || mpBuffer[mCurrPos + 1] != '/'))
+                     mCurrPos++;
+
+                  if (mCurrPos < mBufferSize - 1)
+                     mCurrPos += 2;
+
+                  cont = false;
+               }
+            }
             else
             {
                // If this is the first non-token character then store the


### PR DESCRIPTION
Fixed a possible assert on changing material, and we now map the material to the MATMGR by name instead of type.
