### PR TITLE
zero() method added to all point classes

### DIFF
--- a/Engine/source/math/mPoint2.h
+++ b/Engine/source/math/mPoint2.h
@@ -48,6 +48,7 @@ class Point2I
    void set(S32 in_x, S32 in_y);            ///< Set (x,y) position
    void setMin(const Point2I&);             ///< Store lesser co-ordinates from parameter in this point.
    void setMax(const Point2I&);             ///< Store greater co-ordinates from parameter in this point.
+   void zero();                             ///< Zero all values
 
    //-------------------------------------- Math mutators
    void neg();                              ///< Invert sign of point's co-ordinates.
@@ -122,6 +123,8 @@ class Point2F
    /// @param   b   Ending point.
    /// @param   c   Interpolation factor (0.0 .. 1.0).
    void interpolate(const Point2F& a, const Point2F& b, const F32 c);
+
+   void zero();                         ///< Zero all values
 
    operator F32*() { return &x; }
    operator const F32*() const { return &x; }
@@ -213,6 +216,8 @@ class Point2D
    /// @param   c   Interpolation factor (0.0 .. 1.0).
    void interpolate(const Point2D &a, const Point2D &b, const F64 c);
 
+   void zero();                         ///< Zero all values
+
    operator F64*() { return &x; }
    operator const F64*() const { return &x; }
 
@@ -298,6 +303,12 @@ inline void Point2I::setMax(const Point2I& _test)
 {
    x = (_test.x > x) ? _test.x : x;
    y = (_test.y > y) ? _test.y : y;
+}
+
+
+inline void Point2I::zero()
+{
+   x = y = 0;
 }
 
 
@@ -480,6 +491,12 @@ inline void Point2F::interpolate(const Point2F& _rFrom, const Point2F& _to, cons
    AssertFatal(_factor >= 0.0f && _factor <= 1.0f, "Out of bound interpolation factor");
    x = (_rFrom.x * (1.0f - _factor)) + (_to.x * _factor);
    y = (_rFrom.y * (1.0f - _factor)) + (_to.y * _factor);
+}
+
+
+inline void Point2F::zero()
+{
+   x = y = 0.0f;
 }
 
 
@@ -717,6 +734,12 @@ inline void Point2D::interpolate(const Point2D& _rFrom, const Point2D& _to, cons
    AssertFatal(_factor >= 0.0f && _factor <= 1.0f, "Out of bound interpolation factor");
    x = (_rFrom.x * (1.0f - _factor)) + (_to.x * _factor);
    y = (_rFrom.y * (1.0f - _factor)) + (_to.y * _factor);
+}
+
+
+inline void Point2D::zero()
+{
+   x = y = 0.0;
 }
 
 

--- a/Engine/source/math/mPoint3.h
+++ b/Engine/source/math/mPoint3.h
@@ -54,6 +54,7 @@ class Point3I
    void set(S32 in_x, S32 in_y, S32 in_z); ///< Set co-ordinates.
    void setMin(const Point3I&); ///< Store lesser co-ordinates in this point.
    void setMax(const Point3I&); ///< Store greater co-ordinates in this point.
+   void zero();                 ///< Zero all values
 
    //-------------------------------------- Math mutators
    void neg();                      ///< Invert co-ordinate's signs.
@@ -222,6 +223,7 @@ class Point3D
    void setMax(const Point3D&);
 
    void interpolate(const Point3D&, const Point3D&, F64);
+   void zero();
 
    operator F64*() { return (&x); }
    operator const F64*() const { return &x; }
@@ -318,6 +320,11 @@ inline void Point3I::setMax(const Point3I& _test)
    x = (_test.x > x) ? _test.x : x;
    y = (_test.y > y) ? _test.y : y;
    z = (_test.z > z) ? _test.z : z;
+}
+
+inline void Point3I::zero()
+{
+   x = y = z = 0;
 }
 
 inline void Point3I::neg()
@@ -808,6 +815,11 @@ inline void Point3D::interpolate(const Point3D& _from, const Point3D& _to, F64 _
 {
    AssertFatal(_factor >= 0.0f && _factor <= 1.0f, "Out of bound interpolation factor");
    m_point3D_interpolate( _from, _to, _factor, *this);
+}
+
+inline void Point3D::zero()
+{
+   x = y = z = 0.0;
 }
 
 inline bool Point3D::isZero() const

--- a/Engine/source/math/mPoint4.h
+++ b/Engine/source/math/mPoint4.h
@@ -42,6 +42,8 @@ class Point4I
    Point4I() {}
    Point4I(S32 _x, S32 _y, S32 _z, S32 _w);
 
+   void zero();   ///< Zero all values
+
    S32 x;                                                   
    S32 y;                                                   
    S32 z;                                                   
@@ -85,6 +87,8 @@ class Point4F
    /// @param   _factor Interpolation factor (0.0 .. 1.0).
    void interpolate(const Point4F& _pt1, const Point4F& _pt2, F32 _factor);
 
+   void zero();
+
    operator F32*() { return (&x); }
    operator const F32*() const { return &x; }
    
@@ -110,6 +114,14 @@ class Point4F
 };
 
 typedef Point4F Vector4F;   ///< Points can be vectors!
+
+//------------------------------------------------------------------------------
+//-------------------------------------- Point4I
+
+inline void Point4I::zero()
+{
+   x = y = z = w = 0;
+}
 
 //------------------------------------------------------------------------------
 //-------------------------------------- Point4F
@@ -147,6 +159,11 @@ inline void Point4F::interpolate(const Point4F& _from, const Point4F& _to, F32 _
    y = (_from.y * (1.0f - _factor)) + (_to.y * _factor);
    z = (_from.z * (1.0f - _factor)) + (_to.z * _factor);
    w = (_from.w * (1.0f - _factor)) + (_to.w * _factor);
+}
+
+inline void Point4F::zero()
+{
+   x = y = z = w = 0.0f;
 }
 
 inline Point4F& Point4F::operator=(const Point3F &_vec)


### PR DESCRIPTION
Only some of the mPointX classes had the zero() method implemented.
This commit adds the method to all point classes.
