### PR TITLE
Fix texture and object console paths

### DIFF
--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -57,16 +57,16 @@ void GFXTextureManager::init()
       "as not allowing down scaling.\n"
       "@ingroup GFX\n" );
 
-   Con::addVariable( "$pref::Video::missingTexturePath", TypeString, &smMissingTexturePath,
+   Con::addVariable( "$pref::Video::missingTexturePath", TypeRealString, &smMissingTexturePath,
       "The file path of the texture to display when the requested texture is missing.\n"
       "@ingroup GFX\n" );
 
-   Con::addVariable( "$pref::Video::unavailableTexturePath", TypeString, &smUnavailableTexturePath,
+   Con::addVariable( "$pref::Video::unavailableTexturePath", TypeRealString, &smUnavailableTexturePath,
       "@brief The file path of the texture to display when the requested texture is unavailable.\n\n"
       "Often this texture is used by GUI controls to indicate that the request image is unavailable.\n"
       "@ingroup GFX\n" );
 
-   Con::addVariable( "$pref::Video::warningTexturePath", TypeString, &smWarningTexturePath,
+   Con::addVariable( "$pref::Video::warningTexturePath", TypeRealString, &smWarningTexturePath,
       "The file path of the texture used to warn the developer.\n"
       "@ingroup GFX\n" );
 }

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -394,7 +394,7 @@ void ProcessedMaterial::_setStageData()
             
             // Load a debug texture to make it clear to the user 
             // that the texture for this stage was missing.
-            mStages[i].setTex( MFT_DiffuseMap, _createTexture( GFXTextureManager::getMissingTexturePath(), &GFXDefaultStaticDiffuseProfile ) );
+            mStages[i].setTex( MFT_DiffuseMap, _createTexture( GFXTextureManager::getMissingTexturePath().c_str(), &GFXDefaultStaticDiffuseProfile ) );
          }
       }
 

--- a/Engine/source/ts/tsShapeConstruct.cpp
+++ b/Engine/source/ts/tsShapeConstruct.cpp
@@ -288,15 +288,15 @@ void TSShapeConstructor::consoleInit()
 {
    Parent::consoleInit();
 
-   Con::addVariable( "$pref::TSShapeConstructor::CapsuleShapePath", TypeString, &TSShapeConstructor::smCapsuleShapePath, 
+   Con::addVariable( "$pref::TSShapeConstructor::CapsuleShapePath", TypeRealString, &TSShapeConstructor::smCapsuleShapePath, 
       "The file path to the capsule shape used by tsMeshFit.\n\n"
 	   "@ingroup MeshFit\n" );
 
-   Con::addVariable( "$pref::TSShapeConstructor::CubeShapePath", TypeString, &TSShapeConstructor::smCubeShapePath, 
+   Con::addVariable( "$pref::TSShapeConstructor::CubeShapePath", TypeRealString, &TSShapeConstructor::smCubeShapePath, 
       "The file path to the cube shape used by tsMeshFit.\n\n"
 	   "@ingroup MeshFit\n" );
 
-   Con::addVariable( "$pref::TSShapeConstructor::SphereShapePath", TypeString, &TSShapeConstructor::smSphereShapePath, 
+   Con::addVariable( "$pref::TSShapeConstructor::SphereShapePath", TypeRealString, &TSShapeConstructor::smSphereShapePath, 
       "The file path to the sphere shape used by tsMeshFit.\n\n"
 	   "@ingroup MeshFit\n" );
 }


### PR DESCRIPTION
- Be sure to delete all prefs.cs files following this change.
- Changes the console types of the missing, unavailable and warning
  texture paths.  The old type was causing string corruption when saving
  preferences.
- Changes the console type of the TSShapeConstructor collision shapes.
  The old type was causing string corruption when saving preferences.
- Changed missing texture reference in ProcessedMaterial from String to
  const char*.
