### PR TITLE
Expose ShapeBase blowUp method

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -4613,6 +4613,11 @@ DefineEngineMethod( ShapeBase, isEnabled, bool, (),,
    return object->getDamageState() == ShapeBase::Enabled;
 }
 
+DefineEngineMethod(ShapeBase, blowUp, void, (),, "@brief Explodes an object into pieces.")
+{
+	object->blowUp();
+}
+
 DefineEngineMethod( ShapeBase, applyDamage, void, ( F32 amount ),,
    "@brief Increment the current damage level by the specified amount.\n\n"
 

--- a/Engine/source/T3D/shapeBase.h
+++ b/Engine/source/T3D/shapeBase.h
@@ -1121,7 +1121,6 @@ protected:
    virtual void ejectShellCasing( U32 imageSlot );
    virtual void updateDamageLevel();
    virtual void updateDamageState();
-   virtual void blowUp();
    virtual void onImpact(SceneObject* obj, VectorF vec);
    virtual void onImpact(VectorF vec);
    /// @}
@@ -1306,6 +1305,9 @@ public:
 
    /// Returns the recharge rate
    F32  getRechargeRate() { return mRechargeRate; }
+
+   /// Makes the shape explode.
+   virtual void blowUp();
 
    /// @}
 


### PR DESCRIPTION
This means it can be called from scripts on objects like Player that don't usually blow up. [Credit to Michael Hall.](http://www.garagegames.com/community/resources/view/21682)
