### PR TITLE
Update squish library to compile under Linux

### DIFF
--- a/Engine/lib/squish/alpha.cpp
+++ b/Engine/lib/squish/alpha.cpp
@@ -25,6 +25,7 @@
    
 #include "alpha.h"
 #include <algorithm>
+#include <limits.h> 
 
 namespace squish {
 

--- a/Engine/lib/squish/singlecolourfit.cpp
+++ b/Engine/lib/squish/singlecolourfit.cpp
@@ -26,6 +26,7 @@
 #include "singlecolourfit.h"
 #include "colourset.h"
 #include "colourblock.h"
+#include <limits.h> 
 
 namespace squish {
 


### PR DESCRIPTION
There is a fix in the libsquish repository to make v1.11 compile under Linux.  http://code.google.com/p/libsquish/  This involves adding an `#include <limits.h>` to a couple of files.
