### PR TITLE
error splitting mesh and image filenames

### DIFF
--- a/Templates/Empty/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
+++ b/Templates/Empty/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
@@ -380,7 +380,10 @@ function ShapeEdSelectWindow::navigate( %this, %address )
 
       // Ignore assets in the tools folder
       %fullPath = makeRelativePath( %fullPath, getMainDotCSDir() );
-      %splitPath = strreplace( %fullPath, "/", " " );
+
+      %splitPath = strreplace( %fullPath, " ", "|" );     
+      %splitPath = strreplace( %splitPath, "/", " " );  
+      
       if ( getWord( %splitPath, 0 ) $= "tools" )
       {
          %fullPath = findNextFileMultiExpr( %filePatterns );
@@ -393,6 +396,8 @@ function ShapeEdSelectWindow::navigate( %this, %address )
       // Add this file's path ( parent folders ) to the
       // popup menu if it isn't there yet.
       %temp = strreplace( %pathFolders, " ", "/" );
+      %temp = strreplace( %temp, "|", " " );  
+      
       %r = ShapeEdSelectMenu.findText( %temp );
       if ( %r == -1 )
          ShapeEdSelectMenu.add( %temp );

--- a/Templates/Empty/game/tools/worldEditor/scripts/editors/creator.ed.cs
+++ b/Templates/Empty/game/tools/worldEditor/scripts/editors/creator.ed.cs
@@ -333,7 +333,10 @@ function EWCreatorWindow::navigate( %this, %address )
          }
 
          %fullPath = makeRelativePath( %fullPath, getMainDotCSDir() );                                  
-         %splitPath = strreplace( %fullPath, "/", " " );     
+
+	 %splitPath = strreplace( %fullPath, " ", "|" );     
+	 %splitPath = strreplace( %splitPath, "/", " " );   
+
          if( getWord(%splitPath, 0) $= "tools" )
          {
             %fullPath = findNextFileMultiExpr( "*.dts" TAB "*.dae" TAB "*.kmz"  TAB "*.dif" );
@@ -346,7 +349,9 @@ function EWCreatorWindow::navigate( %this, %address )
          
          // Add this file's path (parent folders) to the
          // popup menu if it isn't there yet.
-         %temp = strreplace( %pathFolders, " ", "/" );         
+         %temp = strreplace( %pathFolders, " ", "/" );
+	 %temp = strreplace( %temp, "|", " " );  
+	 
          %r = CreatorPopupMenu.findText( %temp );
          if ( %r == -1 )
          {
@@ -445,7 +450,9 @@ function EWCreatorWindow::navigate( %this, %address )
       while ( %fullPath !$= "" )
       {         
          %fullPath = makeRelativePath( %fullPath, getMainDotCSDir() );                                  
-         %splitPath = strreplace( %fullPath, "/", " " );     
+
+         %splitPath = strreplace( %fullPath, " ", "|" );
+	 %splitPath = strreplace( %splitPath, "/", " " );  
          if( getWord(%splitPath, 0) $= "tools" )
          {
             %fullPath = findNextFile( %expr );
@@ -458,7 +465,9 @@ function EWCreatorWindow::navigate( %this, %address )
          
          // Add this file's path (parent folders) to the
          // popup menu if it isn't there yet.
-         %temp = strreplace( %pathFolders, " ", "/" );         
+         %temp = strreplace( %pathFolders, " ", "/" );    
+	 %temp = strreplace( %temp, "|", " " ); 
+	 
          %r = CreatorPopupMenu.findText( %temp );
          if ( %r == -1 )
          {

--- a/Templates/Full/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
+++ b/Templates/Full/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
@@ -380,7 +380,10 @@ function ShapeEdSelectWindow::navigate( %this, %address )
 
       // Ignore assets in the tools folder
       %fullPath = makeRelativePath( %fullPath, getMainDotCSDir() );
-      %splitPath = strreplace( %fullPath, "/", " " );
+
+      %splitPath = strreplace( %fullPath, " ", "|" );     
+      %splitPath = strreplace( %splitPath, "/", " " );  
+      
       if ( getWord( %splitPath, 0 ) $= "tools" )
       {
          %fullPath = findNextFileMultiExpr( %filePatterns );
@@ -393,6 +396,8 @@ function ShapeEdSelectWindow::navigate( %this, %address )
       // Add this file's path ( parent folders ) to the
       // popup menu if it isn't there yet.
       %temp = strreplace( %pathFolders, " ", "/" );
+      %temp = strreplace( %temp, "|", " " );  
+      
       %r = ShapeEdSelectMenu.findText( %temp );
       if ( %r == -1 )
          ShapeEdSelectMenu.add( %temp );

--- a/Templates/Full/game/tools/worldEditor/scripts/editors/creator.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editors/creator.ed.cs
@@ -333,7 +333,10 @@ function EWCreatorWindow::navigate( %this, %address )
          }
 
          %fullPath = makeRelativePath( %fullPath, getMainDotCSDir() );                                  
-         %splitPath = strreplace( %fullPath, "/", " " );     
+
+	 %splitPath = strreplace( %fullPath, " ", "|" );     
+	 %splitPath = strreplace( %splitPath, "/", " " );   
+
          if( getWord(%splitPath, 0) $= "tools" )
          {
             %fullPath = findNextFileMultiExpr( "*.dts" TAB "*.dae" TAB "*.kmz"  TAB "*.dif" );
@@ -346,7 +349,9 @@ function EWCreatorWindow::navigate( %this, %address )
          
          // Add this file's path (parent folders) to the
          // popup menu if it isn't there yet.
-         %temp = strreplace( %pathFolders, " ", "/" );         
+         %temp = strreplace( %pathFolders, " ", "/" );
+	 %temp = strreplace( %temp, "|", " " );  
+	 
          %r = CreatorPopupMenu.findText( %temp );
          if ( %r == -1 )
          {
@@ -445,7 +450,9 @@ function EWCreatorWindow::navigate( %this, %address )
       while ( %fullPath !$= "" )
       {         
          %fullPath = makeRelativePath( %fullPath, getMainDotCSDir() );                                  
-         %splitPath = strreplace( %fullPath, "/", " " );     
+
+         %splitPath = strreplace( %fullPath, " ", "|" );
+	 %splitPath = strreplace( %splitPath, "/", " " );  
          if( getWord(%splitPath, 0) $= "tools" )
          {
             %fullPath = findNextFile( %expr );
@@ -458,7 +465,9 @@ function EWCreatorWindow::navigate( %this, %address )
          
          // Add this file's path (parent folders) to the
          // popup menu if it isn't there yet.
-         %temp = strreplace( %pathFolders, " ", "/" );         
+         %temp = strreplace( %pathFolders, " ", "/" );    
+	 %temp = strreplace( %temp, "|", " " ); 
+	 
          %r = CreatorPopupMenu.findText( %temp );
          if ( %r == -1 )
          {


### PR DESCRIPTION
If a mesh or Image filename has a space in them they are incorrectly
split into folders based on the spaces in the name.
so "Left Wall.dae"  would be split into "Left/Wall" etc.
