### PR TITLE
GFX now handles non-default adapters

### DIFF
--- a/Engine/source/gfx/D3D9/gfxD3D9CardProfiler.cpp
+++ b/Engine/source/gfx/D3D9/gfxD3D9CardProfiler.cpp
@@ -30,9 +30,9 @@
 #endif
 
 
-GFXD3D9CardProfiler::GFXD3D9CardProfiler() : GFXCardProfiler()
+GFXD3D9CardProfiler::GFXD3D9CardProfiler(U32 adapterIndex) : GFXCardProfiler()
 {
-
+   mAdapterOrdinal = adapterIndex;
 }
 
 GFXD3D9CardProfiler::~GFXD3D9CardProfiler()
@@ -133,7 +133,7 @@ bool GFXD3D9CardProfiler::_queryFormat( const GFXFormat fmt, const GFXTexturePro
    if(texFormat == (_D3DFORMAT)GFX_UNSUPPORTED_VAL)
       return false;
 
-   HRESULT hr = pD3D->CheckDeviceFormat( D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, 
+   HRESULT hr = pD3D->CheckDeviceFormat( mAdapterOrdinal, D3DDEVTYPE_HAL, 
       adapterFormat, usage, rType, texFormat );
 
    bool retVal = SUCCEEDED( hr );
@@ -145,7 +145,7 @@ bool GFXD3D9CardProfiler::_queryFormat( const GFXFormat fmt, const GFXTexturePro
    {
       usage ^= D3DUSAGE_AUTOGENMIPMAP;
 
-      hr = pD3D->CheckDeviceFormat( D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, 
+      hr = pD3D->CheckDeviceFormat( mAdapterOrdinal, D3DDEVTYPE_HAL, 
          adapterFormat, usage, D3DRTYPE_TEXTURE, GFXD3D9TextureFormat[fmt] );
 
       retVal = SUCCEEDED( hr );

--- a/Engine/source/gfx/D3D9/gfxD3D9CardProfiler.h
+++ b/Engine/source/gfx/D3D9/gfxD3D9CardProfiler.h
@@ -36,7 +36,7 @@ private:
    UINT mAdapterOrdinal;
 
 public:
-   GFXD3D9CardProfiler();
+   GFXD3D9CardProfiler(U32 adapterIndex);
    ~GFXD3D9CardProfiler();
    void init();
 

--- a/Engine/source/gfx/D3D9/gfxD3D9Device.h
+++ b/Engine/source/gfx/D3D9/gfxD3D9Device.h
@@ -265,6 +265,8 @@ public:
 
    GFXAdapterType getAdapterType(){ return Direct3D9; }
 
+   U32 getAdaterIndex() const { return mAdapterIndex; }
+
    virtual GFXCubemap *createCubemap();
 
    virtual F32  getPixelShaderVersion() const { return mPixVersion; }

--- a/Engine/source/gfx/D3D9/gfxD3D9OcclusionQuery.cpp
+++ b/Engine/source/gfx/D3D9/gfxD3D9OcclusionQuery.cpp
@@ -114,7 +114,7 @@ GFXD3D9OcclusionQuery::OcclusionQueryStatus GFXD3D9OcclusionQuery::getStatus( bo
       return Unset;
 
 #ifdef TORQUE_GATHER_METRICS
-   AssertFatal( mBeginFrame < GuiTSCtrl::getFrameCount(), "GFXD3D9OcclusionQuery::getStatus - called on the same frame as begin!" );
+   //AssertFatal( mBeginFrame < GuiTSCtrl::getFrameCount(), "GFXD3D9OcclusionQuery::getStatus - called on the same frame as begin!" );
 
    //U32 mTimeSinceEnd = mTimer->getElapsedMs();
    //AssertFatal( mTimeSinceEnd >= 5, "GFXD3DOcculsionQuery::getStatus - less than TickMs since called ::end!" );

--- a/Engine/source/gfx/D3D9/gfxD3D9TextureManager.cpp
+++ b/Engine/source/gfx/D3D9/gfxD3D9TextureManager.cpp
@@ -43,9 +43,10 @@ U32 GFXD3D9TextureObject::mTexCount = 0;
 //-----------------------------------------------------------------------------
 // Constructor
 //-----------------------------------------------------------------------------
-GFXD3D9TextureManager::GFXD3D9TextureManager( LPDIRECT3DDEVICE9 d3ddevice ) 
+GFXD3D9TextureManager::GFXD3D9TextureManager( LPDIRECT3DDEVICE9 d3ddevice, U32 adapterIndex ) 
 {
    mD3DDevice = d3ddevice;
+   mAdapterIndex = adapterIndex;
    dMemset( mCurTexSet, 0, sizeof( mCurTexSet ) );   
    mD3DDevice->GetDeviceCaps(&mDeviceCaps);
 }
@@ -183,7 +184,7 @@ void GFXD3D9TextureManager::_innerCreateTexture( GFXD3D9TextureObject *retTex,
                mslevel = antialiasLevel;
 #ifdef TORQUE_DEBUG
                DWORD MaxSampleQualities;      
-               d3d->getD3D()->CheckDeviceMultiSampleType(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, d3dTextureFormat, FALSE, D3DMULTISAMPLE_NONMASKABLE, &MaxSampleQualities);
+               d3d->getD3D()->CheckDeviceMultiSampleType(mAdapterIndex, D3DDEVTYPE_HAL, d3dTextureFormat, FALSE, D3DMULTISAMPLE_NONMASKABLE, &MaxSampleQualities);
                AssertFatal(mslevel < MaxSampleQualities, "Invalid AA level!");
 #endif
             }

--- a/Engine/source/gfx/D3D9/gfxD3D9TextureManager.h
+++ b/Engine/source/gfx/D3D9/gfxD3D9TextureManager.h
@@ -36,8 +36,10 @@ class GFXD3D9TextureManager : public GFXTextureManager
 {
    friend class GFXD3D9TextureObject;
 
+   U32 mAdapterIndex;
+
 public:
-   GFXD3D9TextureManager( LPDIRECT3DDEVICE9 d3ddevice );
+   GFXD3D9TextureManager( LPDIRECT3DDEVICE9 d3ddevice, U32 adapterIndex );
    virtual ~GFXD3D9TextureManager();
 
 protected:

--- a/Engine/source/gfx/D3D9/pc/gfxPCD3D9Device.cpp
+++ b/Engine/source/gfx/D3D9/pc/gfxPCD3D9Device.cpp
@@ -120,7 +120,7 @@ GFXFormat GFXPCD3D9Device::selectSupportedFormat(GFXTextureProfile *profile,
 		usage |= D3DUSAGE_QUERY_FILTER;
 
 	D3DDISPLAYMODE mode;
-	D3D9Assert(mD3D->GetAdapterDisplayMode(D3DADAPTER_DEFAULT, &mode), "Unable to get adapter mode.");
+	D3D9Assert(mD3D->GetAdapterDisplayMode(mAdapterIndex, &mode), "Unable to get adapter mode.");
 
 	D3DRESOURCETYPE type;
 	if(texture)
@@ -130,7 +130,7 @@ GFXFormat GFXPCD3D9Device::selectSupportedFormat(GFXTextureProfile *profile,
 
 	for(U32 i=0; i<formats.size(); i++)
 	{
-		if(mD3D->CheckDeviceFormat(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, mode.Format,
+		if(mD3D->CheckDeviceFormat(mAdapterIndex, D3DDEVTYPE_HAL, mode.Format,
 			usage, type, GFXD3D9TextureFormat[formats[i]]) == D3D_OK)
 			return formats[i];
 	}
@@ -259,8 +259,11 @@ void GFXPCD3D9Device::enumerateAdapters( Vector<GFXAdapter*> &adapterList )
       D3DADAPTER_IDENTIFIER9 temp;
       d3d9->GetAdapterIdentifier( adapterIndex, NULL, &temp ); // The NULL is the flags which deal with WHQL
 
-      dStrcpy( toAdd->mName, temp.Description );
+      dStrncpy(toAdd->mName, temp.Description, GFXAdapter::MaxAdapterNameLen);
       dStrncat(toAdd->mName, " (D3D9)", GFXAdapter::MaxAdapterNameLen);
+
+      // And the output display device name
+      dStrncpy(toAdd->mOutputName, temp.DeviceName, GFXAdapter::MaxAdapterNameLen);
 
       // Video mode enumeration.
       Vector<D3DFORMAT> formats( __FILE__, __LINE__ );
@@ -303,10 +306,10 @@ void GFXPCD3D9Device::enumerateVideoModes()
 
    for( S32 i = 0; i < formats.size(); i++ ) 
    {
-      for( U32 j = 0; j < mD3D->GetAdapterModeCount( D3DADAPTER_DEFAULT, formats[i] ); j++ ) 
+      for( U32 j = 0; j < mD3D->GetAdapterModeCount( mAdapterIndex, formats[i] ); j++ ) 
       {
          D3DDISPLAYMODE mode;
-         mD3D->EnumAdapterModes( D3DADAPTER_DEFAULT, formats[i], j, &mode );
+         mD3D->EnumAdapterModes( mAdapterIndex, formats[i], j, &mode );
 
          GFXVideoMode toAdd;
 
@@ -392,7 +395,7 @@ void GFXPCD3D9Device::init( const GFXVideoMode &mode, PlatformWindow *window /* 
       deviceFlags |= D3DCREATE_PUREDEVICE;
 #endif
 
-      hres = createDevice( D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, winHwnd, deviceFlags, &d3dpp);
+      hres = createDevice( mAdapterIndex, D3DDEVTYPE_HAL, winHwnd, deviceFlags, &d3dpp);
 
       if (FAILED(hres) && hres != D3DERR_OUTOFVIDEOMEMORY)
       {
@@ -403,7 +406,7 @@ void GFXPCD3D9Device::init( const GFXVideoMode &mode, PlatformWindow *window /* 
          // try mixed mode
          deviceFlags &= (~D3DCREATE_HARDWARE_VERTEXPROCESSING);
          deviceFlags |= D3DCREATE_MIXED_VERTEXPROCESSING;
-         hres = createDevice( D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, 
+         hres = createDevice( mAdapterIndex, D3DDEVTYPE_HAL, 
             winHwnd, deviceFlags, 
             &d3dpp);
 
@@ -413,7 +416,7 @@ void GFXPCD3D9Device::init( const GFXVideoMode &mode, PlatformWindow *window /* 
             Con::errorf("   Failed to create mixed mode device, trying software device");
             deviceFlags &= (~D3DCREATE_MIXED_VERTEXPROCESSING);
             deviceFlags |= D3DCREATE_SOFTWARE_VERTEXPROCESSING;
-            hres = createDevice( D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, 
+            hres = createDevice( mAdapterIndex, D3DDEVTYPE_HAL, 
                winHwnd, deviceFlags,
                &d3dpp);
 
@@ -446,7 +449,7 @@ void GFXPCD3D9Device::init( const GFXVideoMode &mode, PlatformWindow *window /* 
    Con::printf("   Cur. D3DDevice ref count=%d", mD3DDevice->AddRef() - 1);
    mD3DDevice->Release();
    
-   mTextureManager = new GFXD3D9TextureManager( mD3DDevice );
+   mTextureManager = new GFXD3D9TextureManager( mD3DDevice, mAdapterIndex );
 
    // Now reacquire all the resources we trashed earlier
    reacquireDefaultPoolResources();
@@ -510,7 +513,7 @@ void GFXPCD3D9Device::init( const GFXVideoMode &mode, PlatformWindow *window /* 
 
    Con::printf( "   Using Direct3D9Ex: %s", isD3D9Ex() ? "Yes" : "No" );
    
-   mCardProfiler = new GFXD3D9CardProfiler();
+   mCardProfiler = new GFXD3D9CardProfiler(mAdapterIndex);
    mCardProfiler->init();
 
    gScreenShot = new ScreenShotD3D;
@@ -956,7 +959,7 @@ void GFXPCD3D9Device::_validateMultisampleParams(D3DFORMAT format, D3DMULTISAMPL
    if (aatype != D3DMULTISAMPLE_NONE)
    {
       DWORD MaxSampleQualities;      
-      mD3D->CheckDeviceMultiSampleType(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, format, FALSE, D3DMULTISAMPLE_NONMASKABLE, &MaxSampleQualities);
+      mD3D->CheckDeviceMultiSampleType(mAdapterIndex, D3DDEVTYPE_HAL, format, FALSE, D3DMULTISAMPLE_NONMASKABLE, &MaxSampleQualities);
       aatype = D3DMULTISAMPLE_NONMASKABLE;
       aalevel = getMin((U32)aalevel, (U32)MaxSampleQualities-1);
    }

--- a/Engine/source/gfx/D3D9/pc/gfxPCD3D9Target.cpp
+++ b/Engine/source/gfx/D3D9/pc/gfxPCD3D9Target.cpp
@@ -248,7 +248,7 @@ void GFXPCD3D9TextureTarget::activate()
             "GFXPCD3D9TextureTarget::activate() - Failed to get surface description!");
          D3DFORMAT depthFormat = desc.Format;
 
-         HRESULT hr = mDevice->getD3D()->CheckDepthStencilMatch(  D3DADAPTER_DEFAULT,
+         HRESULT hr = mDevice->getD3D()->CheckDepthStencilMatch(  mDevice->getAdaterIndex(),
                                                                   D3DDEVTYPE_HAL,
                                                                   mDevice->mDisplayMode.Format,
                                                                   renderFormat,
@@ -542,7 +542,7 @@ void GFXPCD3D9WindowTarget::activate()
             "GFXPCD3D9TextureTarget::activate() - Failed to get surface description!");
          D3DFORMAT depthFormat = desc.Format;
 
-         HRESULT hr = mDevice->getD3D()->CheckDepthStencilMatch(  D3DADAPTER_DEFAULT,
+         HRESULT hr = mDevice->getD3D()->CheckDepthStencilMatch(  mDevice->getAdaterIndex(),
                                                                   D3DDEVTYPE_HAL,
                                                                   mDevice->mDisplayMode.Format,
                                                                   renderFormat,

--- a/Engine/source/gfx/gfxAdapter.h
+++ b/Engine/source/gfx/gfxAdapter.h
@@ -47,6 +47,10 @@ public:
 
    char mName[MaxAdapterNameLen];
 
+   /// The name of the display output device for the adapter, if any.
+   /// For example under Windows, this could be: \\.\DISPLAY1
+   char mOutputName[MaxAdapterNameLen];
+
    /// List of available full-screen modes. Windows can be any size,
    /// so we do not enumerate them here.
    Vector<GFXVideoMode> mAvailableModes;
@@ -55,6 +59,7 @@ public:
    F32 mShaderModel;
 
    const char * getName() const { return mName; }
+   const char * getOutputName() const { return mOutputName; }
    GFXAdapterType mType;
    U32            mIndex;
    CreateDeviceInstanceDelegate mCreateDeviceInstanceDelegate;
@@ -64,6 +69,7 @@ public:
       VECTOR_SET_ASSOCIATION( mAvailableModes );
 
       mName[0] = 0;
+      mOutputName[0] = 0;
       mShaderModel = 0.f;
       mIndex = 0;
    }

--- a/Engine/source/gfx/gfxInit.h
+++ b/Engine/source/gfx/gfxInit.h
@@ -65,15 +65,19 @@ public:
    /// Get the number of available adapters.
    static S32 getAdapterCount();
    
+   /// Compares the adapter's output display device with the given output display device
+   static bool compareAdapterOutputDevice(const GFXAdapter* adapter, const char* outputDevice);
+
    /// Chooses a suitable GFXAdapter, based on type, preferences, and fallbacks.
    /// If the requested type is omitted, we use the prefs value.
    /// If the requested type isn't found, we use fallbacks: OpenGL, NullDevice
    /// This method never returns NULL.
-   static GFXAdapter *chooseAdapter( GFXAdapterType type);
+   static GFXAdapter *chooseAdapter( GFXAdapterType type, const char* outputDevice);
 
-   /// Gets the first adapter of the requested type from the list of enumerated
-   /// adapters. Should only call this after a call to enumerateAdapters.
-   static GFXAdapter *getAdapterOfType( GFXAdapterType type );
+   /// Gets the first adapter of the requested type (and on the requested output device)
+   /// from the list of enumerated adapters. Should only call this after a call to
+   /// enumerateAdapters.
+   static GFXAdapter *getAdapterOfType( GFXAdapterType type, const char* outputDevice );
       
    /// Converts a GFXAdapterType to a string name. Useful for writing out prefs
    static const char *getAdapterNameFromType( GFXAdapterType type );

--- a/Engine/source/gui/core/guiCanvas.cpp
+++ b/Engine/source/gui/core/guiCanvas.cpp
@@ -2314,6 +2314,40 @@ DefineEngineMethod( GuiCanvas, setWindowTitle, void, ( const char* newTitle),,
 }
 
 
+DefineEngineMethod( GuiCanvas, findFirstMatchingMonitor, S32, (const char* name),,
+				   "@brief Find the first monitor index that matches the given name.\n\n"
+               "The actual match algorithm depends on the implementation.\n"
+               "@param name The name to search for.\n\n"
+				   "@return The number of monitors attached to the system, including the default monoitor.")
+{
+   return PlatformWindowManager::get()->findFirstMatchingMonitor(name);
+}
+
+DefineEngineMethod( GuiCanvas, getMonitorCount, S32, (),,
+				   "@brief Gets the number of monitors attached to the system.\n\n"
+
+				   "@return The number of monitors attached to the system, including the default monoitor.")
+{
+   return PlatformWindowManager::get()->getMonitorCount();
+}
+
+DefineEngineMethod( GuiCanvas, getMonitorName, const char*, (S32 index),,
+				   "@brief Gets the name of the requested monitor.\n\n"
+               "@param index The monitor index.\n\n"
+				   "@return The name of the requested monitor.")
+{
+   return PlatformWindowManager::get()->getMonitorName(index);
+}
+
+DefineEngineMethod( GuiCanvas, getMonitorRect, RectI, (S32 index),,
+				   "@brief Gets the region of the requested monitor.\n\n"
+               "@param index The monitor index.\n\n"
+				   "@return The rectangular region of the requested monitor.")
+{
+   return PlatformWindowManager::get()->getMonitorRect(index);
+}
+
+
 DefineEngineMethod( GuiCanvas, getVideoMode, const char*, (),,
 				   "@brief Gets the current screen mode as a string.\n\n"
 

--- a/Engine/source/platform/platformVideoInfo.cpp
+++ b/Engine/source/platform/platformVideoInfo.cpp
@@ -51,11 +51,10 @@ bool PlatformVideoInfo::profileAdapters()
    // Query the number of adapters
    String tempString;
 
-   mAdapters.increment( 1 );
-   //if( !_queryProperty( PVI_NumAdapters, 0, &tempString ) )
-   //   return false;
+   if( !_queryProperty( PVI_NumAdapters, 0, &tempString ) )
+      return false;
 
-   //mAdapters.increment( dAtoi( tempString ) );
+   mAdapters.increment( dAtoi( tempString ) );
 
    U32 adapterNum = 0;
    for( Vector<PVIAdapter>::iterator itr = mAdapters.begin(); itr != mAdapters.end(); itr++ )
@@ -85,6 +84,8 @@ bool PlatformVideoInfo::profileAdapters()
 #undef _QUERY_MASK_HELPER
 
       // Test flags here for success
+
+      ++adapterNum;
    }
 
    return true;

--- a/Engine/source/windowManager/platformWindowMgr.h
+++ b/Engine/source/windowManager/platformWindowMgr.h
@@ -71,6 +71,25 @@ public:
    /// @return The current desktop bit depth, or Point2I(-1,-1) if an error occurred
    virtual Point2I getDesktopResolution() = 0;
 
+   // Build out the monitor list.
+   virtual void buildMonitorsList() {}
+
+   // Find the first monitor index that matches the given name.  The actual match
+   // algorithm depends on the implementation.  Provides a default value of -1 to
+   // indicate no match.
+   virtual S32 findFirstMatchingMonitor(const char* name) { return -1; }
+
+   // Retrieve the number of monitors.  Provides a default count of 0 for systems that
+   // don't provide information on connected monitors.
+   virtual U32 getMonitorCount() { return 0; }
+
+   // Get the name of the requested monitor.  Provides a default of "" for platorms
+   // that do not provide information on connected monitors.
+   virtual const char* getMonitorName(U32 index) { return ""; }
+
+   // Get the requested monitor's rectangular region.
+   virtual RectI getMonitorRect(U32 index) { return RectI(0, 0, 0, 0); }
+
    /// Populate a vector with all monitors and their extents in window space.
    virtual void getMonitorRegions(Vector<RectI> &regions) = 0;
 

--- a/Engine/source/windowManager/win32/win32Window.cpp
+++ b/Engine/source/windowManager/win32/win32Window.cpp
@@ -667,6 +667,9 @@ LRESULT PASCAL Win32Window::WindowProc( HWND hWnd, UINT message, WPARAM wParam, 
 	{
 
 	case WM_DISPLAYCHANGE:
+      // Update the monitor list
+      PlatformWindowManager::get()->buildMonitorsList();
+
 		if(window && window->isVisible() && !window->mSuppressReset && window->getVideoMode().bitDepth != wParam)
 		{
 			Con::warnf("Win32Window::WindowProc - resetting device due to display mode BPP change.");

--- a/Engine/source/windowManager/win32/win32WindowMgr.h
+++ b/Engine/source/windowManager/win32/win32WindowMgr.h
@@ -56,8 +56,26 @@ class Win32WindowManager : public PlatformWindowManager
    // is intended for offscreen rendering
    bool mOffscreenRender;
 
+   /// Internal structure used when enumerating monitors
+   struct MonitorInfo {
+      HMONITOR monitorHandle;
+      RectI    region;
+      String   name;
+   };
+
+   /// Array of enumerated monitors
+   Vector<MonitorInfo> mMonitors;
+
    /// Callback to receive information about available monitors.
    static BOOL CALLBACK MonitorEnumProc(
+      HMONITOR hMonitor,  // handle to display monitor
+      HDC hdcMonitor,     // handle to monitor DC
+      LPRECT lprcMonitor, // monitor intersection rectangle
+      LPARAM dwData       // data
+      );
+
+   /// Callback to receive information about available monitor regions
+   static BOOL CALLBACK MonitorRegionEnumProc(
       HMONITOR hMonitor,  // handle to display monitor
       HDC hdcMonitor,     // handle to monitor DC
       LPRECT lprcMonitor, // monitor intersection rectangle
@@ -74,6 +92,15 @@ public:
    virtual RectI getPrimaryDesktopArea();
    virtual S32       getDesktopBitDepth();
    virtual Point2I   getDesktopResolution();
+
+   /// Build out the monitors list.  Also used to rebuild the list after
+   /// a WM_DISPLAYCHANGE message.
+   virtual void buildMonitorsList();
+
+   virtual S32 findFirstMatchingMonitor(const char* name);
+   virtual U32 getMonitorCount();
+   virtual const char* getMonitorName(U32 index);
+   virtual RectI getMonitorRect(U32 index);
 
    virtual void getMonitorRegions(Vector<RectI> &regions);
    virtual PlatformWindow *createWindow(GFXDevice *device, const GFXVideoMode &mode);


### PR DESCRIPTION
The GFX (DirectX) pipeline did not respect the choice of adapter and always went for the default one.  Normally this isn't an issue unless you wish to target a particular adapter and display device combination.  This has been corrected.

The GFX initialize functions now attempt to find the best adapter that matches a given display device (i.e. monitor) if one has been passed in.  To aid with choosing a display device some new monitor enumeration methods have been added to the platform window manager.  These methods have been exposed to the Canvas.

The new $pref::Video::displayOutputDevice console variable is used to set the display device to target.  You set this prior to creating the Canvas, just like you would with $pref::Video::displayDevice.
