### PR TITLE
Don't require ClientMissionCleanup to exist

### DIFF
--- a/Engine/source/T3D/fx/particleEmitter.cpp
+++ b/Engine/source/T3D/fx/particleEmitter.cpp
@@ -757,11 +757,6 @@ bool ParticleEmitter::onAdd()
    {
       cleanup->addObject( this );
    }
-   else
-   {
-      AssertFatal( false, "Error, could not find ClientMissionCleanup group" );
-      return false;
-   }
 
    removeFromProcessList();
 


### PR DESCRIPTION
Lukas Joergensen [noticed](http://www.garagegames.com/community/forums/viewthread/134056/1#comment-844077) that ParticleEmitter requires a SimGroup called ClientMissionCleanup to be present or it will have a tantrum. This seems like bad practise.
