### PR TITLE
ImplementEnumType Clean up, removed spaces from the enum types

### DIFF
--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -126,8 +126,8 @@ ImplementEnumType( TSMeshType,
    "@ingroup gameObjects" )
    { TSStatic::None,          "None",           "No mesh data." },
    { TSStatic::Bounds,        "Bounds",         "Bounding box of the shape." },
-   { TSStatic::CollisionMesh, "Collision Mesh", "Specifically desingated \"collision\" meshes." },
-   { TSStatic::VisibleMesh,   "Visible Mesh",   "Rendered mesh polygons." },
+   { TSStatic::CollisionMesh, "Collision_Mesh", "Specifically designated \"collision\" meshes." },
+   { TSStatic::VisibleMesh,   "Visible_Mesh",   "Rendered mesh polygons." },
 EndImplementEnumType;
 
 

--- a/Engine/source/gui/3d/guiTSControl.cpp
+++ b/Engine/source/gui/3d/guiTSControl.cpp
@@ -57,7 +57,7 @@ ImplementEnumType( GuiTSRenderStyles,
    "Style of rendering for a GuiTSCtrl.\n\n"
    "@ingroup Gui3D" )
 	{ GuiTSCtrl::RenderStyleStandard,         "standard"              },
-	{ GuiTSCtrl::RenderStyleStereoSideBySide, "stereo side by side"   },
+	{ GuiTSCtrl::RenderStyleStereoSideBySide, "stereo_side_by_side"   },
 EndImplementEnumType;
 
 

--- a/Engine/source/gui/containers/guiStackCtrl.cpp
+++ b/Engine/source/gui/containers/guiStackCtrl.cpp
@@ -66,15 +66,15 @@ EndImplementEnumType;
 ImplementEnumType( GuiHorizontalStackingType,
    "Determines how child controls are stacked horizontally.\n\n"
    "@ingroup GuiContainers" )
-   { GuiStackControl::horizStackLeft, "Left to Right", "Child controls are positioned in order from left to right (left-most control is first)" },
-   { GuiStackControl::horizStackRight,"Right to Left", "Child controls are positioned in order from right to left (right-most control is first)" }
+   { GuiStackControl::horizStackLeft, "Left_to_Right", "Child controls are positioned in order from left to right (left-most control is first)" },
+   { GuiStackControl::horizStackRight,"Right_to_Left", "Child controls are positioned in order from right to left (right-most control is first)" }
 EndImplementEnumType;
 
 ImplementEnumType( GuiVerticalStackingType,
    "Determines how child controls are stacked vertically.\n\n"
    "@ingroup GuiContainers" )
-   { GuiStackControl::vertStackTop, "Top to Bottom", "Child controls are positioned in order from top to bottom (top-most control is first)" },
-   { GuiStackControl::vertStackBottom,"Bottom to Top", "Child controls are positioned in order from bottom to top (bottom-most control is first)" }
+   { GuiStackControl::vertStackTop, "Top_to_Bottom", "Child controls are positioned in order from top to bottom (top-most control is first)" },
+   { GuiStackControl::vertStackBottom,"Bottom_to_Top", "Child controls are positioned in order from bottom to top (bottom-most control is first)" }
 EndImplementEnumType;
 
 

--- a/Templates/Empty PhysX/game/core/art/gui/consoleVarDlg.gui
+++ b/Templates/Empty PhysX/game/core/art/gui/consoleVarDlg.gui
@@ -77,8 +77,8 @@
          
          new GuiVariableInspector(ConsoleVarInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Empty PhysX/game/tools/convexEditor/convexEditorGui.gui
+++ b/Templates/Empty PhysX/game/tools/convexEditor/convexEditorGui.gui
@@ -316,8 +316,8 @@
 
          new GuiInspector(ConvexInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "ConvexInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Empty PhysX/game/tools/convexEditor/convexEditorSettingsTab.ed.gui
+++ b/Templates/Empty PhysX/game/tools/convexEditor/convexEditorSettingsTab.ed.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Empty PhysX/game/tools/datablockEditor/DatablockEditorInspectorWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/datablockEditor/DatablockEditorInspectorWindow.ed.gui
@@ -98,8 +98,8 @@
             new GuiInspector(DatablockEditorInspector) {
                dividerMargin = "5";
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                ChangeChildSizeToFit = "1";
                ChangeChildPosition = "1";

--- a/Templates/Empty PhysX/game/tools/decalEditor/decalEditorGui.gui
+++ b/Templates/Empty PhysX/game/tools/decalEditor/decalEditorGui.gui
@@ -444,8 +444,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -477,8 +477,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -557,8 +557,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -688,8 +688,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -721,8 +721,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -801,8 +801,8 @@
                
                new GuiInspector(DecalInspector) {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "1";
                   canSaveDynamicFields = "0";
                   Enabled = "1";

--- a/Templates/Empty PhysX/game/tools/forestEditor/forestEditorGui.gui
+++ b/Templates/Empty PhysX/game/tools/forestEditor/forestEditorGui.gui
@@ -274,8 +274,8 @@
       };
       new GuiStackControl() {
          StackingType = "Horizontal";
-         HorizStacking = "Left to Right";
-         VertStacking = "Top to Bottom";
+         HorizStacking = "Left_to_Right";
+         VertStacking = "Top_to_Bottom";
          Padding = "3";
          DynamicSize = "1";
          ChangeChildSizeToFit = "0";
@@ -337,8 +337,8 @@
       };
       new GuiStackControl() {
          StackingType = "Horizontal";
-         HorizStacking = "Left to Right";
-         VertStacking = "Top to Bottom";
+         HorizStacking = "Left_to_Right";
+         VertStacking = "Top_to_Bottom";
          Padding = "3";
          DynamicSize = "1";
          ChangeChildSizeToFit = "0";
@@ -485,8 +485,8 @@
             dividerMargin = "5";
             showCustomFields = "0";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             DynamicSize = "1";
             ChangeChildSizeToFit = "1";

--- a/Templates/Empty PhysX/game/tools/gui/guiObjectInspector.ed.gui
+++ b/Templates/Empty PhysX/game/tools/gui/guiObjectInspector.ed.gui
@@ -281,8 +281,8 @@
                      dividerMargin = "5";
                      showCustomFields = "1";
                      stackingType = "Vertical";
-                     horizStacking = "Left to Right";
-                     vertStacking = "Top to Bottom";
+                     horizStacking = "Left_to_Right";
+                     vertStacking = "Top_to_Bottom";
                      padding = "1";
                      dynamicSize = "1";
                      changeChildSizeToFit = "1";

--- a/Templates/Empty PhysX/game/tools/gui/simViewDlg.ed.gui
+++ b/Templates/Empty PhysX/game/tools/gui/simViewDlg.ed.gui
@@ -95,8 +95,8 @@
 
          new GuiInspector(InspectFields) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             canSaveDynamicFields = "0";
             Profile = "GuiTransparentProfile";

--- a/Templates/Empty PhysX/game/tools/guiEditor/gui/guiEditor.ed.gui
+++ b/Templates/Empty PhysX/game/tools/guiEditor/gui/guiEditor.ed.gui
@@ -995,8 +995,8 @@
                            dividerMargin = "5";
                            showCustomFields = "1";
                            StackingType = "Vertical";
-                           HorizStacking = "Left to Right";
-                           VertStacking = "Top to Bottom";
+                           HorizStacking = "Left_to_Right";
+                           VertStacking = "Top_to_Bottom";
                            Padding = "1";
                            DynamicSize = "1";
                            ChangeChildSizeToFit = "1";
@@ -1086,8 +1086,8 @@
 
                   new GuiStackControl(GuiEditorToolbox) {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "2";
                      DynamicSize = "1";
                      ChangeChildSizeToFit = "1";
@@ -1371,8 +1371,8 @@
                            dividerMargin = "5";
                            showCustomFields = "1";
                            StackingType = "Vertical";
-                           HorizStacking = "Left to Right";
-                           VertStacking = "Top to Bottom";
+                           HorizStacking = "Left_to_Right";
+                           VertStacking = "Top_to_Bottom";
                            Padding = "1";
                            DynamicSize = "1";
                            ChangeChildSizeToFit = "1";

--- a/Templates/Empty PhysX/game/tools/guiEditor/gui/guiEditorSelectDlg.ed.gui
+++ b/Templates/Empty PhysX/game/tools/guiEditor/gui/guiEditorSelectDlg.ed.gui
@@ -97,8 +97,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";
@@ -431,8 +431,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";

--- a/Templates/Empty PhysX/game/tools/materialEditor/gui/guiMaterialPropertiesWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/materialEditor/gui/guiMaterialPropertiesWindow.ed.gui
@@ -182,8 +182,8 @@
                
             new GuiStackControl(MatEd_scrollContents) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                isContainer = "1";
                Profile = "GuiDefaultProfile";
@@ -238,8 +238,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -675,8 +675,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1500,8 +1500,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1946,8 +1946,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2757,8 +2757,8 @@
                            
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";

--- a/Templates/Empty PhysX/game/tools/meshRoadEditor/meshRoadEditorGui.gui
+++ b/Templates/Empty PhysX/game/tools/meshRoadEditor/meshRoadEditorGui.gui
@@ -316,8 +316,8 @@
 
          new GuiInspector(MeshRoadInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "MeshRoadInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Empty PhysX/game/tools/meshRoadEditor/meshRoadEditorSettingsTab.gui
+++ b/Templates/Empty PhysX/game/tools/meshRoadEditor/meshRoadEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -487,8 +487,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Empty PhysX/game/tools/missionAreaEditor/missionAreaEditorGui.ed.gui
+++ b/Templates/Empty PhysX/game/tools/missionAreaEditor/missionAreaEditorGui.ed.gui
@@ -191,8 +191,8 @@
 
          new GuiInspector(MissionAreaInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "MissionAreaInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Empty PhysX/game/tools/particleEditor/ParticleEditor.ed.gui
+++ b/Templates/Empty PhysX/game/tools/particleEditor/ParticleEditor.ed.gui
@@ -120,8 +120,8 @@ $PE_guielement_ext_colorpicker = "18 18";
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                canSaveDynamicFields = "0";
                Enabled = "1";
@@ -276,8 +276,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -562,8 +562,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -778,8 +778,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1090,8 +1090,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1297,8 +1297,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1596,8 +1596,8 @@ $PE_guielement_ext_colorpicker = "18 18";
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                canSaveDynamicFields = "0";
                Enabled = "1";
@@ -1751,8 +1751,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2051,8 +2051,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2290,8 +2290,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2492,8 +2492,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";

--- a/Templates/Empty PhysX/game/tools/riverEditor/RiverEditorGui.gui
+++ b/Templates/Empty PhysX/game/tools/riverEditor/RiverEditorGui.gui
@@ -366,8 +366,8 @@
 
          new GuiInspector(RiverInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "RiverInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Empty PhysX/game/tools/riverEditor/RiverEditorSettingsTab.gui
+++ b/Templates/Empty PhysX/game/tools/riverEditor/RiverEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -307,8 +307,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Empty PhysX/game/tools/roadEditor/RoadEditorGui.gui
+++ b/Templates/Empty PhysX/game/tools/roadEditor/RoadEditorGui.gui
@@ -339,8 +339,8 @@
 
             new GuiInspector(RoadInspector) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                canSaveDynamicFields = "0";
                Enabled = "1";

--- a/Templates/Empty PhysX/game/tools/roadEditor/RoadEditorSettingsTab.gui
+++ b/Templates/Empty PhysX/game/tools/roadEditor/RoadEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -247,8 +247,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Empty PhysX/game/tools/shapeEditor/gui/ShapeEditorSettingsTab.gui
+++ b/Templates/Empty PhysX/game/tools/shapeEditor/gui/ShapeEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -403,8 +403,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Empty PhysX/game/tools/shapeEditor/gui/shapeEdSelectWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/shapeEditor/gui/shapeEdSelectWindow.ed.gui
@@ -381,8 +381,8 @@
                   tooltipprofile = "GuiToolTipProfile";
                   hovertime = "1000";
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "2";
 
                   new GuiRolloutCtrl() {
@@ -411,8 +411,8 @@
                         tooltipprofile = "GuiToolTipProfile";
                         hovertime = "1000";
                         StackingType = "Vertical";
-                        HorizStacking = "Left to Right";
-                        VertStacking = "Top to Bottom";
+                        HorizStacking = "Left_to_Right";
+                        VertStacking = "Top_to_Bottom";
                         Padding = "2";
                      };
                   };
@@ -443,8 +443,8 @@
                         tooltipprofile = "GuiToolTipProfile";
                         hovertime = "1000";
                         StackingType = "Vertical";
-                        HorizStacking = "Left to Right";
-                        VertStacking = "Top to Bottom";
+                        HorizStacking = "Left_to_Right";
+                        VertStacking = "Top_to_Bottom";
                         Padding = "2";
                      };
                   };

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/AxisGizmoSettingsTab.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/AxisGizmoSettingsTab.ed.gui
@@ -69,8 +69,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -98,8 +98,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -295,8 +295,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/CameraSettingsTab.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/CameraSettingsTab.ed.gui
@@ -67,8 +67,8 @@
          new GuiStackControl() {
             internalName = "content";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -96,8 +96,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -227,8 +227,8 @@ function ECameraSettingsPage::init(%this)
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                isContainer = "1";
                Profile = "GuiDefaultProfile";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/EditorGui.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/EditorGui.ed.gui
@@ -1120,8 +1120,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";
@@ -1189,8 +1189,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassVisList";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/GeneralSettingsTab.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/GeneralSettingsTab.ed.gui
@@ -69,8 +69,8 @@
 
          new GuiStackControl() {
             stackingType = "Vertical";
-            horizStacking = "Left to Right";
-            vertStacking = "Top to Bottom";
+            horizStacking = "Left_to_Right";
+            vertStacking = "Top_to_Bottom";
             padding = "0";
             dynamicSize = "1";
             changeChildSizeToFit = "1";
@@ -113,8 +113,8 @@
 
                new GuiStackControl() {
                   stackingType = "Vertical";
-                  horizStacking = "Left to Right";
-                  vertStacking = "Top to Bottom";
+                  horizStacking = "Left_to_Right";
+                  vertStacking = "Top_to_Bottom";
                   padding = "3";
                   dynamicSize = "1";
                   changeChildSizeToFit = "1";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/ManageBookmarksWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/ManageBookmarksWindow.ed.gui
@@ -122,8 +122,8 @@
          new GuiStackControl() {
             internalName = "ManageBookmarksWindowStack";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "2";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/ManageSFXParametersWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/ManageSFXParametersWindow.ed.gui
@@ -214,8 +214,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "2";
             DynamicSize = "1";
             ChangeChildSizeToFit = "1";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/ObjectEditorSettingsTab.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/ObjectEditorSettingsTab.ed.gui
@@ -69,8 +69,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -98,8 +98,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
                   HorizSizing = "width";
@@ -225,8 +225,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
                   HorizSizing = "width";
@@ -906,8 +906,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/ObjectSnapOptionsWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/ObjectSnapOptionsWindow.ed.gui
@@ -110,8 +110,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   canSaveDynamicFields = "0";
                   Enabled = "1";
@@ -417,8 +417,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "5";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/SelectObjectsWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/SelectObjectsWindow.ed.gui
@@ -97,8 +97,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";
@@ -431,8 +431,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/TerrainEditorSettingsTab.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/TerrainEditorSettingsTab.ed.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/TerrainPainterWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/TerrainPainterWindow.ed.gui
@@ -80,8 +80,8 @@
 
          new GuiStackControl( EPainterStack ) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "-2";
             canSaveDynamicFields = "0";
             internalName = "theMaterialList";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/TransformSelectionWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/TransformSelectionWindow.ed.gui
@@ -70,8 +70,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "5";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/VisibilityLayerWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/VisibilityLayerWindow.ed.gui
@@ -114,8 +114,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";
@@ -183,8 +183,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassVisList";
@@ -252,8 +252,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassSelList";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/WorldEditorInspectorWindow.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/WorldEditorInspectorWindow.ed.gui
@@ -98,8 +98,8 @@
 
             new GuiInspector(Inspector) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                canSaveDynamicFields = "0";
                Enabled = "1";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
@@ -15,8 +15,8 @@
    
    new GuiStackControl() {
       StackingType = "Horizontal";
-      HorizStacking = "Left to Right";
-      VertStacking = "Top to Bottom";
+      HorizStacking = "Left_to_Right";
+      VertStacking = "Top_to_Bottom";
       Padding = "0";
       canSaveDynamicFields = "0";
       Enabled = "1";

--- a/Templates/Empty PhysX/game/tools/worldEditor/gui/guiWorldEditorMissionInspector.ed.gui
+++ b/Templates/Empty PhysX/game/tools/worldEditor/gui/guiWorldEditorMissionInspector.ed.gui
@@ -275,8 +275,8 @@
 
                   new GuiInspector(Inspector) {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "1";
                      canSaveDynamicFields = "0";
                      isContainer = "1";

--- a/Templates/Empty/game/core/art/gui/consoleVarDlg.gui
+++ b/Templates/Empty/game/core/art/gui/consoleVarDlg.gui
@@ -77,8 +77,8 @@
          
          new GuiVariableInspector(ConsoleVarInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Empty/game/tools/convexEditor/convexEditorGui.gui
+++ b/Templates/Empty/game/tools/convexEditor/convexEditorGui.gui
@@ -316,8 +316,8 @@
 
          new GuiInspector(ConvexInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "ConvexInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Empty/game/tools/convexEditor/convexEditorSettingsTab.ed.gui
+++ b/Templates/Empty/game/tools/convexEditor/convexEditorSettingsTab.ed.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Empty/game/tools/datablockEditor/DatablockEditorInspectorWindow.ed.gui
+++ b/Templates/Empty/game/tools/datablockEditor/DatablockEditorInspectorWindow.ed.gui
@@ -98,8 +98,8 @@
             new GuiInspector(DatablockEditorInspector) {
                dividerMargin = "5";
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                ChangeChildSizeToFit = "1";
                ChangeChildPosition = "1";

--- a/Templates/Empty/game/tools/decalEditor/decalEditorGui.gui
+++ b/Templates/Empty/game/tools/decalEditor/decalEditorGui.gui
@@ -444,8 +444,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -477,8 +477,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -557,8 +557,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -688,8 +688,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -721,8 +721,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -801,8 +801,8 @@
                
                new GuiInspector(DecalInspector) {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "1";
                   canSaveDynamicFields = "0";
                   Enabled = "1";

--- a/Templates/Empty/game/tools/forestEditor/forestEditorGui.gui
+++ b/Templates/Empty/game/tools/forestEditor/forestEditorGui.gui
@@ -274,8 +274,8 @@
       };
       new GuiStackControl() {
          StackingType = "Horizontal";
-         HorizStacking = "Left to Right";
-         VertStacking = "Top to Bottom";
+         HorizStacking = "Left_to_Right";
+         VertStacking = "Top_to_Bottom";
          Padding = "3";
          DynamicSize = "1";
          ChangeChildSizeToFit = "0";
@@ -337,8 +337,8 @@
       };
       new GuiStackControl() {
          StackingType = "Horizontal";
-         HorizStacking = "Left to Right";
-         VertStacking = "Top to Bottom";
+         HorizStacking = "Left_to_Right";
+         VertStacking = "Top_to_Bottom";
          Padding = "3";
          DynamicSize = "1";
          ChangeChildSizeToFit = "0";
@@ -485,8 +485,8 @@
             dividerMargin = "5";
             showCustomFields = "0";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             DynamicSize = "1";
             ChangeChildSizeToFit = "1";

--- a/Templates/Empty/game/tools/gui/guiObjectInspector.ed.gui
+++ b/Templates/Empty/game/tools/gui/guiObjectInspector.ed.gui
@@ -281,8 +281,8 @@
                      dividerMargin = "5";
                      showCustomFields = "1";
                      stackingType = "Vertical";
-                     horizStacking = "Left to Right";
-                     vertStacking = "Top to Bottom";
+                     horizStacking = "Left_to_Right";
+                     vertStacking = "Top_to_Bottom";
                      padding = "1";
                      dynamicSize = "1";
                      changeChildSizeToFit = "1";

--- a/Templates/Empty/game/tools/gui/simViewDlg.ed.gui
+++ b/Templates/Empty/game/tools/gui/simViewDlg.ed.gui
@@ -95,8 +95,8 @@
 
          new GuiInspector(InspectFields) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             canSaveDynamicFields = "0";
             Profile = "ToolsGuiTransparentProfile";

--- a/Templates/Empty/game/tools/guiEditor/gui/guiEditor.ed.gui
+++ b/Templates/Empty/game/tools/guiEditor/gui/guiEditor.ed.gui
@@ -995,8 +995,8 @@
                            dividerMargin = "5";
                            showCustomFields = "1";
                            StackingType = "Vertical";
-                           HorizStacking = "Left to Right";
-                           VertStacking = "Top to Bottom";
+                           HorizStacking = "Left_to_Right";
+                           VertStacking = "Top_to_Bottom";
                            Padding = "1";
                            DynamicSize = "1";
                            ChangeChildSizeToFit = "1";
@@ -1086,8 +1086,8 @@
 
                   new GuiStackControl(GuiEditorToolbox) {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "2";
                      DynamicSize = "1";
                      ChangeChildSizeToFit = "1";
@@ -1371,8 +1371,8 @@
                            dividerMargin = "5";
                            showCustomFields = "1";
                            StackingType = "Vertical";
-                           HorizStacking = "Left to Right";
-                           VertStacking = "Top to Bottom";
+                           HorizStacking = "Left_to_Right";
+                           VertStacking = "Top_to_Bottom";
                            Padding = "1";
                            DynamicSize = "1";
                            ChangeChildSizeToFit = "1";

--- a/Templates/Empty/game/tools/guiEditor/gui/guiEditorSelectDlg.ed.gui
+++ b/Templates/Empty/game/tools/guiEditor/gui/guiEditorSelectDlg.ed.gui
@@ -97,8 +97,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";
@@ -431,8 +431,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";

--- a/Templates/Empty/game/tools/materialEditor/gui/guiMaterialPropertiesWindow.ed.gui
+++ b/Templates/Empty/game/tools/materialEditor/gui/guiMaterialPropertiesWindow.ed.gui
@@ -182,8 +182,8 @@
                
             new GuiStackControl(MatEd_scrollContents) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                isContainer = "1";
                Profile = "ToolsGuiDefaultProfile";
@@ -238,8 +238,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -675,8 +675,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1500,8 +1500,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1946,8 +1946,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2757,8 +2757,8 @@
                            
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";

--- a/Templates/Empty/game/tools/meshRoadEditor/meshRoadEditorGui.gui
+++ b/Templates/Empty/game/tools/meshRoadEditor/meshRoadEditorGui.gui
@@ -316,8 +316,8 @@
 
          new GuiInspector(MeshRoadInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "MeshRoadInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Empty/game/tools/meshRoadEditor/meshRoadEditorSettingsTab.gui
+++ b/Templates/Empty/game/tools/meshRoadEditor/meshRoadEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -487,8 +487,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Empty/game/tools/missionAreaEditor/missionAreaEditorGui.ed.gui
+++ b/Templates/Empty/game/tools/missionAreaEditor/missionAreaEditorGui.ed.gui
@@ -191,8 +191,8 @@
 
          new GuiInspector(MissionAreaInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "MissionAreaInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Empty/game/tools/particleEditor/ParticleEditor.ed.gui
+++ b/Templates/Empty/game/tools/particleEditor/ParticleEditor.ed.gui
@@ -120,8 +120,8 @@ $PE_guielement_ext_colorpicker = "18 18";
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                canSaveDynamicFields = "0";
                Enabled = "1";
@@ -276,8 +276,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -562,8 +562,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -778,8 +778,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1090,8 +1090,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1297,8 +1297,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1596,8 +1596,8 @@ $PE_guielement_ext_colorpicker = "18 18";
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                canSaveDynamicFields = "0";
                Enabled = "1";
@@ -1751,8 +1751,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2051,8 +2051,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2290,8 +2290,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2492,8 +2492,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";

--- a/Templates/Empty/game/tools/riverEditor/RiverEditorGui.gui
+++ b/Templates/Empty/game/tools/riverEditor/RiverEditorGui.gui
@@ -366,8 +366,8 @@
 
          new GuiInspector(RiverInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "RiverInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Empty/game/tools/riverEditor/RiverEditorSettingsTab.gui
+++ b/Templates/Empty/game/tools/riverEditor/RiverEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -307,8 +307,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Empty/game/tools/roadEditor/RoadEditorGui.gui
+++ b/Templates/Empty/game/tools/roadEditor/RoadEditorGui.gui
@@ -339,8 +339,8 @@
 
             new GuiInspector(RoadInspector) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                canSaveDynamicFields = "0";
                Enabled = "1";

--- a/Templates/Empty/game/tools/roadEditor/RoadEditorSettingsTab.gui
+++ b/Templates/Empty/game/tools/roadEditor/RoadEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -247,8 +247,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Empty/game/tools/shapeEditor/gui/ShapeEditorSettingsTab.gui
+++ b/Templates/Empty/game/tools/shapeEditor/gui/ShapeEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -403,8 +403,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Empty/game/tools/shapeEditor/gui/shapeEdSelectWindow.ed.gui
+++ b/Templates/Empty/game/tools/shapeEditor/gui/shapeEdSelectWindow.ed.gui
@@ -381,8 +381,8 @@
                   tooltipprofile = "ToolsGuiToolTipProfile";
                   hovertime = "1000";
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "2";
 
                   new GuiRolloutCtrl() {
@@ -411,8 +411,8 @@
                         tooltipprofile = "ToolsGuiToolTipProfile";
                         hovertime = "1000";
                         StackingType = "Vertical";
-                        HorizStacking = "Left to Right";
-                        VertStacking = "Top to Bottom";
+                        HorizStacking = "Left_to_Right";
+                        VertStacking = "Top_to_Bottom";
                         Padding = "2";
                      };
                   };
@@ -443,8 +443,8 @@
                         tooltipprofile = "ToolsGuiToolTipProfile";
                         hovertime = "1000";
                         StackingType = "Vertical";
-                        HorizStacking = "Left to Right";
-                        VertStacking = "Top to Bottom";
+                        HorizStacking = "Left_to_Right";
+                        VertStacking = "Top_to_Bottom";
                         Padding = "2";
                      };
                   };

--- a/Templates/Empty/game/tools/worldEditor/gui/AxisGizmoSettingsTab.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/AxisGizmoSettingsTab.ed.gui
@@ -69,8 +69,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -98,8 +98,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -295,8 +295,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Empty/game/tools/worldEditor/gui/CameraSettingsTab.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/CameraSettingsTab.ed.gui
@@ -67,8 +67,8 @@
          new GuiStackControl() {
             internalName = "content";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -96,8 +96,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -227,8 +227,8 @@ function ECameraSettingsPage::init(%this)
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                isContainer = "1";
                Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Empty/game/tools/worldEditor/gui/EditorGui.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/EditorGui.ed.gui
@@ -1120,8 +1120,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";
@@ -1189,8 +1189,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassVisList";

--- a/Templates/Empty/game/tools/worldEditor/gui/GeneralSettingsTab.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/GeneralSettingsTab.ed.gui
@@ -69,8 +69,8 @@
 
          new GuiStackControl() {
             stackingType = "Vertical";
-            horizStacking = "Left to Right";
-            vertStacking = "Top to Bottom";
+            horizStacking = "Left_to_Right";
+            vertStacking = "Top_to_Bottom";
             padding = "0";
             dynamicSize = "1";
             changeChildSizeToFit = "1";
@@ -113,8 +113,8 @@
 
                new GuiStackControl() {
                   stackingType = "Vertical";
-                  horizStacking = "Left to Right";
-                  vertStacking = "Top to Bottom";
+                  horizStacking = "Left_to_Right";
+                  vertStacking = "Top_to_Bottom";
                   padding = "3";
                   dynamicSize = "1";
                   changeChildSizeToFit = "1";

--- a/Templates/Empty/game/tools/worldEditor/gui/ManageBookmarksWindow.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/ManageBookmarksWindow.ed.gui
@@ -122,8 +122,8 @@
          new GuiStackControl() {
             internalName = "ManageBookmarksWindowStack";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "2";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Empty/game/tools/worldEditor/gui/ManageSFXParametersWindow.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/ManageSFXParametersWindow.ed.gui
@@ -214,8 +214,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "2";
             DynamicSize = "1";
             ChangeChildSizeToFit = "1";

--- a/Templates/Empty/game/tools/worldEditor/gui/ObjectEditorSettingsTab.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/ObjectEditorSettingsTab.ed.gui
@@ -69,8 +69,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -98,8 +98,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
                   HorizSizing = "width";
@@ -225,8 +225,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
                   HorizSizing = "width";
@@ -906,8 +906,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Empty/game/tools/worldEditor/gui/ObjectSnapOptionsWindow.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/ObjectSnapOptionsWindow.ed.gui
@@ -110,8 +110,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   canSaveDynamicFields = "0";
                   Enabled = "1";
@@ -417,8 +417,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "5";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";

--- a/Templates/Empty/game/tools/worldEditor/gui/SelectObjectsWindow.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/SelectObjectsWindow.ed.gui
@@ -97,8 +97,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";
@@ -431,8 +431,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";

--- a/Templates/Empty/game/tools/worldEditor/gui/TerrainEditorSettingsTab.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/TerrainEditorSettingsTab.ed.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Empty/game/tools/worldEditor/gui/TerrainPainterWindow.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/TerrainPainterWindow.ed.gui
@@ -80,8 +80,8 @@
 
          new GuiStackControl( EPainterStack ) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "-2";
             canSaveDynamicFields = "0";
             internalName = "theMaterialList";

--- a/Templates/Empty/game/tools/worldEditor/gui/TransformSelectionWindow.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/TransformSelectionWindow.ed.gui
@@ -70,8 +70,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "5";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Empty/game/tools/worldEditor/gui/VisibilityLayerWindow.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/VisibilityLayerWindow.ed.gui
@@ -114,8 +114,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";
@@ -183,8 +183,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassVisList";
@@ -252,8 +252,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassSelList";

--- a/Templates/Empty/game/tools/worldEditor/gui/WorldEditorInspectorWindow.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/WorldEditorInspectorWindow.ed.gui
@@ -98,8 +98,8 @@
 
             new GuiInspector(Inspector) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                canSaveDynamicFields = "0";
                Enabled = "1";

--- a/Templates/Empty/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
@@ -15,8 +15,8 @@
    
    new GuiStackControl() {
       StackingType = "Horizontal";
-      HorizStacking = "Left to Right";
-      VertStacking = "Top to Bottom";
+      HorizStacking = "Left_to_Right";
+      VertStacking = "Top_to_Bottom";
       Padding = "0";
       canSaveDynamicFields = "0";
       Enabled = "1";

--- a/Templates/Empty/game/tools/worldEditor/gui/guiWorldEditorMissionInspector.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/guiWorldEditorMissionInspector.ed.gui
@@ -275,8 +275,8 @@
 
                   new GuiInspector(Inspector) {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "1";
                      canSaveDynamicFields = "0";
                      isContainer = "1";

--- a/Templates/Full PhysX/game/core/art/gui/consoleVarDlg.gui
+++ b/Templates/Full PhysX/game/core/art/gui/consoleVarDlg.gui
@@ -77,8 +77,8 @@
          
          new GuiVariableInspector(ConsoleVarInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Full PhysX/game/tools/convexEditor/convexEditorGui.gui
+++ b/Templates/Full PhysX/game/tools/convexEditor/convexEditorGui.gui
@@ -316,8 +316,8 @@
 
          new GuiInspector(ConvexInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "ConvexInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Full PhysX/game/tools/convexEditor/convexEditorSettingsTab.ed.gui
+++ b/Templates/Full PhysX/game/tools/convexEditor/convexEditorSettingsTab.ed.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Full PhysX/game/tools/datablockEditor/DatablockEditorInspectorWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/datablockEditor/DatablockEditorInspectorWindow.ed.gui
@@ -98,8 +98,8 @@
             new GuiInspector(DatablockEditorInspector) {
                dividerMargin = "5";
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                ChangeChildSizeToFit = "1";
                ChangeChildPosition = "1";

--- a/Templates/Full PhysX/game/tools/decalEditor/decalEditorGui.gui
+++ b/Templates/Full PhysX/game/tools/decalEditor/decalEditorGui.gui
@@ -444,8 +444,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -477,8 +477,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -557,8 +557,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -688,8 +688,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -721,8 +721,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -801,8 +801,8 @@
                
                new GuiInspector(DecalInspector) {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "1";
                   canSaveDynamicFields = "0";
                   Enabled = "1";

--- a/Templates/Full PhysX/game/tools/forestEditor/forestEditorGui.gui
+++ b/Templates/Full PhysX/game/tools/forestEditor/forestEditorGui.gui
@@ -274,8 +274,8 @@
       };
       new GuiStackControl() {
          StackingType = "Horizontal";
-         HorizStacking = "Left to Right";
-         VertStacking = "Top to Bottom";
+         HorizStacking = "Left_to_Right";
+         VertStacking = "Top_to_Bottom";
          Padding = "3";
          DynamicSize = "1";
          ChangeChildSizeToFit = "0";
@@ -337,8 +337,8 @@
       };
       new GuiStackControl() {
          StackingType = "Horizontal";
-         HorizStacking = "Left to Right";
-         VertStacking = "Top to Bottom";
+         HorizStacking = "Left_to_Right";
+         VertStacking = "Top_to_Bottom";
          Padding = "3";
          DynamicSize = "1";
          ChangeChildSizeToFit = "0";
@@ -485,8 +485,8 @@
             dividerMargin = "5";
             showCustomFields = "0";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             DynamicSize = "1";
             ChangeChildSizeToFit = "1";

--- a/Templates/Full PhysX/game/tools/gui/guiObjectInspector.ed.gui
+++ b/Templates/Full PhysX/game/tools/gui/guiObjectInspector.ed.gui
@@ -281,8 +281,8 @@
                      dividerMargin = "5";
                      showCustomFields = "1";
                      stackingType = "Vertical";
-                     horizStacking = "Left to Right";
-                     vertStacking = "Top to Bottom";
+                     horizStacking = "Left_to_Right";
+                     vertStacking = "Top_to_Bottom";
                      padding = "1";
                      dynamicSize = "1";
                      changeChildSizeToFit = "1";

--- a/Templates/Full PhysX/game/tools/gui/simViewDlg.ed.gui
+++ b/Templates/Full PhysX/game/tools/gui/simViewDlg.ed.gui
@@ -95,8 +95,8 @@
 
          new GuiInspector(InspectFields) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             canSaveDynamicFields = "0";
             Profile = "GuiTransparentProfile";

--- a/Templates/Full PhysX/game/tools/guiEditor/gui/guiEditor.ed.gui
+++ b/Templates/Full PhysX/game/tools/guiEditor/gui/guiEditor.ed.gui
@@ -995,8 +995,8 @@
                            dividerMargin = "5";
                            showCustomFields = "1";
                            StackingType = "Vertical";
-                           HorizStacking = "Left to Right";
-                           VertStacking = "Top to Bottom";
+                           HorizStacking = "Left_to_Right";
+                           VertStacking = "Top_to_Bottom";
                            Padding = "1";
                            DynamicSize = "1";
                            ChangeChildSizeToFit = "1";
@@ -1086,8 +1086,8 @@
 
                   new GuiStackControl(GuiEditorToolbox) {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "2";
                      DynamicSize = "1";
                      ChangeChildSizeToFit = "1";
@@ -1371,8 +1371,8 @@
                            dividerMargin = "5";
                            showCustomFields = "1";
                            StackingType = "Vertical";
-                           HorizStacking = "Left to Right";
-                           VertStacking = "Top to Bottom";
+                           HorizStacking = "Left_to_Right";
+                           VertStacking = "Top_to_Bottom";
                            Padding = "1";
                            DynamicSize = "1";
                            ChangeChildSizeToFit = "1";

--- a/Templates/Full PhysX/game/tools/guiEditor/gui/guiEditorSelectDlg.ed.gui
+++ b/Templates/Full PhysX/game/tools/guiEditor/gui/guiEditorSelectDlg.ed.gui
@@ -97,8 +97,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";
@@ -431,8 +431,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";

--- a/Templates/Full PhysX/game/tools/materialEditor/gui/guiMaterialPropertiesWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/materialEditor/gui/guiMaterialPropertiesWindow.ed.gui
@@ -182,8 +182,8 @@
                
             new GuiStackControl(MatEd_scrollContents) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                isContainer = "1";
                Profile = "GuiDefaultProfile";
@@ -238,8 +238,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -675,8 +675,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1500,8 +1500,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1946,8 +1946,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2757,8 +2757,8 @@
                            
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";

--- a/Templates/Full PhysX/game/tools/meshRoadEditor/meshRoadEditorGui.gui
+++ b/Templates/Full PhysX/game/tools/meshRoadEditor/meshRoadEditorGui.gui
@@ -316,8 +316,8 @@
 
          new GuiInspector(MeshRoadInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "MeshRoadInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Full PhysX/game/tools/meshRoadEditor/meshRoadEditorSettingsTab.gui
+++ b/Templates/Full PhysX/game/tools/meshRoadEditor/meshRoadEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -487,8 +487,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Full PhysX/game/tools/missionAreaEditor/missionAreaEditorGui.ed.gui
+++ b/Templates/Full PhysX/game/tools/missionAreaEditor/missionAreaEditorGui.ed.gui
@@ -191,8 +191,8 @@
 
          new GuiInspector(MissionAreaInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "MissionAreaInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Full PhysX/game/tools/particleEditor/ParticleEditor.ed.gui
+++ b/Templates/Full PhysX/game/tools/particleEditor/ParticleEditor.ed.gui
@@ -120,8 +120,8 @@ $PE_guielement_ext_colorpicker = "18 18";
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                canSaveDynamicFields = "0";
                Enabled = "1";
@@ -276,8 +276,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -562,8 +562,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -778,8 +778,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1090,8 +1090,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1297,8 +1297,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1596,8 +1596,8 @@ $PE_guielement_ext_colorpicker = "18 18";
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                canSaveDynamicFields = "0";
                Enabled = "1";
@@ -1751,8 +1751,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2051,8 +2051,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2290,8 +2290,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2492,8 +2492,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";

--- a/Templates/Full PhysX/game/tools/riverEditor/RiverEditorGui.gui
+++ b/Templates/Full PhysX/game/tools/riverEditor/RiverEditorGui.gui
@@ -366,8 +366,8 @@
 
          new GuiInspector(RiverInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "RiverInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Full PhysX/game/tools/riverEditor/RiverEditorSettingsTab.gui
+++ b/Templates/Full PhysX/game/tools/riverEditor/RiverEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -307,8 +307,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Full PhysX/game/tools/roadEditor/RoadEditorGui.gui
+++ b/Templates/Full PhysX/game/tools/roadEditor/RoadEditorGui.gui
@@ -339,8 +339,8 @@
 
             new GuiInspector(RoadInspector) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                canSaveDynamicFields = "0";
                Enabled = "1";

--- a/Templates/Full PhysX/game/tools/roadEditor/RoadEditorSettingsTab.gui
+++ b/Templates/Full PhysX/game/tools/roadEditor/RoadEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -247,8 +247,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Full PhysX/game/tools/shapeEditor/gui/ShapeEditorSettingsTab.gui
+++ b/Templates/Full PhysX/game/tools/shapeEditor/gui/ShapeEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -403,8 +403,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Full PhysX/game/tools/shapeEditor/gui/shapeEdSelectWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/shapeEditor/gui/shapeEdSelectWindow.ed.gui
@@ -381,8 +381,8 @@
                   tooltipprofile = "GuiToolTipProfile";
                   hovertime = "1000";
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "2";
 
                   new GuiRolloutCtrl() {
@@ -411,8 +411,8 @@
                         tooltipprofile = "GuiToolTipProfile";
                         hovertime = "1000";
                         StackingType = "Vertical";
-                        HorizStacking = "Left to Right";
-                        VertStacking = "Top to Bottom";
+                        HorizStacking = "Left_to_Right";
+                        VertStacking = "Top_to_Bottom";
                         Padding = "2";
                      };
                   };
@@ -443,8 +443,8 @@
                         tooltipprofile = "GuiToolTipProfile";
                         hovertime = "1000";
                         StackingType = "Vertical";
-                        HorizStacking = "Left to Right";
-                        VertStacking = "Top to Bottom";
+                        HorizStacking = "Left_to_Right";
+                        VertStacking = "Top_to_Bottom";
                         Padding = "2";
                      };
                   };

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/AxisGizmoSettingsTab.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/AxisGizmoSettingsTab.ed.gui
@@ -69,8 +69,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -98,8 +98,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -295,8 +295,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/CameraSettingsTab.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/CameraSettingsTab.ed.gui
@@ -67,8 +67,8 @@
          new GuiStackControl() {
             internalName = "content";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -96,8 +96,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
@@ -227,8 +227,8 @@ function ECameraSettingsPage::init(%this)
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                isContainer = "1";
                Profile = "GuiDefaultProfile";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/EditorGui.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/EditorGui.ed.gui
@@ -1120,8 +1120,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";
@@ -1189,8 +1189,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassVisList";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/GeneralSettingsTab.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/GeneralSettingsTab.ed.gui
@@ -69,8 +69,8 @@
 
          new GuiStackControl() {
             stackingType = "Vertical";
-            horizStacking = "Left to Right";
-            vertStacking = "Top to Bottom";
+            horizStacking = "Left_to_Right";
+            vertStacking = "Top_to_Bottom";
             padding = "0";
             dynamicSize = "1";
             changeChildSizeToFit = "1";
@@ -113,8 +113,8 @@
 
                new GuiStackControl() {
                   stackingType = "Vertical";
-                  horizStacking = "Left to Right";
-                  vertStacking = "Top to Bottom";
+                  horizStacking = "Left_to_Right";
+                  vertStacking = "Top_to_Bottom";
                   padding = "3";
                   dynamicSize = "1";
                   changeChildSizeToFit = "1";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/ManageBookmarksWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/ManageBookmarksWindow.ed.gui
@@ -122,8 +122,8 @@
          new GuiStackControl() {
             internalName = "ManageBookmarksWindowStack";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "2";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/ManageSFXParametersWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/ManageSFXParametersWindow.ed.gui
@@ -214,8 +214,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "2";
             DynamicSize = "1";
             ChangeChildSizeToFit = "1";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/ObjectEditorSettingsTab.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/ObjectEditorSettingsTab.ed.gui
@@ -69,8 +69,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -98,8 +98,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
                   HorizSizing = "width";
@@ -225,8 +225,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";
                   HorizSizing = "width";
@@ -906,8 +906,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/ObjectSnapOptionsWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/ObjectSnapOptionsWindow.ed.gui
@@ -110,8 +110,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   canSaveDynamicFields = "0";
                   Enabled = "1";
@@ -417,8 +417,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "5";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/SelectObjectsWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/SelectObjectsWindow.ed.gui
@@ -97,8 +97,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";
@@ -431,8 +431,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/TerrainEditorSettingsTab.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/TerrainEditorSettingsTab.ed.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "GuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "GuiDefaultProfile";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/TerrainPainterWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/TerrainPainterWindow.ed.gui
@@ -80,8 +80,8 @@
 
          new GuiStackControl( EPainterStack ) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "-2";
             canSaveDynamicFields = "0";
             internalName = "theMaterialList";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/TransformSelectionWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/TransformSelectionWindow.ed.gui
@@ -70,8 +70,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "5";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/VisibilityLayerWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/VisibilityLayerWindow.ed.gui
@@ -114,8 +114,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";
@@ -183,8 +183,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassVisList";
@@ -252,8 +252,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassSelList";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/WorldEditorInspectorWindow.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/WorldEditorInspectorWindow.ed.gui
@@ -98,8 +98,8 @@
 
             new GuiInspector(Inspector) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                canSaveDynamicFields = "0";
                Enabled = "1";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
@@ -15,8 +15,8 @@
    
    new GuiStackControl() {
       StackingType = "Horizontal";
-      HorizStacking = "Left to Right";
-      VertStacking = "Top to Bottom";
+      HorizStacking = "Left_to_Right";
+      VertStacking = "Top_to_Bottom";
       Padding = "0";
       canSaveDynamicFields = "0";
       Enabled = "1";

--- a/Templates/Full PhysX/game/tools/worldEditor/gui/guiWorldEditorMissionInspector.ed.gui
+++ b/Templates/Full PhysX/game/tools/worldEditor/gui/guiWorldEditorMissionInspector.ed.gui
@@ -275,8 +275,8 @@
 
                   new GuiInspector(Inspector) {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "1";
                      canSaveDynamicFields = "0";
                      isContainer = "1";

--- a/Templates/Full/game/core/art/gui/consoleVarDlg.gui
+++ b/Templates/Full/game/core/art/gui/consoleVarDlg.gui
@@ -77,8 +77,8 @@
          
          new GuiVariableInspector(ConsoleVarInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Full/game/core/scripts/client/oculusVR.cs
+++ b/Templates/Full/game/core/scripts/client/oculusVR.cs
@@ -59,7 +59,7 @@ function pointCanvasToOculusVRDisplay()
 function enableOculusVRDisplay(%gameConnection, %trueStereoRendering)
 {
    setOVRHMDAsGameConnectionDisplayDevice(%gameConnection);
-   PlayGui.renderStyle = "stereo side by side";
+   PlayGui.renderStyle = "stereo_side_by_side";
    
    if(%trueStereoRendering)
    {

--- a/Templates/Full/game/tools/convexEditor/convexEditorGui.gui
+++ b/Templates/Full/game/tools/convexEditor/convexEditorGui.gui
@@ -316,8 +316,8 @@
 
          new GuiInspector(ConvexInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "ConvexInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Full/game/tools/convexEditor/convexEditorSettingsTab.ed.gui
+++ b/Templates/Full/game/tools/convexEditor/convexEditorSettingsTab.ed.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Full/game/tools/datablockEditor/DatablockEditorInspectorWindow.ed.gui
+++ b/Templates/Full/game/tools/datablockEditor/DatablockEditorInspectorWindow.ed.gui
@@ -98,8 +98,8 @@
             new GuiInspector(DatablockEditorInspector) {
                dividerMargin = "5";
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                ChangeChildSizeToFit = "1";
                ChangeChildPosition = "1";

--- a/Templates/Full/game/tools/decalEditor/decalEditorGui.gui
+++ b/Templates/Full/game/tools/decalEditor/decalEditorGui.gui
@@ -444,8 +444,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -477,8 +477,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -557,8 +557,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -688,8 +688,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -721,8 +721,8 @@
                
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -801,8 +801,8 @@
                
                new GuiInspector(DecalInspector) {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "1";
                   canSaveDynamicFields = "0";
                   Enabled = "1";

--- a/Templates/Full/game/tools/forestEditor/forestEditorGui.gui
+++ b/Templates/Full/game/tools/forestEditor/forestEditorGui.gui
@@ -274,8 +274,8 @@
       };
       new GuiStackControl() {
          StackingType = "Horizontal";
-         HorizStacking = "Left to Right";
-         VertStacking = "Top to Bottom";
+         HorizStacking = "Left_to_Right";
+         VertStacking = "Top_to_Bottom";
          Padding = "3";
          DynamicSize = "1";
          ChangeChildSizeToFit = "0";
@@ -337,8 +337,8 @@
       };
       new GuiStackControl() {
          StackingType = "Horizontal";
-         HorizStacking = "Left to Right";
-         VertStacking = "Top to Bottom";
+         HorizStacking = "Left_to_Right";
+         VertStacking = "Top_to_Bottom";
          Padding = "3";
          DynamicSize = "1";
          ChangeChildSizeToFit = "0";
@@ -485,8 +485,8 @@
             dividerMargin = "5";
             showCustomFields = "0";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             DynamicSize = "1";
             ChangeChildSizeToFit = "1";

--- a/Templates/Full/game/tools/gui/guiObjectInspector.ed.gui
+++ b/Templates/Full/game/tools/gui/guiObjectInspector.ed.gui
@@ -281,8 +281,8 @@
                      dividerMargin = "5";
                      showCustomFields = "1";
                      stackingType = "Vertical";
-                     horizStacking = "Left to Right";
-                     vertStacking = "Top to Bottom";
+                     horizStacking = "Left_to_Right";
+                     vertStacking = "Top_to_Bottom";
                      padding = "1";
                      dynamicSize = "1";
                      changeChildSizeToFit = "1";

--- a/Templates/Full/game/tools/gui/simViewDlg.ed.gui
+++ b/Templates/Full/game/tools/gui/simViewDlg.ed.gui
@@ -95,8 +95,8 @@
 
          new GuiInspector(InspectFields) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             canSaveDynamicFields = "0";
             Profile = "ToolsGuiTransparentProfile";

--- a/Templates/Full/game/tools/guiEditor/gui/guiEditor.ed.gui
+++ b/Templates/Full/game/tools/guiEditor/gui/guiEditor.ed.gui
@@ -995,8 +995,8 @@
                            dividerMargin = "5";
                            showCustomFields = "1";
                            StackingType = "Vertical";
-                           HorizStacking = "Left to Right";
-                           VertStacking = "Top to Bottom";
+                           HorizStacking = "Left_to_Right";
+                           VertStacking = "Top_to_Bottom";
                            Padding = "1";
                            DynamicSize = "1";
                            ChangeChildSizeToFit = "1";
@@ -1086,8 +1086,8 @@
 
                   new GuiStackControl(GuiEditorToolbox) {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "2";
                      DynamicSize = "1";
                      ChangeChildSizeToFit = "1";
@@ -1371,8 +1371,8 @@
                            dividerMargin = "5";
                            showCustomFields = "1";
                            StackingType = "Vertical";
-                           HorizStacking = "Left to Right";
-                           VertStacking = "Top to Bottom";
+                           HorizStacking = "Left_to_Right";
+                           VertStacking = "Top_to_Bottom";
                            Padding = "1";
                            DynamicSize = "1";
                            ChangeChildSizeToFit = "1";

--- a/Templates/Full/game/tools/guiEditor/gui/guiEditorSelectDlg.ed.gui
+++ b/Templates/Full/game/tools/guiEditor/gui/guiEditorSelectDlg.ed.gui
@@ -97,8 +97,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";
@@ -431,8 +431,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";

--- a/Templates/Full/game/tools/materialEditor/gui/guiMaterialPropertiesWindow.ed.gui
+++ b/Templates/Full/game/tools/materialEditor/gui/guiMaterialPropertiesWindow.ed.gui
@@ -182,8 +182,8 @@
                
             new GuiStackControl(MatEd_scrollContents) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                isContainer = "1";
                Profile = "ToolsGuiDefaultProfile";
@@ -238,8 +238,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -675,8 +675,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1500,8 +1500,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1946,8 +1946,8 @@
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2757,8 +2757,8 @@
                            
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";

--- a/Templates/Full/game/tools/meshRoadEditor/meshRoadEditorGui.gui
+++ b/Templates/Full/game/tools/meshRoadEditor/meshRoadEditorGui.gui
@@ -316,8 +316,8 @@
 
          new GuiInspector(MeshRoadInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "MeshRoadInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Full/game/tools/meshRoadEditor/meshRoadEditorSettingsTab.gui
+++ b/Templates/Full/game/tools/meshRoadEditor/meshRoadEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -487,8 +487,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Full/game/tools/missionAreaEditor/missionAreaEditorGui.ed.gui
+++ b/Templates/Full/game/tools/missionAreaEditor/missionAreaEditorGui.ed.gui
@@ -191,8 +191,8 @@
 
          new GuiInspector(MissionAreaInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "MissionAreaInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Full/game/tools/particleEditor/ParticleEditor.ed.gui
+++ b/Templates/Full/game/tools/particleEditor/ParticleEditor.ed.gui
@@ -120,8 +120,8 @@ $PE_guielement_ext_colorpicker = "18 18";
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                canSaveDynamicFields = "0";
                Enabled = "1";
@@ -276,8 +276,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -562,8 +562,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -778,8 +778,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1090,8 +1090,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1297,8 +1297,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -1596,8 +1596,8 @@ $PE_guielement_ext_colorpicker = "18 18";
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                canSaveDynamicFields = "0";
                Enabled = "1";
@@ -1751,8 +1751,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2051,8 +2051,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2290,8 +2290,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";
@@ -2492,8 +2492,8 @@ $PE_guielement_ext_colorpicker = "18 18";
                   
                   new GuiStackControl() {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "0";
                      canSaveDynamicFields = "0";
                      Enabled = "1";

--- a/Templates/Full/game/tools/riverEditor/RiverEditorGui.gui
+++ b/Templates/Full/game/tools/riverEditor/RiverEditorGui.gui
@@ -366,8 +366,8 @@
 
          new GuiInspector(RiverInspector) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "1";
             name = "RiverInspector";
             canSaveDynamicFields = "0";

--- a/Templates/Full/game/tools/riverEditor/RiverEditorSettingsTab.gui
+++ b/Templates/Full/game/tools/riverEditor/RiverEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -307,8 +307,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Full/game/tools/roadEditor/RoadEditorGui.gui
+++ b/Templates/Full/game/tools/roadEditor/RoadEditorGui.gui
@@ -339,8 +339,8 @@
 
             new GuiInspector(RoadInspector) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                canSaveDynamicFields = "0";
                Enabled = "1";

--- a/Templates/Full/game/tools/roadEditor/RoadEditorSettingsTab.gui
+++ b/Templates/Full/game/tools/roadEditor/RoadEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -247,8 +247,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Full/game/tools/shapeEditor/gui/ShapeEditorSettingsTab.gui
+++ b/Templates/Full/game/tools/shapeEditor/gui/ShapeEditorSettingsTab.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -403,8 +403,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Full/game/tools/shapeEditor/gui/shapeEdSelectWindow.ed.gui
+++ b/Templates/Full/game/tools/shapeEditor/gui/shapeEdSelectWindow.ed.gui
@@ -381,8 +381,8 @@
                   tooltipprofile = "ToolsGuiToolTipProfile";
                   hovertime = "1000";
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "2";
 
                   new GuiRolloutCtrl() {
@@ -411,8 +411,8 @@
                         tooltipprofile = "ToolsGuiToolTipProfile";
                         hovertime = "1000";
                         StackingType = "Vertical";
-                        HorizStacking = "Left to Right";
-                        VertStacking = "Top to Bottom";
+                        HorizStacking = "Left_to_Right";
+                        VertStacking = "Top_to_Bottom";
                         Padding = "2";
                      };
                   };
@@ -443,8 +443,8 @@
                         tooltipprofile = "ToolsGuiToolTipProfile";
                         hovertime = "1000";
                         StackingType = "Vertical";
-                        HorizStacking = "Left to Right";
-                        VertStacking = "Top to Bottom";
+                        HorizStacking = "Left_to_Right";
+                        VertStacking = "Top_to_Bottom";
                         Padding = "2";
                      };
                   };

--- a/Templates/Full/game/tools/worldEditor/gui/AxisGizmoSettingsTab.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/AxisGizmoSettingsTab.ed.gui
@@ -69,8 +69,8 @@
          
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -98,8 +98,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -295,8 +295,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Full/game/tools/worldEditor/gui/CameraSettingsTab.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/CameraSettingsTab.ed.gui
@@ -67,8 +67,8 @@
          new GuiStackControl() {
             internalName = "content";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -96,8 +96,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
@@ -227,8 +227,8 @@ function ECameraSettingsPage::init(%this)
             
             new GuiStackControl() {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "0";
                isContainer = "1";
                Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Full/game/tools/worldEditor/gui/EditorGui.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/EditorGui.ed.gui
@@ -1120,8 +1120,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";
@@ -1189,8 +1189,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassVisList";

--- a/Templates/Full/game/tools/worldEditor/gui/GeneralSettingsTab.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/GeneralSettingsTab.ed.gui
@@ -69,8 +69,8 @@
 
          new GuiStackControl() {
             stackingType = "Vertical";
-            horizStacking = "Left to Right";
-            vertStacking = "Top to Bottom";
+            horizStacking = "Left_to_Right";
+            vertStacking = "Top_to_Bottom";
             padding = "0";
             dynamicSize = "1";
             changeChildSizeToFit = "1";
@@ -113,8 +113,8 @@
 
                new GuiStackControl() {
                   stackingType = "Vertical";
-                  horizStacking = "Left to Right";
-                  vertStacking = "Top to Bottom";
+                  horizStacking = "Left_to_Right";
+                  vertStacking = "Top_to_Bottom";
                   padding = "3";
                   dynamicSize = "1";
                   changeChildSizeToFit = "1";

--- a/Templates/Full/game/tools/worldEditor/gui/ManageBookmarksWindow.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/ManageBookmarksWindow.ed.gui
@@ -122,8 +122,8 @@
          new GuiStackControl() {
             internalName = "ManageBookmarksWindowStack";
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "2";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Full/game/tools/worldEditor/gui/ManageSFXParametersWindow.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/ManageSFXParametersWindow.ed.gui
@@ -214,8 +214,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "2";
             DynamicSize = "1";
             ChangeChildSizeToFit = "1";

--- a/Templates/Full/game/tools/worldEditor/gui/ObjectEditorSettingsTab.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/ObjectEditorSettingsTab.ed.gui
@@ -69,8 +69,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -98,8 +98,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
                   HorizSizing = "width";
@@ -225,8 +225,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";
                   HorizSizing = "width";
@@ -906,8 +906,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Full/game/tools/worldEditor/gui/ObjectSnapOptionsWindow.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/ObjectSnapOptionsWindow.ed.gui
@@ -110,8 +110,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   canSaveDynamicFields = "0";
                   Enabled = "1";
@@ -417,8 +417,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "5";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";

--- a/Templates/Full/game/tools/worldEditor/gui/SelectObjectsWindow.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/SelectObjectsWindow.ed.gui
@@ -97,8 +97,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";
@@ -431,8 +431,8 @@
 
             new GuiStackControl() {
                stackingType = "Vertical";
-               horizStacking = "Left to Right";
-               vertStacking = "Top to Bottom";
+               horizStacking = "Left_to_Right";
+               vertStacking = "Top_to_Bottom";
                padding = "0";
                dynamicSize = "1";
                changeChildSizeToFit = "1";

--- a/Templates/Full/game/tools/worldEditor/gui/TerrainEditorSettingsTab.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/TerrainEditorSettingsTab.ed.gui
@@ -66,8 +66,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "0";
             isContainer = "1";
             Profile = "ToolsGuiDefaultProfile";
@@ -95,8 +95,8 @@
                 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "0";
                   isContainer = "1";
                   Profile = "ToolsGuiDefaultProfile";

--- a/Templates/Full/game/tools/worldEditor/gui/TerrainPainterWindow.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/TerrainPainterWindow.ed.gui
@@ -80,8 +80,8 @@
 
          new GuiStackControl( EPainterStack ) {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "-2";
             canSaveDynamicFields = "0";
             internalName = "theMaterialList";

--- a/Templates/Full/game/tools/worldEditor/gui/TransformSelectionWindow.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/TransformSelectionWindow.ed.gui
@@ -70,8 +70,8 @@
 
          new GuiStackControl() {
             StackingType = "Vertical";
-            HorizStacking = "Left to Right";
-            VertStacking = "Top to Bottom";
+            HorizStacking = "Left_to_Right";
+            VertStacking = "Top_to_Bottom";
             Padding = "5";
             canSaveDynamicFields = "0";
             Enabled = "1";

--- a/Templates/Full/game/tools/worldEditor/gui/VisibilityLayerWindow.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/VisibilityLayerWindow.ed.gui
@@ -114,8 +114,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theVisOptionsList";
@@ -183,8 +183,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassVisList";
@@ -252,8 +252,8 @@
 
                new GuiStackControl() {
                   StackingType = "Vertical";
-                  HorizStacking = "Left to Right";
-                  VertStacking = "Top to Bottom";
+                  HorizStacking = "Left_to_Right";
+                  VertStacking = "Top_to_Bottom";
                   Padding = "-2";
                   canSaveDynamicFields = "0";
                   internalName = "theClassSelList";

--- a/Templates/Full/game/tools/worldEditor/gui/WorldEditorInspectorWindow.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/WorldEditorInspectorWindow.ed.gui
@@ -98,8 +98,8 @@
 
             new GuiInspector(Inspector) {
                StackingType = "Vertical";
-               HorizStacking = "Left to Right";
-               VertStacking = "Top to Bottom";
+               HorizStacking = "Left_to_Right";
+               VertStacking = "Top_to_Bottom";
                Padding = "1";
                canSaveDynamicFields = "0";
                Enabled = "1";

--- a/Templates/Full/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
@@ -15,8 +15,8 @@
    
    new GuiStackControl() {
       StackingType = "Horizontal";
-      HorizStacking = "Left to Right";
-      VertStacking = "Top to Bottom";
+      HorizStacking = "Left_to_Right";
+      VertStacking = "Top_to_Bottom";
       Padding = "0";
       canSaveDynamicFields = "0";
       Enabled = "1";

--- a/Templates/Full/game/tools/worldEditor/gui/guiWorldEditorMissionInspector.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/guiWorldEditorMissionInspector.ed.gui
@@ -275,8 +275,8 @@
 
                   new GuiInspector(Inspector) {
                      StackingType = "Vertical";
-                     HorizStacking = "Left to Right";
-                     VertStacking = "Top to Bottom";
+                     HorizStacking = "Left_to_Right";
+                     VertStacking = "Top_to_Bottom";
                      Padding = "1";
                      canSaveDynamicFields = "0";
                      isContainer = "1";


### PR DESCRIPTION
Example
   { TSStatic::CollisionMesh, "Collision Mesh", "Specifically designated \"collision\" meshes." },

was changed to

   { TSStatic::CollisionMesh, "Collision_Mesh", "Specifically designated \"collision\" meshes." },

Updated all the templates as well.
