### PR TITLE
Game cam and eye banking, control schemes

### DIFF
--- a/Engine/source/T3D/camera.cpp
+++ b/Engine/source/T3D/camera.cpp
@@ -35,6 +35,12 @@
 #include "math/mathUtils.h"
 #include "math/mTransform.h"
 
+#ifdef TORQUE_EXTENDED_MOVE
+   #include "T3D/gameBase/extended/extendedMove.h"
+#endif
+
+S32 Camera::smExtendedMovePosRotIndex = 0;  // The ExtendedMove position/rotation index used for camera movements
+
 #define MaxPitch 1.5706f
 #define CameraRadius 0.05f;
 
@@ -254,6 +260,7 @@ Camera::Camera()
 {
    mNetFlags.clear(Ghostable);
    mTypeMask |= CameraObjectType;
+   mDataBlock = 0;
    mDelta.pos = Point3F(0.0f, 0.0f, 100.0f);
    mDelta.rot = Point3F(0.0f, 0.0f, 0.0f);
    mDelta.posVec = mDelta.rotVec = VectorF(0.0f, 0.0f, 0.0f);
@@ -269,6 +276,9 @@ Camera::Camera()
    mPosition.set(0.0f, 0.0f, 0.0f);
    mObservingClientObject = false;
    mMode = FlyMode;
+
+   mLastAbsoluteYaw = 0.0f;
+   mLastAbsolutePitch = 0.0f;
 
    // For NewtonFlyMode
    mNewtonRotation = false;
@@ -301,7 +311,7 @@ Camera::~Camera()
 
 bool Camera::onAdd()
 {
-   if(!Parent::onAdd())
+   if(!Parent::onAdd() || !mDataBlock)
       return false;
 
    mObjBox.maxExtents = mObjScale;
@@ -310,6 +320,31 @@ bool Camera::onAdd()
    resetWorldBox();
 
    addToScene();
+
+   scriptOnAdd();
+
+   return true;
+}
+
+//----------------------------------------------------------------------------
+
+void Camera::onRemove()
+{
+   scriptOnRemove();
+   removeFromScene();
+   Parent::onRemove();
+}
+
+//----------------------------------------------------------------------------
+
+bool Camera::onNewDataBlock( GameBaseData *dptr, bool reload )
+{
+   mDataBlock = dynamic_cast<CameraData*>(dptr);
+   if ( !mDataBlock || !Parent::onNewDataBlock( dptr, reload ) )
+      return false;
+
+   scriptOnNewDataBlock();
+
    return true;
 }
 
@@ -325,14 +360,6 @@ void Camera::onEditorEnable()
 void Camera::onEditorDisable()
 {
    mNetFlags.clear(Ghostable);
-}
-
-//----------------------------------------------------------------------------
-
-void Camera::onRemove()
-{
-   removeFromScene();
-   Parent::onRemove();
 }
 
 //----------------------------------------------------------------------------
@@ -460,79 +487,154 @@ void Camera::processTick(const Move* move)
 
       VectorF rotVec(0, 0, 0);
 
-      // process input/determine rotation vector
-      if(virtualMode != StationaryMode &&
-         virtualMode != TrackObjectMode &&
-         (!mLocked || virtualMode != OrbitObjectMode && virtualMode != OrbitPointMode))
+      bool doStandardMove = true;
+
+#ifdef TORQUE_EXTENDED_MOVE
+      GameConnection* con = getControllingClient();
+
+      // Work with an absolute rotation from the ExtendedMove class?
+      if(con && con->getControlSchemeAbsoluteRotation())
       {
-         if(!strafeMode)
+         doStandardMove = false;
+         const ExtendedMove* emove = dynamic_cast<const ExtendedMove*>(move);
+         U32 emoveIndex = smExtendedMovePosRotIndex;
+         if(emoveIndex >= ExtendedMove::MaxPositionsRotations)
+            emoveIndex = 0;
+
+         if(emove->EulerBasedRotation[emoveIndex])
          {
-            rotVec.x = move->pitch;
-            rotVec.z = move->yaw;
+            if(virtualMode != StationaryMode &&
+               virtualMode != TrackObjectMode &&
+               (!mLocked || virtualMode != OrbitObjectMode && virtualMode != OrbitPointMode))
+            {
+               // Pitch
+               mRot.x += (emove->rotX[emoveIndex] - mLastAbsolutePitch);
+
+               // Do we also include the relative pitch value?
+               if(con->getControlSchemeAddPitchToAbsRot() && !strafeMode)
+               {
+                  F32 x = move->pitch;
+                  if (x > M_PI_F)
+                     x -= M_2PI_F;
+
+                  mRot.x += x;
+               }
+
+               // Constrain the range of mRot.x
+               while (mRot.x < -M_PI_F) 
+                  mRot.x += M_2PI_F;
+               while (mRot.x > M_PI_F) 
+                  mRot.x -= M_2PI_F;
+
+               // Yaw
+               mRot.z += (emove->rotZ[emoveIndex] - mLastAbsoluteYaw);
+
+               // Do we also include the relative yaw value?
+               if(con->getControlSchemeAddYawToAbsRot() && !strafeMode)
+               {
+                  F32 z = move->yaw;
+                  if (z > M_PI_F)
+                     z -= M_2PI_F;
+
+                  mRot.z += z;
+               }
+
+               // Constrain the range of mRot.z
+               while (mRot.z < -M_PI_F) 
+                  mRot.z += M_2PI_F;
+               while (mRot.z > M_PI_F) 
+                  mRot.z -= M_2PI_F;
+
+               mLastAbsoluteYaw = emove->rotZ[emoveIndex];
+               mLastAbsolutePitch = emove->rotX[emoveIndex];
+
+               // Bank
+               mRot.y = emove->rotY[emoveIndex];
+
+               // Constrain the range of mRot.y
+               while (mRot.y > M_PI_F) 
+                  mRot.y -= M_2PI_F;
+            }
          }
       }
-      else if(virtualMode == TrackObjectMode && bool(mOrbitObject))
+#endif
+
+      if(doStandardMove)
       {
-         // orient the camera to face the object
-         Point3F objPos;
-         // If this is a shapebase, use its render eye transform
-         // to avoid jittering.
-         ShapeBase *shape = dynamic_cast<ShapeBase*>((GameBase*)mOrbitObject);
-         if( shape != NULL )
+         // process input/determine rotation vector
+         if(virtualMode != StationaryMode &&
+            virtualMode != TrackObjectMode &&
+            (!mLocked || virtualMode != OrbitObjectMode && virtualMode != OrbitPointMode))
          {
-            MatrixF ret;
-            shape->getRenderEyeTransform( &ret );
-            objPos = ret.getPosition();
+            if(!strafeMode)
+            {
+               rotVec.x = move->pitch;
+               rotVec.z = move->yaw;
+            }
+         }
+         else if(virtualMode == TrackObjectMode && bool(mOrbitObject))
+         {
+            // orient the camera to face the object
+            Point3F objPos;
+            // If this is a shapebase, use its render eye transform
+            // to avoid jittering.
+            ShapeBase *shape = dynamic_cast<ShapeBase*>((GameBase*)mOrbitObject);
+            if( shape != NULL )
+            {
+               MatrixF ret;
+               shape->getRenderEyeTransform( &ret );
+               objPos = ret.getPosition();
+            }
+            else
+            {
+               mOrbitObject->getWorldBox().getCenter(&objPos);
+            }
+            mObjToWorld.getColumn(3,&pos);
+            vec = objPos - pos;
+            vec.normalizeSafe();
+            F32 pitch, yaw;
+            MathUtils::getAnglesFromVector(vec, yaw, pitch);
+            rotVec.x = -pitch - mRot.x;
+            rotVec.z = yaw - mRot.z;
+            if(rotVec.z > M_PI_F)
+               rotVec.z -= M_2PI_F;
+            else if(rotVec.z < -M_PI_F)
+               rotVec.z += M_2PI_F;
+         }
+
+         // apply rotation vector according to physics rules
+         if(mNewtonRotation)
+         {
+            const F32 force = mAngularForce;
+            const F32 drag = mAngularDrag;
+
+            VectorF acc(0.0f, 0.0f, 0.0f);
+
+            rotVec.x *= 2.0f;   // Assume that our -2PI to 2PI range was clamped to -PI to PI in script
+            rotVec.z *= 2.0f;   // Assume that our -2PI to 2PI range was clamped to -PI to PI in script
+
+            F32 rotVecL = rotVec.len();
+            if(rotVecL > 0)
+            {
+               acc = (rotVec * force / mMass) * TickSec;
+            }
+
+            // Accelerate
+            mAngularVelocity += acc;
+
+            // Drag
+            mAngularVelocity -= mAngularVelocity * drag * TickSec;
+
+            // Rotate
+            mRot += mAngularVelocity * TickSec;
+            clampPitchAngle(mRot.x);
          }
          else
          {
-            mOrbitObject->getWorldBox().getCenter(&objPos);
+            mRot.x += rotVec.x;
+            mRot.z += rotVec.z;
+            clampPitchAngle(mRot.x);
          }
-         mObjToWorld.getColumn(3,&pos);
-         vec = objPos - pos;
-         vec.normalizeSafe();
-         F32 pitch, yaw;
-         MathUtils::getAnglesFromVector(vec, yaw, pitch);
-         rotVec.x = -pitch - mRot.x;
-         rotVec.z = yaw - mRot.z;
-         if(rotVec.z > M_PI_F)
-            rotVec.z -= M_2PI_F;
-         else if(rotVec.z < -M_PI_F)
-            rotVec.z += M_2PI_F;
-      }
-
-      // apply rotation vector according to physics rules
-      if(mNewtonRotation)
-      {
-         const F32 force = mAngularForce;
-         const F32 drag = mAngularDrag;
-
-         VectorF acc(0.0f, 0.0f, 0.0f);
-
-         rotVec.x *= 2.0f;   // Assume that our -2PI to 2PI range was clamped to -PI to PI in script
-         rotVec.z *= 2.0f;   // Assume that our -2PI to 2PI range was clamped to -PI to PI in script
-
-         F32 rotVecL = rotVec.len();
-         if(rotVecL > 0)
-         {
-            acc = (rotVec * force / mMass) * TickSec;
-         }
-
-         // Accelerate
-         mAngularVelocity += acc;
-
-         // Drag
-         mAngularVelocity -= mAngularVelocity * drag * TickSec;
-
-         // Rotate
-         mRot += mAngularVelocity * TickSec;
-         clampPitchAngle(mRot.x);
-      }
-      else
-      {
-         mRot.x += rotVec.x;
-         mRot.z += rotVec.z;
-         clampPitchAngle(mRot.x);
       }
 
       // Update position
@@ -667,6 +769,13 @@ void Camera::processTick(const Move* move)
          mDelta.rot = mRot;
          mDelta.posVec = mDelta.posVec - mDelta.pos;
          mDelta.rotVec = mDelta.rotVec - mDelta.rot;
+         for(U32 i=0; i<3; ++i)
+         {
+            if (mDelta.rotVec[i] > M_PI_F)
+               mDelta.rotVec[i] -= M_2PI_F;
+            else if (mDelta.rotVec[i] < -M_PI_F)
+               mDelta.rotVec[i] += M_2PI_F;
+         }
       }
 
       if(mustValidateEyePoint)
@@ -793,7 +902,21 @@ void Camera::_setPosition(const Point3F& pos, const Point3F& rot)
    zRot.set(EulerF(0.0f, 0.0f, rot.z));
    
    MatrixF temp;
-   temp.mul(zRot, xRot);
+
+   if(mDataBlock->cameraCanBank)
+   {
+      // Take rot.y into account to bank the camera
+      MatrixF imat;
+      imat.mul(zRot, xRot);
+      MatrixF ymat;
+      ymat.set(EulerF(0.0f, rot.y, 0.0f));
+      temp.mul(imat, ymat);
+   }
+   else
+   {
+      temp.mul(zRot, xRot);
+   }
+
    temp.setColumn(3, pos);
    Parent::setTransform(temp);
    mRot = rot;
@@ -808,7 +931,21 @@ void Camera::setRotation(const Point3F& rot)
    zRot.set(EulerF(0.0f, 0.0f, rot.z));
 
    MatrixF temp;
-   temp.mul(zRot, xRot);
+
+   if(mDataBlock->cameraCanBank)
+   {
+      // Take rot.y into account to bank the camera
+      MatrixF imat;
+      imat.mul(zRot, xRot);
+      MatrixF ymat;
+      ymat.set(EulerF(0.0f, rot.y, 0.0f));
+      temp.mul(imat, ymat);
+   }
+   else
+   {
+      temp.mul(zRot, xRot);
+   }
+
    temp.setColumn(3, getPosition());
    Parent::setTransform(temp);
    mRot = rot;
@@ -821,8 +958,25 @@ void Camera::_setRenderPosition(const Point3F& pos,const Point3F& rot)
    MatrixF xRot, zRot;
    xRot.set(EulerF(rot.x, 0, 0));
    zRot.set(EulerF(0, 0, rot.z));
+
    MatrixF temp;
-   temp.mul(zRot, xRot);
+
+   // mDataBlock may not be defined yet as this method is called during
+   // SceneObject::onAdd().
+   if(mDataBlock && mDataBlock->cameraCanBank)
+   {
+      // Take rot.y into account to bank the camera
+      MatrixF imat;
+      imat.mul(zRot, xRot);
+      MatrixF ymat;
+      ymat.set(EulerF(0.0f, rot.y, 0.0f));
+      temp.mul(imat, ymat);
+   }
+   else
+   {
+      temp.mul(zRot, xRot);
+   }
+
    temp.setColumn(3, pos);
    Parent::setRenderTransform(temp);
 }
@@ -839,6 +993,11 @@ void Camera::writePacketData(GameConnection *connection, BitStream *bstream)
    bstream->setCompressionPoint(pos);
    mathWrite(*bstream, pos);
    bstream->write(mRot.x);
+   if(bstream->writeFlag(mDataBlock->cameraCanBank))
+   {
+      // Include mRot.y to allow for camera banking
+      bstream->write(mRot.y);
+   }
    bstream->write(mRot.z);
 
    U32 writeMode = mMode;
@@ -912,6 +1071,11 @@ void Camera::readPacketData(GameConnection *connection, BitStream *bstream)
    mathRead(*bstream, &pos);
    bstream->setCompressionPoint(pos);
    bstream->read(&rot.x);
+   if(bstream->readFlag())
+   {
+      // Include rot.y to allow for camera banking
+      bstream->read(&rot.y);
+   }
    bstream->read(&rot.z);
 
    GameBase* obj = 0;
@@ -1184,6 +1348,11 @@ void Camera::consoleInit()
       "- Fly Mode\n"
       "- Overhead Mode\n"
       "@ingroup BaseCamera\n");
+
+   // ExtendedMove support
+   Con::addVariable("$camera::extendedMovePosRotIndex", TypeS32, &smExtendedMovePosRotIndex, 
+      "@brief The ExtendedMove position/rotation index used for camera movements.\n\n"
+	   "@ingroup BaseCamera\n");
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/T3D/camera.h
+++ b/Engine/source/T3D/camera.h
@@ -73,6 +73,9 @@ class Camera: public ShapeBase
          CameraLastMode  = EditOrbitMode
       };
 
+      /// The ExtendedMove position/rotation index used for camera movements
+      static S32 smExtendedMovePosRotIndex;
+
    protected:
 
       enum MaskBits
@@ -92,6 +95,8 @@ class Camera: public ShapeBase
          VectorF rotVec;
       };
 
+      CameraData* mDataBlock;
+
       Point3F mRot;
       StateDelta mDelta;
 
@@ -105,6 +110,9 @@ class Camera: public ShapeBase
       F32 mCurOrbitDist;
       Point3F mPosition;
       bool mObservingClientObject;
+
+      F32 mLastAbsoluteYaw;            ///< Stores that last absolute yaw value as passed in by ExtendedMove
+      F32 mLastAbsolutePitch;          ///< Stores that last absolute pitch value as passed in by ExtendedMove
 
       /// @name NewtonFlyMode
       /// @{
@@ -223,6 +231,7 @@ class Camera: public ShapeBase
 
       virtual bool onAdd();
       virtual void onRemove();
+      virtual bool onNewDataBlock( GameBaseData *dptr, bool reload );
       virtual void processTick( const Move* move );
       virtual void interpolateTick( F32 delta);
       virtual void getCameraTransform( F32* pos,MatrixF* mat );

--- a/Engine/source/T3D/gameBase/gameConnection.h
+++ b/Engine/source/T3D/gameBase/gameConnection.h
@@ -91,6 +91,14 @@ private:
    IDisplayDevice* mDisplayDevice;  ///< Optional client display device that imposes rendering properties.
    /// @}
 
+   /// @name Client side control scheme that may be referenced by control objects
+   /// @{
+   bool  mUpdateControlScheme;   ///< Set to notify client or server of control scheme change
+   bool  mAbsoluteRotation;      ///< Use absolute rotation values from client, likely through ExtendedMove
+   bool  mAddYawToAbsRot;        ///< Add relative yaw control to the absolute rotation calculation.  Only useful with mAbsoluteRotation.
+   bool  mAddPitchToAbsRot;      ///< Add relative pitch control to the absolute rotation calculation.  Only useful with mAbsoluteRotation.
+   /// @}
+
 public:
 
    /// @name Protocol Versions
@@ -270,6 +278,12 @@ public:
    const IDisplayDevice* getDisplayDevice() const { return mDisplayDevice; }
    void setDisplayDevice(IDisplayDevice* display) { mDisplayDevice = display; }
    void clearDisplayDevice() { mDisplayDevice = NULL; }
+
+   void setControlSchemeParameters(bool absoluteRotation, bool addYawToAbsRot, bool addPitchToAbsRot);
+   bool getControlSchemeAbsoluteRotation() {return mAbsoluteRotation;}
+   bool getControlSchemeAddYawToAbsRot() {return mAddYawToAbsRot;}
+   bool getControlSchemeAddPitchToAbsRot() {return mAddPitchToAbsRot;}
+
    /// @}
 
    void detectLag();

--- a/Engine/source/T3D/player.h
+++ b/Engine/source/T3D/player.h
@@ -385,6 +385,9 @@ public:
       NumPoseBits = 3
    };
 
+   /// The ExtendedMove position/rotation index used for head movements
+   static S32 smExtendedMoveHeadPosRotIndex;
+
 protected:
 
    /// Bit masks for different types of events
@@ -443,6 +446,9 @@ protected:
    S32 mImpactSound;
 
    bool mUseHeadZCalc;              ///< Including mHead.z in transform calculations
+
+   F32 mLastAbsoluteYaw;            ///< Stores that last absolute yaw value as passed in by ExtendedMove
+   F32 mLastAbsolutePitch;          ///< Stores that last absolute pitch value as passed in by ExtendedMove
 
    S32 mMountPending;               ///< mMountPending suppresses tickDelay countdown so players will sit until
                                     ///< their mount, or another animation, comes through (or 13 seconds elapses).
@@ -687,9 +693,9 @@ public:
 
    void setTransform(const MatrixF &mat);
    void getEyeTransform(MatrixF* mat);
-   void getEyeBaseTransform(MatrixF* mat);
+   void getEyeBaseTransform(MatrixF* mat, bool includeBank);
    void getRenderEyeTransform(MatrixF* mat);
-   void getRenderEyeBaseTransform(MatrixF* mat);
+   void getRenderEyeBaseTransform(MatrixF* mat, bool includeBank);
    void getCameraParameters(F32 *min, F32 *max, Point3F *offset, MatrixF *rot);
    void getMuzzleTransform(U32 imageSlot,MatrixF* mat);
    void getRenderMuzzleTransform(U32 imageSlot,MatrixF* mat);   

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -171,6 +171,8 @@ ShapeBaseData::ShapeBaseData()
    cameraDefaultFov( 75.0f ),
    cameraMinFov( 5.0f ),
    cameraMaxFov( 120.f ),
+   cameraCanBank( false ),
+   mountedImagesBank( false ),
    isInvincible( false ),
    renderWhenDestroyed( true ),
    debris( NULL ),
@@ -544,6 +546,10 @@ void ShapeBaseData::initPersistFields()
          "The minimum camera vertical FOV allowed in degrees." );
       addField( "cameraMaxFov", TypeF32, Offset(cameraMaxFov, ShapeBaseData),
          "The maximum camera vertical FOV allowed in degrees." );
+      addField( "cameraCanBank", TypeBool, Offset(cameraCanBank, ShapeBaseData),
+         "If the derrived class supports it, allow the camera to bank." );
+      addField( "mountedImagesBank", TypeBool, Offset(mountedImagesBank, ShapeBaseData),
+         "Do mounted images bank along with the camera?" );
       addField( "firstPersonOnly", TypeBool, Offset(firstPersonOnly, ShapeBaseData),
          "Flag controlling whether the view from this object is first person "
          "only." );
@@ -689,6 +695,8 @@ void ShapeBaseData::packData(BitStream* stream)
       stream->write(cameraMinFov);
    if(stream->writeFlag(cameraMaxFov != gShapeBaseDataProto.cameraMaxFov))
       stream->write(cameraMaxFov);
+   stream->writeFlag(cameraCanBank);
+   stream->writeFlag(mountedImagesBank);
    stream->writeString( debrisShapeName );
 
    stream->writeFlag(observeThroughObject);
@@ -787,6 +795,9 @@ void ShapeBaseData::unpackData(BitStream* stream)
       stream->read(&cameraMaxFov);
    else
       cameraMaxFov = gShapeBaseDataProto.cameraMaxFov;
+
+   cameraCanBank = stream->readFlag();
+   mountedImagesBank = stream->readFlag();
 
    debrisShapeName = stream->readSTString();
 
@@ -1872,10 +1883,10 @@ Point3F ShapeBase::getAIRepairPoint()
 
 void ShapeBase::getEyeTransform(MatrixF* mat)
 {
-   getEyeBaseTransform(mat);
+   getEyeBaseTransform(mat, true);
 }
 
-void ShapeBase::getEyeBaseTransform(MatrixF* mat)
+void ShapeBase::getEyeBaseTransform(MatrixF* mat, bool includeBank)
 {
    // Returns eye to world space transform
    S32 eyeNode = mDataBlock->eyeNode;
@@ -1887,10 +1898,10 @@ void ShapeBase::getEyeBaseTransform(MatrixF* mat)
 
 void ShapeBase::getRenderEyeTransform(MatrixF* mat)
 {
-   getRenderEyeBaseTransform(mat);
+   getRenderEyeBaseTransform(mat, true);
 }
 
-void ShapeBase::getRenderEyeBaseTransform(MatrixF* mat)
+void ShapeBase::getRenderEyeBaseTransform(MatrixF* mat, bool includeBank)
 {
    // Returns eye to world space transform
    S32 eyeNode = mDataBlock->eyeNode;

--- a/Engine/source/T3D/shapeBase.h
+++ b/Engine/source/T3D/shapeBase.h
@@ -578,6 +578,12 @@ public:
    F32 cameraMaxFov;                ///< Max vertical FOV allowed in degrees.
    /// @}
 
+   /// @name Camera Misc
+   /// @{
+   bool cameraCanBank;              ///< If the derrived class supports it, allow the camera to bank
+   bool mountedImagesBank;          ///< Do mounted images bank along with the camera?
+   /// @}
+
    /// @name Data initialized on preload
    /// @{
 
@@ -1618,7 +1624,7 @@ public:
 
    /// Returns the eye transform of this shape without including mounted images, IE the eyes of a player
    /// @param   mat   Eye transform (out)
-   virtual void getEyeBaseTransform(MatrixF* mat);
+   virtual void getEyeBaseTransform(MatrixF* mat, bool includeBank);
 
    /// The retraction transform is the muzzle transform in world space.
    ///
@@ -1671,7 +1677,7 @@ public:
    virtual void getRenderMuzzleVector(U32 imageSlot,VectorF* vec);
    virtual void getRenderMuzzlePoint(U32 imageSlot,Point3F* pos);
    virtual void getRenderEyeTransform(MatrixF* mat);
-   virtual void getRenderEyeBaseTransform(MatrixF* mat);
+   virtual void getRenderEyeBaseTransform(MatrixF* mat, bool includeBank);
    /// @}
 
 

--- a/Engine/source/T3D/shapeImage.cpp
+++ b/Engine/source/T3D/shapeImage.cpp
@@ -1861,7 +1861,7 @@ void ShapeBase::getImageTransform(U32 imageSlot,MatrixF* mat)
          // We need to animate, even on the server, to make sure the nodes are in the correct location.
          image.shapeInstance[shapeIndex]->animate();
 
-         getEyeBaseTransform(&nmat);
+         getEyeBaseTransform(&nmat, mDataBlock->mountedImagesBank);
 
          MatrixF mountTransform = image.shapeInstance[shapeIndex]->mNodeTransforms[data.eyeMountNode[shapeIndex]];
 
@@ -1900,7 +1900,7 @@ void ShapeBase::getImageTransform(U32 imageSlot,S32 node,MatrixF* mat)
             image.shapeInstance[shapeIndex]->animate();
 
             MatrixF emat;
-            getEyeBaseTransform(&emat);
+            getEyeBaseTransform(&emat, mDataBlock->mountedImagesBank);
 
             MatrixF mountTransform = image.shapeInstance[shapeIndex]->mNodeTransforms[data.eyeMountNode[shapeIndex]];
             mountTransform.affineInverse();
@@ -1985,7 +1985,7 @@ void ShapeBase::getRenderImageTransform( U32 imageSlot, MatrixF* mat, bool noEye
 
       MatrixF nmat;
       if ( data.useEyeNode && isFirstPerson() && data.eyeMountNode[shapeIndex] != -1 ) {
-         getRenderEyeBaseTransform(&nmat);
+         getRenderEyeBaseTransform(&nmat, mDataBlock->mountedImagesBank);
 
          MatrixF mountTransform = image.shapeInstance[shapeIndex]->mNodeTransforms[data.eyeMountNode[shapeIndex]];
 
@@ -2023,7 +2023,7 @@ void ShapeBase::getRenderImageTransform(U32 imageSlot,S32 node,MatrixF* mat)
          if ( data.useEyeNode && isFirstPerson() && data.eyeMountNode[shapeIndex] != -1 )
          {
             MatrixF emat;
-            getRenderEyeBaseTransform(&emat);
+            getRenderEyeBaseTransform(&emat, mDataBlock->mountedImagesBank);
 
             MatrixF mountTransform = image.shapeInstance[shapeIndex]->mNodeTransforms[data.eyeMountNode[shapeIndex]];
             mountTransform.affineInverse();

--- a/Engine/source/T3D/turret/turretShape.cpp
+++ b/Engine/source/T3D/turret/turretShape.cpp
@@ -1270,7 +1270,7 @@ void TurretShape::getImageTransform(U32 imageSlot,S32 node,MatrixF* mat)
             image.shapeInstance[shapeIndex]->animate();
 
             MatrixF emat;
-            getEyeBaseTransform(&emat);
+            getEyeBaseTransform(&emat, mDataBlock->mountedImagesBank);
 
             MatrixF mountTransform = image.shapeInstance[shapeIndex]->mNodeTransforms[data.eyeMountNode[shapeIndex]];
             mountTransform.affineInverse();
@@ -1318,7 +1318,7 @@ void TurretShape::getRenderImageTransform(U32 imageSlot,S32 node,MatrixF* mat)
          if ( data.useEyeNode && isFirstPerson() && data.eyeMountNode[shapeIndex] != -1 )
          {
             MatrixF emat;
-            getRenderEyeBaseTransform(&emat);
+            getRenderEyeBaseTransform(&emat, mDataBlock->mountedImagesBank);
 
             MatrixF mountTransform = image.shapeInstance[shapeIndex]->mNodeTransforms[data.eyeMountNode[shapeIndex]];
             mountTransform.affineInverse();


### PR DESCRIPTION
- ShapeBaseData has two new properties.  cameraCanBank indicates that the game object may bank its eye/camera, if supported by the object. mountedImagesBank indicates that mounted images should bank with the eye/camera in first person view.  Both default to false.
- Player supports 1st person eye and 3rd person camera banking when making use of the new ExtendedMove class.
- Camera class supports banking when making use of the new ExtendedMove class.
- GameConnection now has an idea of a control scheme.  This determines how game objects should respond to input events.  A control scheme may be set by either the server or client.  Current control schemes are:
  -- Absolute rotation (likely though the ExtendedMove class)
  -- Add relative yaw (from mouse or gamepad) to absolute rotation.
  -- Add relative pitch (from mouse or gamepad) to absolute rotation.
- Player class supports the new control schemes when using the ExtendedMove class.
- Camera class supports the new control scheme when using the ExtendedMove class.
