### PR TITLE
Post effect fix(renaming function isenabled to get enabled)

### DIFF
--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -1448,7 +1448,7 @@ DefineEngineMethod( PostEffect, toggle, bool, (),,
    return object->isEnabled();
 }
 
-DefineEngineMethod( PostEffect, isEnabled, bool, (),,
+DefineEngineMethod( PostEffect, GetEnabled, bool, (),,
    "@return True if the effect is enabled." )
 {
    return object->isEnabled();

--- a/Templates/Full PhysX/game/core/scripts/client/lighting/advanced/lightViz.cs
+++ b/Templates/Full PhysX/game/core/scripts/client/lighting/advanced/lightViz.cs
@@ -195,7 +195,7 @@ function toggleDepthViz( %enable )
 {
    if ( %enable $= "" )
    {
-      $AL_DepthVisualizeVar = AL_DepthVisualize.isEnabled() ? false : true;
+      $AL_DepthVisualizeVar = AL_DepthVisualize.GetEnabled() ? false : true;
       AL_DepthVisualize.toggle();
    }
    else if ( %enable )
@@ -209,7 +209,7 @@ function toggleNormalsViz( %enable )
 {
    if ( %enable $= "" )
    {
-      $AL_NormalsVisualizeVar = AL_NormalsVisualize.isEnabled() ? false : true;
+      $AL_NormalsVisualizeVar = AL_NormalsVisualize.GetEnabled() ? false : true;
       AL_NormalsVisualize.toggle();
    }
    else if ( %enable )
@@ -223,7 +223,7 @@ function toggleLightColorViz( %enable )
 {   
    if ( %enable $= "" )
    {
-      $AL_LightColorVisualizeVar = AL_LightColorVisualize.isEnabled() ? false : true;
+      $AL_LightColorVisualizeVar = AL_LightColorVisualize.GetEnabled() ? false : true;
       AL_LightColorVisualize.toggle();
    }
    else if ( %enable )
@@ -237,7 +237,7 @@ function toggleLightSpecularViz( %enable )
 {   
    if ( %enable $= "" )
    {
-      $AL_LightSpecularVisualizeVar = AL_LightSpecularVisualize.isEnabled() ? false : true;
+      $AL_LightSpecularVisualizeVar = AL_LightSpecularVisualize.GetEnabled() ? false : true;
       AL_LightSpecularVisualize.toggle();
    }
    else if ( %enable )

--- a/Templates/Full PhysX/game/core/scripts/client/postFx/hdr.cs
+++ b/Templates/Full PhysX/game/core/scripts/client/postFx/hdr.cs
@@ -455,7 +455,7 @@ singleton PostEffect( LuminanceVisPostFX )
 
 function LuminanceVisPostFX::onEnabled( %this )
 {
-   if ( !HDRPostFX.isEnabled() )
+   if ( !HDRPostFX.GetEnabled() )
    {
       HDRPostFX.enable();
    }

--- a/Templates/Full PhysX/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
+++ b/Templates/Full PhysX/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
@@ -199,10 +199,10 @@ function PostFXManager::settingsRefreshDOF(%this)
 function PostFXManager::settingsRefreshAll(%this)
 {    
    $PostFXManager::PostFX::Enabled           = $pref::enablePostEffects;
-   $PostFXManager::PostFX::EnableSSAO        = SSAOPostFx.isEnabled();
-   $PostFXManager::PostFX::EnableHDR         = HDRPostFX.isEnabled();
-   $PostFXManager::PostFX::EnableLightRays   = LightRayPostFX.isEnabled();
-   $PostFXManager::PostFX::EnableDOF         = DOFPostEffect.isEnabled();
+   $PostFXManager::PostFX::EnableSSAO        = SSAOPostFx.GetEnabled();
+   $PostFXManager::PostFX::EnableHDR         = HDRPostFX.GetEnabled();
+   $PostFXManager::PostFX::EnableLightRays   = LightRayPostFX.GetEnabled();
+   $PostFXManager::PostFX::EnableDOF         = DOFPostEffect.GetEnabled();
    
    //For all the postFX here, apply the active settings in the system
    //to the gui controls.

--- a/Templates/Full/game/core/scripts/client/lighting/advanced/lightViz.cs
+++ b/Templates/Full/game/core/scripts/client/lighting/advanced/lightViz.cs
@@ -195,7 +195,7 @@ function toggleDepthViz( %enable )
 {
    if ( %enable $= "" )
    {
-      $AL_DepthVisualizeVar = AL_DepthVisualize.isEnabled() ? false : true;
+      $AL_DepthVisualizeVar = AL_DepthVisualize.GetEnabled() ? false : true;
       AL_DepthVisualize.toggle();
    }
    else if ( %enable )
@@ -209,7 +209,7 @@ function toggleNormalsViz( %enable )
 {
    if ( %enable $= "" )
    {
-      $AL_NormalsVisualizeVar = AL_NormalsVisualize.isEnabled() ? false : true;
+      $AL_NormalsVisualizeVar = AL_NormalsVisualize.GetEnabled() ? false : true;
       AL_NormalsVisualize.toggle();
    }
    else if ( %enable )
@@ -223,7 +223,7 @@ function toggleLightColorViz( %enable )
 {   
    if ( %enable $= "" )
    {
-      $AL_LightColorVisualizeVar = AL_LightColorVisualize.isEnabled() ? false : true;
+      $AL_LightColorVisualizeVar = AL_LightColorVisualize.GetEnabled() ? false : true;
       AL_LightColorVisualize.toggle();
    }
    else if ( %enable )
@@ -237,7 +237,7 @@ function toggleLightSpecularViz( %enable )
 {   
    if ( %enable $= "" )
    {
-      $AL_LightSpecularVisualizeVar = AL_LightSpecularVisualize.isEnabled() ? false : true;
+      $AL_LightSpecularVisualizeVar = AL_LightSpecularVisualize.GetEnabled() ? false : true;
       AL_LightSpecularVisualize.toggle();
    }
    else if ( %enable )

--- a/Templates/Full/game/core/scripts/client/postFx/hdr.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/hdr.cs
@@ -455,7 +455,7 @@ singleton PostEffect( LuminanceVisPostFX )
 
 function LuminanceVisPostFX::onEnabled( %this )
 {
-   if ( !HDRPostFX.isEnabled() )
+   if ( !HDRPostFX.GetEnabled() )
    {
       HDRPostFX.enable();
    }

--- a/Templates/Full/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
@@ -199,10 +199,10 @@ function PostFXManager::settingsRefreshDOF(%this)
 function PostFXManager::settingsRefreshAll(%this)
 {    
    $PostFXManager::PostFX::Enabled           = $pref::enablePostEffects;
-   $PostFXManager::PostFX::EnableSSAO        = SSAOPostFx.isEnabled();
-   $PostFXManager::PostFX::EnableHDR         = HDRPostFX.isEnabled();
-   $PostFXManager::PostFX::EnableLightRays   = LightRayPostFX.isEnabled();
-   $PostFXManager::PostFX::EnableDOF         = DOFPostEffect.isEnabled();
+   $PostFXManager::PostFX::EnableSSAO        = SSAOPostFx.GetEnabled();
+   $PostFXManager::PostFX::EnableHDR         = HDRPostFX.GetEnabled();
+   $PostFXManager::PostFX::EnableLightRays   = LightRayPostFX.GetEnabled();
+   $PostFXManager::PostFX::EnableDOF         = DOFPostEffect.GetEnabled();
    
    //For all the postFX here, apply the active settings in the system
    //to the gui controls.


### PR DESCRIPTION
Their was a function and a member function with the same signature, even though it works in TorqueScript it is very bad programming syntax.  I renamed the function to GetEnabled and updated the script to reflect the changes.
