### PR TITLE
UUID Replacement

### DIFF
--- a/Engine/source/T3D/physics/physicsShape.cpp
+++ b/Engine/source/T3D/physics/physicsShape.cpp
@@ -41,6 +41,7 @@
 #include "lighting/lightQuery.h"
 #include "console/engineAPI.h"
 
+using namespace Torque;
 
 bool PhysicsShape::smNoCorrections = false;
 bool PhysicsShape::smNoSmoothing = false;
@@ -240,7 +241,7 @@ void PhysicsShapeData::onRemove()
 
 void PhysicsShapeData::_onResourceChanged( const Torque::Path &path )
 {
-   if ( path != Path( shapeName ) )
+	if ( path != Path( shapeName ) )
       return;
 
    // Reload the changed shape.

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -49,6 +49,8 @@
 #include "materials/materialFeatureTypes.h"
 #include "console/engineAPI.h"
 
+using namespace Torque;
+
 extern bool gEditingMission;
 
 IMPLEMENT_CO_NETOBJECT_V1(TSStatic);

--- a/Engine/source/core/resourceManager.cpp
+++ b/Engine/source/core/resourceManager.cpp
@@ -29,6 +29,8 @@
 
 #include "console/engineAPI.h"
 
+using namespace Torque;
+
 static AutoPtr< ResourceManager > smInstance;
 
 ResourceManager::ResourceManager()

--- a/Engine/source/core/resourceManager.h
+++ b/Engine/source/core/resourceManager.h
@@ -31,8 +31,6 @@
 #include "core/util/tDictionary.h"
 #endif
 
-using namespace Torque;
-
 class ResourceManager
 {
 public:

--- a/Engine/source/forest/ts/tsForestItemData.cpp
+++ b/Engine/source/forest/ts/tsForestItemData.cpp
@@ -31,6 +31,7 @@
 #include "materials/materialManager.h"
 #include "forest/windDeformation.h"
 
+using namespace Torque;
 
 IMPLEMENT_CO_DATABLOCK_V1(TSForestItemData);
 

--- a/Engine/source/gfx/D3D9/gfxD3D9Shader.cpp
+++ b/Engine/source/gfx/D3D9/gfxD3D9Shader.cpp
@@ -36,6 +36,8 @@
 #include "core/util/safeDelete.h"
 #include "console/console.h"
 
+using namespace Torque;
+
 extern bool gDisassembleAllShaders;
 
 /// D3DXInclude plugin

--- a/Engine/source/gfx/bitmap/gBitmap.cpp
+++ b/Engine/source/gfx/bitmap/gBitmap.cpp
@@ -33,6 +33,7 @@
 #include "platform/profiler.h"
 #include "console/engineAPI.h"
 
+using namespace Torque;
 
 const U32 GBitmap::csFileVersion   = 3;
 

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -35,6 +35,7 @@
 #include "console/consoleTypes.h"
 #include "console/engineAPI.h"
 
+using namespace Torque;
 
 //#define DEBUG_SPEW
 

--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -45,6 +45,7 @@
 #include "postFx/postEffectManager.h"
 #include "postFx/postEffectVis.h"
 
+using namespace Torque;
 
 ConsoleDocClass( PostEffect, 
    "@brief A fullscreen shader effect.\n\n"

--- a/Engine/source/sfx/sfxProfile.cpp
+++ b/Engine/source/sfx/sfxProfile.cpp
@@ -31,6 +31,7 @@
 #include "core/resourceManager.h"
 #include "console/engineAPI.h"
 
+using namespace Torque;
 
 IMPLEMENT_CO_DATABLOCK_V1( SFXProfile );
 

--- a/Engine/source/terrain/terrImport.cpp
+++ b/Engine/source/terrain/terrImport.cpp
@@ -31,6 +31,7 @@
 #include "util/noise2d.h"
 #include "core/volume.h"
 
+using namespace Torque;
 
 ConsoleStaticMethod( TerrainBlock, createNew, S32, 5, 5, 
    "TerrainBlock.create( String terrainName, U32 resolution, String materialName, bool genNoise )\n"


### PR DESCRIPTION
As documented in issue #448, the definition of "using namespace Torque;" in a header file can cause some conflicting issues between the Windows rpcde "::UUID" declaration and T3D's "Torque::UUID" declaration. This pull request removes the namespace declaration from the header file and instead adds the declaration to the source code files in the engine that require the namespace declaration.
