### PR TITLE
Air control speed limit

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -2870,7 +2870,7 @@ void Player::updateMove(const Move* move)
       if (pvl)
          pv *= moveSpeed / pvl;
 
-      VectorF runAcc = pv - acc;
+      VectorF runAcc = pv - (mVelocity + acc);
       runAcc.z = 0;
       runAcc.x = runAcc.x * mDataBlock->airControl;
       runAcc.y = runAcc.y * mDataBlock->airControl;


### PR DESCRIPTION
The current air-control lets you accelerate to insane speeds very quickly. This change handles the acceleration the same way as when you're on the ground, so you can't accelerate to huge speeds while in the air.
