### PR TITLE
ITickable, deletion inside advanceTime.

### DIFF
--- a/Engine/source/core/iTickable.cpp
+++ b/Engine/source/core/iTickable.cpp
@@ -110,7 +110,7 @@ bool ITickable::advanceTime( U32 timeDelta )
       if(iTick == getProcessList()[i])
          ++i;
       // Special case if the object was the last in the list
-      else if((U32)getProcessList()[i] == 0xFEEEFEEE)
+      else if(i == getProcessList().size())
          --i;
    }
 


### PR DESCRIPTION
Adds a fix for when an ITickable object deletes itself inside the advanceTime procedure.
As discussed [here](http://www.garagegames.com/community/forums/viewthread/134512)

Kudos to David Wyand for [this thread](http://www.garagegames.com/community/forums/viewthread/39389) which explains the issue and helped me alot.
