### PR TITLE
compile fix for rift sdk ver 0.2.2

### DIFF
--- a/Engine/source/platform/input/oculusVR/oculusVRSensorData.cpp
+++ b/Engine/source/platform/input/oculusVR/oculusVRSensorData.cpp
@@ -34,7 +34,7 @@ void OculusVRSensorData::reset()
    mDataSet = false;
 }
 
-void OculusVRSensorData::setData(const OVR::SensorFusion& data, const F32& maxAxisRadius)
+void OculusVRSensorData::setData(OVR::SensorFusion& data, const F32& maxAxisRadius)
 {
    // Sensor rotation
    OVR::Quatf orientation;

--- a/Engine/source/platform/input/oculusVR/oculusVRSensorData.h
+++ b/Engine/source/platform/input/oculusVR/oculusVRSensorData.h
@@ -56,7 +56,7 @@ struct OculusVRSensorData
    void reset();
 
    /// Set data based on given sensor fusion
-   void setData(const OVR::SensorFusion& data, const F32& maxAxisRadius);
+   void setData(OVR::SensorFusion& data, const F32& maxAxisRadius);
 
    /// Simulate valid data
    void simulateData(const F32& maxAxisRadius);


### PR DESCRIPTION
Upgrades the T3D code to compile well with the latest Oculus Rift SDK
