### PR TITLE
Trigger a terrain signal when its transform is changed

### DIFF
--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -1070,6 +1070,9 @@ void TerrainBlock::setTransform(const MatrixF & mat)
 
    setRenderTransform( mat );
    setMaskBits( TransformMask );
+
+   if(isClientObject())
+      smUpdateSignal.trigger( HeightmapUpdate, this, Point2I::Zero, Point2I::Max );
 }
 
 void TerrainBlock::setScale( const VectorF &scale )


### PR DESCRIPTION
This will cause GroundCover and DecalRoad objects to be updated/regenerated when the terrain's position or rotation is changed.
