### PR TITLE
Changes add alpha skybox with lighting.

### DIFF
--- a/Engine/source/environment/cloudLayer.h
+++ b/Engine/source/environment/cloudLayer.h
@@ -129,6 +129,7 @@ protected:
    F32 mCoverage;
    F32 mWindSpeed;   
    F32 mHeight;
+   bool mBehindSkybox;
 };
 
 

--- a/Engine/source/environment/skyBox.h
+++ b/Engine/source/environment/skyBox.h
@@ -114,12 +114,16 @@ protected:
    ColorF mLastFogColor;
 
    bool mDrawBottom;
+   bool mDrawTop;
+   F32 mExposure;
+   ColorF mSkyboxColor;
    bool mIsVBDirty;
    U32 mPrimCount;
 
    MatrixSet *mMatrixSet;
 
-   F32 mFogBandHeight;   
+   F32 mFogBandHeight;
+   F32 mFogBandWidth;
 
    void _updateMaterial();
    void _initMaterial();


### PR DESCRIPTION
Skyboxes now work with scatter skies and time of day, and have a color and exposure control.  Cloud layers can be set to be in front of or behind the skybox.  Normal skyboxes will not display properly unless the material property is set to emissive.

Blog post with example screenshots and a skybox found here:
http://www.garagegames.com/community/blogs/view/22265
