### PR TITLE
Bug in TSShapeInstance::MaskNodeHandsOff

### DIFF
--- a/Engine/source/ts/tsAnimate.cpp
+++ b/Engine/source/ts/tsAnimate.cpp
@@ -232,14 +232,24 @@ void TSShapeInstance::animateNodes(S32 ss)
    if (inTransition())
       handleTransitionNodes(a,b);
 
-   // multiply transforms...
+   // multiply transforms...  
    for (i=a; i<b; i++)
    {
       S32 parentIdx = mShape->nodes[i].parentIndex;
-      if (parentIdx < 0)
-         mNodeTransforms[i] = smNodeLocalTransforms[i];
+      if (parentIdx < 0) {
+         if (!mHandsOffNodes.test(i)) {
+            mNodeTransforms[i] = smNodeLocalTransforms[i];
+          }
+      }
       else
-         mNodeTransforms[i].mul(mNodeTransforms[parentIdx],smNodeLocalTransforms[i]);
+      {
+          if (!mHandsOffNodes.test(i)) {
+            mNodeTransforms[i].mul(mNodeTransforms[parentIdx],smNodeLocalTransforms[i]);
+          } else {
+            MatrixF localMat = mNodeTransforms[i];
+            mNodeTransforms[i].mul(mNodeTransforms[parentIdx],localMat);
+          }
+      }
    }
 }
 


### PR DESCRIPTION
When using TSShapeInstance::MaskNodeHandsOff to manually control a nodes rotation and position, you will get garbage data which will cause weird popping specially when switching animations.

<a href="http://www.garagegames.com/community/forums/viewthread/131998">Credit to Tim Newell</a>, 
References bug #83 
