### PR TITLE
allows vehicle on vehicle collisions to bump each other around

### DIFF
--- a/Engine/source/T3D/rigid.cpp
+++ b/Engine/source/T3D/rigid.cpp
@@ -156,7 +156,7 @@ bool Rigid::resolveCollision(const Point3F& p, const Point3F &normal, Rigid* rig
       return false;
 
    // Compute impulse
-   F32 d, n = -nv * (1.0f + restitution * rigid->restitution);
+   F32 d, n = -nv * (2.0 + restitution * rigid->restitution);
    Point3F a1,b1,c1;
    mCross(r1,normal,&a1);
    invWorldInertia.mulV(a1,&b1);
@@ -173,7 +173,7 @@ bool Rigid::resolveCollision(const Point3F& p, const Point3F &normal, Rigid* rig
 
    applyImpulse(r1,impulse);
    impulse.neg();
-   applyImpulse(r2,impulse);
+   rigid->applyImpulse(r2,impulse);
    return true;
 }
 

--- a/Engine/source/T3D/vehicles/vehicle.cpp
+++ b/Engine/source/T3D/vehicles/vehicle.cpp
@@ -1358,12 +1358,22 @@ bool Vehicle::resolveCollision(Rigid&  ns,CollisionList& cList)
          // "constraints".
          if (vn < -mDataBlock->contactTol) 
          {
-
             // Apply impulses to the rigid body to keep it from
             // penetrating the surface.
-            ns.resolveCollision(cList[i].point,
-               cList[i].normal);
-            collided  = true;
+           if ( c.object->getTypeMask() & VehicleObjectType )
+           {
+               Vehicle* other = dynamic_cast<Vehicle*>( c.object );
+               if (other)
+                   ns.resolveCollision(cList[i].point , cList[i].normal, &other->mRigid );
+               else
+               {
+                   //handle rigidshapes. note: we would have handled those like vehicles,
+                   //but there's more wonkiness lurking there. baby steps -BJR
+                   ns.resolveCollision(cList[i].point, cList[i].normal);
+               }
+           }
+           else ns.resolveCollision(cList[i].point, cList[i].normal);
+           collided  = true;
 
             // Keep track of objects we collide with
             if (!isGhost() && c.object->getTypeMask() & ShapeBaseObjectType) 


### PR DESCRIPTION
Note: While rigidshapes still fall through the floor, leaving out:

```
               ns.resolveCollision(cList[i].point , cList[i].normal, &other->mRigid );
           else
           {
               RigidShape* other = dynamic_cast<RigidShape*>( c.object );
               if (other)
                   ns.resolveCollision(cList[i].point , cList[i].normal, &other->mRigid );
```

for now in favor of treating those like any 'normal' collision. though if someone want's to take a poke at that end, feel free.
