### PR TITLE
Increase terrain editing and painting brush max sizes

### DIFF
--- a/Engine/source/gui/worldEditor/terrainEditor.cpp
+++ b/Engine/source/gui/worldEditor/terrainEditor.cpp
@@ -670,7 +670,7 @@ TerrainEditor::TerrainEditor() :
    mUndoSel(0),
    mGridUpdateMin( S32_MAX, S32_MAX ),
    mGridUpdateMax( 0, 0 ),
-   mMaxBrushSize(48,48),
+   mMaxBrushSize(256,256),
    mNeedsGridUpdate( false ),
    mNeedsMaterialUpdate( false ),
    mMouseDown( false )

--- a/Engine/source/gui/worldEditor/terrainEditor.h
+++ b/Engine/source/gui/worldEditor/terrainEditor.h
@@ -112,7 +112,7 @@ protected:
 
 public:
 
-   enum { MaxBrushDim = 40 };
+   enum { MaxBrushDim = 256 };
 
    Brush(TerrainEditor * editor);
    virtual ~Brush(){};

--- a/Templates/Empty/game/tools/worldEditor/gui/EditorGui.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/EditorGui.ed.gui
@@ -531,7 +531,7 @@
       selectionHidden = "1";
       renderVertexSelection = "1";
       processUsesBrush = "0";
-      maxBrushSize = "40 40";
+      maxBrushSize = "256 256";
       adjustHeightVal = "10";
       setHeightVal = "100";
       scaleVal = "1";

--- a/Templates/Empty/game/tools/worldEditor/gui/TerrainEditToolbar.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/TerrainEditToolbar.ed.gui
@@ -517,7 +517,7 @@ new GuiMouseEventCtrl(TerrainBrushSizeSliderCtrlContainer,EditorGuiGroup) {
       canSave = "1";
       Visible = "1";
       AltCommand = "TerrainBrushSizeTextEditContainer-->textEdit.setValue(mCeil($ThisControl.getValue())); ETerrainEditor.setBrushSize( $ThisControl.value );";
-      range = "1 40";
+      range = "1 256";
       ticks = "0";
       value = "0";
    };

--- a/Templates/Empty/game/tools/worldEditor/gui/TerrainPainterToolbar.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/TerrainPainterToolbar.ed.gui
@@ -494,7 +494,7 @@ new GuiMouseEventCtrl(PaintBrushSizeSliderCtrlContainer,EditorGuiGroup) {
       canSave = "1";
       Visible = "1";
       AltCommand = "PaintBrushSizeTextEditContainer-->textEdit.setValue(mFloatLength( ($ThisControl.getValue()), 2 )); ETerrainEditor.setBrushSize( $ThisControl.value );";
-      range = "1 40";
+      range = "1 256";
       ticks = "0";
       value = "0";
    };

--- a/Templates/Full/game/tools/worldEditor/gui/EditorGui.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/EditorGui.ed.gui
@@ -531,7 +531,7 @@
       selectionHidden = "1";
       renderVertexSelection = "1";
       processUsesBrush = "0";
-      maxBrushSize = "40 40";
+      maxBrushSize = "256 256";
       adjustHeightVal = "10";
       setHeightVal = "100";
       scaleVal = "1";

--- a/Templates/Full/game/tools/worldEditor/gui/TerrainEditToolbar.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/TerrainEditToolbar.ed.gui
@@ -517,7 +517,7 @@ new GuiMouseEventCtrl(TerrainBrushSizeSliderCtrlContainer,EditorGuiGroup) {
       canSave = "1";
       Visible = "1";
       AltCommand = "TerrainBrushSizeTextEditContainer-->textEdit.setValue(mCeil($ThisControl.getValue())); ETerrainEditor.setBrushSize( $ThisControl.value );";
-      range = "1 40";
+      range = "1 256";
       ticks = "0";
       value = "0";
    };

--- a/Templates/Full/game/tools/worldEditor/gui/TerrainPainterToolbar.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/TerrainPainterToolbar.ed.gui
@@ -494,7 +494,7 @@ new GuiMouseEventCtrl(PaintBrushSizeSliderCtrlContainer,EditorGuiGroup) {
       canSave = "1";
       Visible = "1";
       AltCommand = "PaintBrushSizeTextEditContainer-->textEdit.setValue(mFloatLength( ($ThisControl.getValue()), 2 )); ETerrainEditor.setBrushSize( $ThisControl.value );";
-      range = "1 40";
+      range = "1 256";
       ticks = "0";
       value = "0";
    };


### PR DESCRIPTION
Increase terrain editing and painting brush max sizes from 40 x 40 to 256 x 256.

Both empty and full templates have been changed.
