### PR TITLE
Allow T3D to compile against the latest version of FMod

### DIFF
--- a/Engine/source/sfx/fmod/sfxFMODDevice.cpp
+++ b/Engine/source/sfx/fmod/sfxFMODDevice.cpp
@@ -33,7 +33,6 @@
 bool                 SFXFMODDevice::smPrefDisableSoftware = false;
 bool                 SFXFMODDevice::smPrefUseSoftwareOcclusion = true;
 bool                 SFXFMODDevice::smPrefUseSoftwareHRTF = true;
-bool                 SFXFMODDevice::smPrefUseSoftwareReverbLowmem = false;
 bool                 SFXFMODDevice::smPrefEnableProfile = false;
 bool                 SFXFMODDevice::smPrefGeometryUseClosest = false;
 const char*          SFXFMODDevice::smPrefDSoundHRTF = "full";
@@ -248,8 +247,6 @@ bool SFXFMODDevice::_init()
          flags |= FMOD_INIT_OCCLUSION_LOWPASS;
       if( smPrefUseSoftwareHRTF )
          flags |= FMOD_INIT_HRTF_LOWPASS;
-      if( smPrefUseSoftwareReverbLowmem )
-         flags |= FMOD_INIT_SOFTWARE_REVERB_LOWMEM;
       if( smPrefEnableProfile )
          flags |= FMOD_INIT_ENABLE_PROFILE;
       if( smPrefGeometryUseClosest )

--- a/Engine/source/sfx/fmod/sfxFMODDevice.h
+++ b/Engine/source/sfx/fmod/sfxFMODDevice.h
@@ -295,9 +295,6 @@ class SFXFMODDevice : public SFXDevice
       static bool smPrefUseSoftwareHRTF;
       
       ///
-      static bool smPrefUseSoftwareReverbLowmem;
-      
-      ///
       static bool smPrefEnableProfile;
       
       ///

--- a/Engine/source/sfx/fmod/sfxFMODProvider.cpp
+++ b/Engine/source/sfx/fmod/sfxFMODProvider.cpp
@@ -60,10 +60,6 @@ public:
          "This will add a lowpass filter effect to the DSP effect chain of all sounds mixed in software.\n\n"
          "@note Only applies when using an %FMOD sound device.\n\n"
          "@ingroup SFXFMOD" );
-      Con::addVariable( "$pref::SFX::FMOD::useSoftwareReverbLowmem", TypeBool, &SFXFMODDevice::smPrefUseSoftwareReverbLowmem,
-         "If true, %FMOD's SFX reverb is run using 22/24kHz delay buffers, halving the memory required.\n\n"
-         "@note Only applies when using an %FMOD sound device.\n\n"
-         "@ingroup SFXFMOD" );
       Con::addVariable( "$pref::SFX::FMOD::enableProfile", TypeBool, &SFXFMODDevice::smPrefEnableProfile,
          "Whether to enable support for %FMOD's profiler.\n\n"
          "@note Only applies when using an %FMOD sound device.\n\n"


### PR DESCRIPTION
FMOD_INIT_SOFTWARE_REVERB_LOWMEM has been removed as of FMOD Ex 44409.
See http://upstream-tracker.org/compat_reports/fmod/44408_to_44409/abi_compat_report.html.
