### PR TITLE
ITickable, deletion inside advanceTime

### DIFF
--- a/Engine/source/core/iTickable.cpp
+++ b/Engine/source/core/iTickable.cpp
@@ -102,8 +102,14 @@ bool ITickable::advanceTime( U32 timeDelta )
 
    // Inform ALL objects that time was advanced
    dt = F32( timeDelta ) / 1000.f;
-   for( ProcessListIterator i = getProcessList().begin(); i != getProcessList().end(); i++ )
-      (*i)->advanceTime( dt );
+   for(int i = 0; i < getProcessList().size(); ){
+      ITickable* iTick = getProcessList()[i];
+      iTick->advanceTime( dt );
+      // Check if we should advance the iterator. Don't if the processed  
+      // object has deleted itself.  
+      if(i < getProcessList().size() && iTick == getProcessList()[i])
+         ++i;
+   }
 
    smLastTime = targetTime;
 


### PR DESCRIPTION
Adds a fix for when an ITickable object deletes itself inside the advanceTime procedure.
As discussed [here](http://www.garagegames.com/community/forums/viewthread/134512)

Kudos to David Wyand for [this thread](http://www.garagegames.com/community/forums/viewthread/39389) which explains the issue and helped me alot.
