### PR TITLE
Theora texture for cloned material fix

### DIFF
--- a/Engine/source/ts/tsShapeInstance.cpp
+++ b/Engine/source/ts/tsShapeInstance.cpp
@@ -259,8 +259,10 @@ void TSShapeInstance::cloneMaterialList( const FeatureSet *features )
    if ( mOwnMaterialList )
       return;
 
+   Material::sAllowTextureTargetAssignment = true;
    mMaterialList = new TSMaterialList(mMaterialList);
    initMaterialList( features );
+   Material::sAllowTextureTargetAssignment = false;
 
    mOwnMaterialList = true;
 }


### PR DESCRIPTION
When a TSShapeInstance makes a copy of its own materials through
cloneMaterialList() (such as done with client side ShapeBase objects),
the reference to a named diffuse render target was being lost.  This
affected using a TheoraTextureObject on a ShapeBase derived object
(StaticShape, etc.).
