### PR TITLE
There is no /shape/ subdirectory in art/particles any more.

### DIFF
--- a/Templates/Empty/game/scripts/server/game.cs
+++ b/Templates/Empty/game/scripts/server/game.cs
@@ -144,8 +144,8 @@ function onServerCreated()
    
    // Load up any objects or datablocks saved to the editor managed scripts
    %datablockFiles = new ArrayObject();
-   %datablockFiles.add( "art/shapes/particles/managedParticleData.cs" );
-   %datablockFiles.add( "art/shapes/particles/managedParticleEmitterData.cs" );
+   %datablockFiles.add( "art/particles/managedParticleData.cs" );
+   %datablockFiles.add( "art/particles/managedParticleEmitterData.cs" );
    %datablockFiles.add( "art/decals/managedDecalData.cs" );
    %datablockFiles.add( "art/datablocks/managedDatablocks.cs" );
    %datablockFiles.add( "art/forest/managedItemData.cs" );


### PR DESCRIPTION
In Empty template onServerCreated() tries to load particle data from "art/shapes/particles/" which doesn't exist anymore. Changed it to "art/particles".
