### PR TITLE
Improve float / double consistency with platform types F32 and F64

### DIFF
--- a/Engine/source/T3D/camera.cpp
+++ b/Engine/source/T3D/camera.cpp
@@ -1543,10 +1543,10 @@ void Camera::_validateEyePoint(F32 pos, MatrixF *mat)
          endPos = startPos - dir * pos;
       else
       {
-         float dot = mDot(dir, collision.normal);
+         F32 dot = mDot(dir, collision.normal);
          if (dot > 0.01f)
          {
-            float colDist = mDot(startPos - collision.point, dir) - (1 / dot) * CameraRadius;
+            F32 colDist = mDot(startPos - collision.point, dir) - (1 / dot) * CameraRadius;
             if (colDist > pos)
                colDist = pos;
             if (colDist < 0.0f)

--- a/Engine/source/T3D/fx/particle.cpp
+++ b/Engine/source/T3D/fx/particle.cpp
@@ -66,11 +66,11 @@ ConsoleDocClass( ParticleData,
    "@see ParticleEmitterNode\n"
 );
 
-static const float sgDefaultWindCoefficient = 0.0f;
-static const float sgDefaultConstantAcceleration = 0.f;
-static const float sgDefaultSpinSpeed = 1.f;
-static const float sgDefaultSpinRandomMin = 0.f;
-static const float sgDefaultSpinRandomMax = 0.f;
+static const F32 sgDefaultWindCoefficient = 0.0f;
+static const F32 sgDefaultConstantAcceleration = 0.f;
+static const F32 sgDefaultSpinSpeed = 1.f;
+static const F32 sgDefaultSpinRandomMin = 0.f;
+static const F32 sgDefaultSpinRandomMax = 0.f;
 
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/T3D/fx/particleEmitter.cpp
+++ b/Engine/source/T3D/fx/particleEmitter.cpp
@@ -100,9 +100,9 @@ ConsoleDocClass( ParticleEmitterData,
    "@see ParticleEmitterNode\n"
 );
 
-static const float sgDefaultEjectionOffset = 0.f;
-static const float sgDefaultPhiReferenceVel = 0.f;
-static const float sgDefaultPhiVariance = 360.f;
+static const F32 sgDefaultEjectionOffset = 0.f;
+static const F32 sgDefaultPhiReferenceVel = 0.f;
+static const F32 sgDefaultPhiVariance = 360.f;
 
 //-----------------------------------------------------------------------------
 // ParticleEmitterData

--- a/Engine/source/T3D/projectile.h
+++ b/Engine/source/T3D/projectile.h
@@ -215,9 +215,9 @@ public:
 
    void updateSound();    
 
-   virtual bool calculateImpact( float simTime,
+   virtual bool calculateImpact( F32 simTime,
                                  Point3F &pointOfImpact,
-                                 float &impactTime );
+                                 F32 &impactTime );
 
    void setInitialPosition( const Point3F& pos );
    void setInitialVelocity( const Point3F& vel );

--- a/Engine/source/T3D/shapeImage.cpp
+++ b/Engine/source/T3D/shapeImage.cpp
@@ -3061,7 +3061,7 @@ TICKAGAIN:
 
       if (image.spinThread[i])
       {
-         float timeScale;
+         F32 timeScale;
 
          switch (stateData.spin) 
          {

--- a/Engine/source/console/CMDscan.cpp
+++ b/Engine/source/console/CMDscan.cpp
@@ -2716,7 +2716,7 @@ bool collapseEscape(char *buf)
 static int Sc_ScanNum()
 {
    CMDtext[CMDleng] = 0;
-   CMDlval.f = MakeToken< double >( dAtof(CMDtext), lineIndex );
+   CMDlval.f = MakeToken< F64 >( dAtof(CMDtext), lineIndex );
    return(FLTCONST);
 }
 

--- a/Engine/source/console/cmdgram.cpp
+++ b/Engine/source/console/cmdgram.cpp
@@ -306,7 +306,7 @@ typedef union YYSTYPE
    Token< int >            i;
    Token< const char* >    s;
    Token< char* >          str;
-   Token< double >         f;
+   Token< F64 >            f;
    StmtNode*               stmt;
    ExprNode*               expr;
    SlotAssignNode*         slist;

--- a/Engine/source/console/cmdgram.h
+++ b/Engine/source/console/cmdgram.h
@@ -198,7 +198,7 @@ typedef union YYSTYPE
    Token< int >            i;
    Token< const char* >    s;
    Token< char* >          str;
-   Token< double >         f;
+   Token< F64 >            f;
    StmtNode*               stmt;
    ExprNode*               expr;
    SlotAssignNode*         slist;

--- a/Engine/source/core/util/tSignal.cpp
+++ b/Engine/source/core/util/tSignal.cpp
@@ -24,7 +24,7 @@
 #include "core/util/tSignal.h"
 
 
-void SignalBase::DelegateLink::insert(DelegateLink* node, float order)
+void SignalBase::DelegateLink::insert(DelegateLink* node, F32 order)
 {
    // Note: can only legitimately be called on list head
    DelegateLink * walk = next;

--- a/Engine/source/environment/waterPlane.cpp
+++ b/Engine/source/environment/waterPlane.cpp
@@ -163,7 +163,7 @@ void WaterPlane::unpackUpdate(NetConnection* con, BitStream* stream)
 
    if( stream->readFlag() ) // UpdateMask
    {
-      float posZ;
+      F32 posZ;
       stream->read( &posZ );
       Point3F newPos = getPosition();
       newPos.z = posZ;

--- a/Engine/source/forest/editor/forestBrushTool.cpp
+++ b/Engine/source/forest/editor/forestBrushTool.cpp
@@ -650,7 +650,7 @@ void ForestBrushTool::_collectElements()
    }
 }
 
-bool ForestBrushTool::getGroundAt( const Point3F &worldPt, float *zValueOut, VectorF *normalOut )
+bool ForestBrushTool::getGroundAt( const Point3F &worldPt, F32 *zValueOut, VectorF *normalOut )
 {
    const U32 mask = TerrainObjectType | StaticShapeObjectType;
 

--- a/Engine/source/forest/editor/forestBrushTool.h
+++ b/Engine/source/forest/editor/forestBrushTool.h
@@ -82,7 +82,7 @@ public:
    void setPressure( F32 val );
    void setHardness( F32 val );
    void collectElements() { _collectElements(); }
-   bool getGroundAt( const Point3F &worldPt, float *zValueOut, VectorF *normalOut );
+   bool getGroundAt( const Point3F &worldPt, F32 *zValueOut, VectorF *normalOut );
 
 protected:      
 

--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -1260,7 +1260,7 @@ DefineEngineFunction( getPixelShaderVersion, F32, (),,
    return GFX->getPixelShaderVersion();
 }   
 
-DefineEngineFunction( setPixelShaderVersion, void, ( float version ),,
+DefineEngineFunction( setPixelShaderVersion, void, ( F32 version ),,
    "@brief Sets the pixel shader version for the active device.\n"
    "This can be used to force a lower pixel shader version than is supported by "
    "the device for testing or performance optimization.\n"

--- a/Engine/source/gfx/util/triListOpt.cpp
+++ b/Engine/source/gfx/util/triListOpt.cpp
@@ -378,7 +378,7 @@ F32 score(const VertData &vertexData)
          AssertFatal(vertexData.cachePosition < MaxSizeVertexCache, "Out of range cache position for vertex");
 
          // Points for being high in the cache.
-         const float Scaler = 1.0f / (MaxSizeVertexCache - 3);
+         const F32 Scaler = 1.0f / (MaxSizeVertexCache - 3);
          Score = 1.0f - (vertexData.cachePosition - 3) * Scaler;
          Score = mPow(Score, FindVertexScore::CacheDecayPower);
       }
@@ -387,7 +387,7 @@ F32 score(const VertData &vertexData)
 
    // Bonus points for having a low number of tris still to
    // use the vert, so we get rid of lone verts quickly.
-   float ValenceBoost = mPow(vertexData.numUnaddedReferences, -FindVertexScore::ValenceBoostPower);
+   F32 ValenceBoost = mPow(vertexData.numUnaddedReferences, -FindVertexScore::ValenceBoostPower);
    Score += FindVertexScore::ValenceBoostScale * ValenceBoost;
 
    return Score;

--- a/Engine/source/gui/3d/guiTSControl.cpp
+++ b/Engine/source/gui/3d/guiTSControl.cpp
@@ -539,7 +539,7 @@ DefineEngineMethod( GuiTSCtrl, getWorldToScreenScale, Point2F, (),,
 
 //-----------------------------------------------------------------------------
 
-DefineEngineMethod( GuiTSCtrl, calculateViewDistance, float, ( float radius ),,
+DefineEngineMethod( GuiTSCtrl, calculateViewDistance, F32, ( F32 radius ),,
    "Given the camera's current FOV, get the distance from the camera's viewpoint at which the given radius will fit in the render area.\n"
    "@param radius Radius in world-space units which should fit in the view.\n"
    "@return The distance from the viewpoint at which the given radius would be fully visible." )

--- a/Engine/source/gui/controls/guiBitmapCtrl.cpp
+++ b/Engine/source/gui/controls/guiBitmapCtrl.cpp
@@ -178,8 +178,8 @@ void GuiBitmapCtrl::onRender(Point2I offset, const RectI &updateRect)
  			GFXTextureObject* texture = mTextureObject;
 			RectI srcRegion;
 			RectI dstRegion;
-			float xdone = ((float)getExtent().x/(float)texture->mBitmapSize.x)+1;
-			float ydone = ((float)getExtent().y/(float)texture->mBitmapSize.y)+1;
+			F32 xdone = ((F32)getExtent().x/(F32)texture->mBitmapSize.x)+1;
+			F32 ydone = ((F32)getExtent().y/(F32)texture->mBitmapSize.y)+1;
 
 			int xshift = mStartPoint.x%texture->mBitmapSize.x;
 			int yshift = mStartPoint.y%texture->mBitmapSize.y;

--- a/Engine/source/gui/editor/guiGraphCtrl.cpp
+++ b/Engine/source/gui/editor/guiGraphCtrl.cpp
@@ -274,7 +274,7 @@ void GuiGraphCtrl::addDatum(S32 plotID, F32 v)
 
 //-----------------------------------------------------------------------------
 
-float GuiGraphCtrl::getDatum( int plotID, int sample)
+F32 GuiGraphCtrl::getDatum( int plotID, int sample)
 {
    AssertFatal(plotID > -1 && plotID < MaxPlots, "Invalid plot specified!");
    AssertFatal(sample > -1 && sample < MaxDataPoints, "Invalid sample specified!");

--- a/Engine/source/gui/game/guiIdleCamFadeBitmapCtrl.cpp
+++ b/Engine/source/gui/game/guiIdleCamFadeBitmapCtrl.cpp
@@ -123,8 +123,8 @@ public:
             GFXTextureObject* texture = mTextureObject;
             RectI srcRegion;
             RectI dstRegion;
-            float xdone = ((float)getExtent().x/(float)texture->mBitmapSize.x)+1;
-            float ydone = ((float)getExtent().y/(float)texture->mBitmapSize.y)+1;
+            F32 xdone = ((F32)getExtent().x/(F32)texture->mBitmapSize.x)+1;
+            F32 ydone = ((F32)getExtent().y/(F32)texture->mBitmapSize.y)+1;
 
             int xshift = mStartPoint.x%texture->mBitmapSize.x;
             int yshift = mStartPoint.y%texture->mBitmapSize.y;

--- a/Engine/source/lighting/common/projectedShadow.cpp
+++ b/Engine/source/lighting/common/projectedShadow.cpp
@@ -53,8 +53,8 @@ SimObjectPtr<RenderPassManager> ProjectedShadow::smRenderPass = NULL;
 SimObjectPtr<PostEffect> ProjectedShadow::smShadowFilter = NULL;
 F32 ProjectedShadow::smDepthAdjust = 10.0f;
 
-float ProjectedShadow::smFadeStartPixelSize = 200.0f;
-float ProjectedShadow::smFadeEndPixelSize = 35.0f;
+F32 ProjectedShadow::smFadeStartPixelSize = 200.0f;
+F32 ProjectedShadow::smFadeEndPixelSize = 35.0f;
 
 
 GFX_ImplementTextureProfile( BLProjectedShadowProfile,

--- a/Engine/source/lighting/common/projectedShadow.h
+++ b/Engine/source/lighting/common/projectedShadow.h
@@ -109,8 +109,8 @@ protected:
 public:
 
    /// @see DecalData
-   static float smFadeStartPixelSize;
-   static float smFadeEndPixelSize;
+   static F32 smFadeStartPixelSize;
+   static F32 smFadeEndPixelSize;
 
    ProjectedShadow( SceneObject *object );
    virtual ~ProjectedShadow();

--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -284,7 +284,7 @@ void ProcessedShaderMaterial::_determineFeatures(  U32 stageNum,
 {
    PROFILE_SCOPE( ProcessedShaderMaterial_DetermineFeatures );
 
-   const float shaderVersion = GFX->getPixelShaderVersion();
+   const F32 shaderVersion = GFX->getPixelShaderVersion();
    AssertFatal(shaderVersion > 0.0 , "Cannot create a shader material if we don't support shaders");
 
    bool lastStage = stageNum == (mMaxStages-1);

--- a/Engine/source/math/mMathAltivec.cpp
+++ b/Engine/source/math/mMathAltivec.cpp
@@ -38,9 +38,9 @@
 /// because we get a much better speed gain if we can assume the data is aligned.
 void vec_MatrixF_x_MatrixF(const F32 *matA, const F32 *matB, F32 *result)
 {
-   vector float A[4][1];
-   vector float B[4][1];
-   vector float C[4][1];
+   vector F32 A[4][1];
+   vector F32 B[4][1];
+   vector F32 C[4][1];
 
    /// If the incoming pointers are not 16-byte aligned, we have to load & store the slow way.
    if((int)matA & 0xF || (int)matB & 0xF || (int)result & 0xF)

--- a/Engine/source/math/mMathFn.h
+++ b/Engine/source/math/mMathFn.h
@@ -442,7 +442,7 @@ inline bool mIsNaN_F( const F32 x )
 
 inline bool mIsInf_F( const F32 x )
 {
-   return ( x == std::numeric_limits< float >::infinity() );
+   return ( x == std::numeric_limits< F32 >::infinity() );
 }
 
 inline F32 mSign( const F32 n )

--- a/Engine/source/math/mQuat.cpp
+++ b/Engine/source/math/mQuat.cpp
@@ -245,7 +245,7 @@ QuatF & QuatF::interpolate( const QuatF & q1, const QuatF & q2, F32 t )
    //-----------------------------------
    // Calculate the cosine of the angle:
 
-   double cosOmega = q1.dot( q2 );
+   F64 cosOmega = q1.dot( q2 );
 
    //-----------------------------------
    // adjust signs if necessary:
@@ -262,12 +262,12 @@ QuatF & QuatF::interpolate( const QuatF & q1, const QuatF & q2, F32 t )
    //-----------------------------------
    // calculate interpolating coeffs:
 
-   double scale1, scale2;
+   F64 scale1, scale2;
    if ( (1.0 - cosOmega) > 0.00001 )
    {
       // standard case
-      double omega = mAcos(cosOmega);
-      double sinOmega = mSin(omega);
+      F64 omega = mAcos(cosOmega);
+      F64 sinOmega = mSin(omega);
       scale1 = mSin((1.0 - t) * omega) / sinOmega;
       scale2 = sign2 * mSin(t * omega) / sinOmega;
    }

--- a/Engine/source/platform/input/event.cpp
+++ b/Engine/source/platform/input/event.cpp
@@ -500,7 +500,7 @@ void InputEventManager::buildInputEvent(U32 deviceType, U32 deviceInst, InputEve
    newEvent.postToSignal(Input::smInputEvent);
 }
 
-void InputEventManager::buildInputEvent(U32 deviceType, U32 deviceInst, InputEventType objType, InputObjectInstances objInst, InputActionType action, float fValue)
+void InputEventManager::buildInputEvent(U32 deviceType, U32 deviceInst, InputEventType objType, InputObjectInstances objInst, InputActionType action, F32 fValue)
 {
    InputEventInfo newEvent;
 

--- a/Engine/source/platform/input/event.h
+++ b/Engine/source/platform/input/event.h
@@ -496,7 +496,7 @@ public:
    void buildInputEvent(U32 deviceType, U32 deviceInst, InputEventType objType, InputObjectInstances objInst, InputActionType action, S32 iValue);
 
    /// Build an input event based on a single fValue
-   void buildInputEvent(U32 deviceType, U32 deviceInst, InputEventType objType, InputObjectInstances objInst, InputActionType action, float fValue);
+   void buildInputEvent(U32 deviceType, U32 deviceInst, InputEventType objType, InputObjectInstances objInst, InputActionType action, F32 fValue);
 
    /// Build an input event based on a Point3F
    void buildInputEvent(U32 deviceType, U32 deviceInst, InputEventType objType, InputObjectInstances objInst, InputActionType action, Point3F& pValue);

--- a/Engine/source/platform/platform.h
+++ b/Engine/source/platform/platform.h
@@ -212,7 +212,7 @@ namespace Platform
    void debugBreak();
    
    // Random
-   float getRandom();
+   F32 getRandom();
    
    // Window state
    void setWindowLocked(bool locked);

--- a/Engine/source/platform/types.h
+++ b/Engine/source/platform/types.h
@@ -218,13 +218,13 @@ inline S8 getMin(S8 a, S8 b)
 }
 
 /// Returns the lesser of the two parameters: a & b.
-inline float getMin(float a, float b)
+inline F32 getMin(F32 a, F32 b)
 {
    return a>b ? b : a;
 }
 
 /// Returns the lesser of the two parameters: a & b.
-inline double getMin(double a, double b)
+inline F64 getMin(F64 a, F64 b)
 {
    return a>b ? b : a;
 }
@@ -266,13 +266,13 @@ inline S8 getMax(S8 a, S8 b)
 }
 
 /// Returns the greater of the two parameters: a & b.
-inline float getMax(float a, float b)
+inline F32 getMax(F32 a, F32 b)
 {
    return a>b ? a : b;
 }
 
 /// Returns the greater of the two parameters: a & b.
-inline double getMax(double a, double b)
+inline F64 getMax(F64 a, F64 b)
 {
    return a>b ? a : b;
 }

--- a/Engine/source/platformWin32/winDInputDevice.cpp
+++ b/Engine/source/platformWin32/winDInputDevice.cpp
@@ -896,8 +896,8 @@ bool DInputDevice::buildEvent( DWORD offset, S32 newData, S32 oldData )
             // Scale to the range -1.0 to 1.0:
             if ( objInfo.mMin != DIPROPRANGE_NOMIN && objInfo.mMax != DIPROPRANGE_NOMAX )
             {
-               float range = float( objInfo.mMax - objInfo.mMin );
-               newEvent.fValue = float( ( 2 * newData ) - objInfo.mMax - objInfo.mMin ) / range;
+               F32 range = F32( objInfo.mMax - objInfo.mMin );
+               newEvent.fValue = F32( ( 2 * newData ) - objInfo.mMax - objInfo.mMin ) / range;
             }
             else
                newEvent.fValue = (F32)newData;
@@ -1041,7 +1041,7 @@ bool DInputDevice::buildEvent( DWORD offset, S32 newData, S32 oldData )
    return true;
 }
 
-void DInputDevice::rumble(float x, float y)
+void DInputDevice::rumble(F32 x, F32 y)
 {
    LONG            rglDirection[2] = { 0, 0 };
    DICONSTANTFORCE cf              = { 0 };

--- a/Engine/source/platformWin32/winDInputDevice.h
+++ b/Engine/source/platformWin32/winDInputDevice.h
@@ -117,7 +117,7 @@ class DInputDevice : public InputDevice
       const char* getProductName();
 
       // Constant Effect Force Feedback
-      void rumble( float x, float y );
+      void rumble( F32 x, F32 y );
 
       // Console interface functions:
       const char* getJoystickAxesString();

--- a/Engine/source/platformWin32/winDirectInput.cpp
+++ b/Engine/source/platformWin32/winDirectInput.cpp
@@ -511,7 +511,7 @@ void DInputManager::deactivateXInput()
 }
 
 //------------------------------------------------------------------------------
-bool DInputManager::rumble( const char *pDeviceName, float x, float y )
+bool DInputManager::rumble( const char *pDeviceName, F32 x, F32 y )
 {
    // Determine the device
    U32 deviceType;
@@ -566,7 +566,7 @@ bool DInputManager::rumble( const char *pDeviceName, float x, float y )
    }
 }
 
-void DInputManager::buildXInputEvent( U32 deviceInst, InputEventType objType, InputObjectInstances objInst, InputActionType action, float fValue )
+void DInputManager::buildXInputEvent( U32 deviceInst, InputEventType objType, InputObjectInstances objInst, InputActionType action, F32 fValue )
 {
    InputEventInfo newEvent;
 
@@ -597,7 +597,7 @@ inline void DInputManager::fireXInputConnectEvent( int controllerID, bool condit
    }
 }
 
-inline void DInputManager::fireXInputMoveEvent( int controllerID, bool condition, InputObjectInstances objInst, float fValue )
+inline void DInputManager::fireXInputMoveEvent( int controllerID, bool condition, InputObjectInstances objInst, F32 fValue )
 {
    if ( mXInputStateReset || condition )
    {

--- a/Engine/source/platformWin32/winDirectInput.h
+++ b/Engine/source/platformWin32/winDirectInput.h
@@ -85,9 +85,9 @@ class DInputManager : public InputManager
       void unacquire( U8 deviceType, U8 deviceID );
 
       // XInput worker functions
-      void buildXInputEvent( U32 deviceInst, InputEventType objType, InputObjectInstances objInst, InputActionType action, float fValue );
+      void buildXInputEvent( U32 deviceInst, InputEventType objType, InputObjectInstances objInst, InputActionType action, F32 fValue );
       void fireXInputConnectEvent( int controllerID, bool condition, bool connected );
-      void fireXInputMoveEvent( int controllerID, bool condition, InputObjectInstances objInst, float fValue );
+      void fireXInputMoveEvent( int controllerID, bool condition, InputObjectInstances objInst, F32 fValue );
       void fireXInputButtonEvent( int controllerID, bool forceFire, int button, InputObjectInstances objInst );
       void processXInput();
 
@@ -126,7 +126,7 @@ class DInputManager : public InputManager
       // Console interface:
       const char* getJoystickAxesString( U32 deviceID );
 
-      bool rumble( const char *pDeviceName, float x, float y );
+      bool rumble( const char *pDeviceName, F32 x, F32 y );
 };
 
 #endif  // _H_WINDIRECTINPUT_

--- a/Engine/source/scene/reflector.cpp
+++ b/Engine/source/scene/reflector.cpp
@@ -682,7 +682,7 @@ MatrixF PlaneReflector::getCameraReflection( MatrixF &camTrans )
    return newTrans;
 }
 
-inline float sgn(float a)
+inline F32 sgn(F32 a)
 {
    if (a > 0.0F) return (1.0F);
    if (a < 0.0F) return (-1.0F);

--- a/Engine/source/ts/collada/colladaUtils.cpp
+++ b/Engine/source/ts/collada/colladaUtils.cpp
@@ -278,9 +278,9 @@ void AnimData::parseTargetString(const char* target, int fullCount, const char* 
 /// Solve the cubic spline B(s) = param for s
 F32 AnimData::invertParamCubic(F32 param, F32 x0, F32 x1, F32 x2, F32 x3) const
 {
-   const double INVERTPARAMCUBIC_TOL         = 1.0e-09;
-   const double INVERTPARAMCUBIC_SMALLERTOL  = 1.0e-20;
-   const double INVERTPARAMCUBIC_MAXIT       = 100;
+   const F64 INVERTPARAMCUBIC_TOL         = 1.0e-09;
+   const F64 INVERTPARAMCUBIC_SMALLERTOL  = 1.0e-20;
+   const F64 INVERTPARAMCUBIC_MAXIT       = 100;
 
    // check input value for outside range
    if ((param - x0) < INVERTPARAMCUBIC_SMALLERTOL)
@@ -295,12 +295,12 @@ F32 AnimData::invertParamCubic(F32 param, F32 x0, F32 x1, F32 x2, F32 x3) const
    F32 v = 1.0f;
 
    while (iterations < INVERTPARAMCUBIC_MAXIT) {
-      double a = (x0 + x1)*0.5f;
-      double b = (x1 + x2)*0.5f;
-      double c = (x2 + x3)*0.5f;
-      double d = (a + b)*0.5f;
-      double e = (b + c)*0.5f;
-      double f = (d + e)*0.5f;
+      F64 a = (x0 + x1)*0.5f;
+      F64 b = (x1 + x2)*0.5f;
+      F64 c = (x2 + x3)*0.5f;
+      F64 d = (a + b)*0.5f;
+      F64 e = (b + c)*0.5f;
+      F64 f = (d + e)*0.5f;
 
       if (mFabs(f - param) < INVERTPARAMCUBIC_TOL)
          break;

--- a/Engine/source/ts/collada/colladaUtils.h
+++ b/Engine/source/ts/collada/colladaUtils.h
@@ -671,8 +671,8 @@ template<> inline const domListOfUInts *ColladaPrimitive<domPolylist>::getTriang
 template<typename T> inline T convert(const char* value) { return value; }
 template<> inline bool convert(const char* value) { return dAtob(value); }
 template<> inline S32 convert(const char* value) { return dAtoi(value); }
-template<> inline double convert(const char* value) { return dAtof(value); }
-template<> inline F32 convert(const char* value) { return convert<double>(value); }
+template<> inline F64 convert(const char* value) { return dAtof(value); }
+template<> inline F32 convert(const char* value) { return convert<F64>(value); }
 
 //-----------------------------------------------------------------------------
 /// Collada animation data

--- a/Engine/source/ts/loader/tsShapeLoader.cpp
+++ b/Engine/source/ts/loader/tsShapeLoader.cpp
@@ -32,9 +32,9 @@
 
 
 const F32 TSShapeLoader::DefaultTime = -1.0f;
-const double TSShapeLoader::MinFrameRate = 15.0f;
-const double TSShapeLoader::MaxFrameRate = 60.0f;
-const double TSShapeLoader::AppGroundFrameRate = 10.0f;
+const F64 TSShapeLoader::MinFrameRate = 15.0f;
+const F64 TSShapeLoader::MaxFrameRate = 60.0f;
+const F64 TSShapeLoader::AppGroundFrameRate = 10.0f;
 Torque::Path TSShapeLoader::shapePath;
 
 //------------------------------------------------------------------------------

--- a/Engine/source/ts/loader/tsShapeLoader.h
+++ b/Engine/source/ts/loader/tsShapeLoader.h
@@ -82,9 +82,9 @@ protected:
 
 public:
    static const F32 DefaultTime;
-   static const double MinFrameRate;
-   static const double MaxFrameRate;
-   static const double AppGroundFrameRate;
+   static const F64 MinFrameRate;
+   static const F64 MaxFrameRate;
+   static const F64 AppGroundFrameRate;
 
 protected:
    // Variables used during loading that must be held until the shape is deleted

--- a/Engine/source/ts/tsLastDetail.h
+++ b/Engine/source/ts/tsLastDetail.h
@@ -62,12 +62,12 @@ GFXDeclareVertexFormat( ImposterState )
    /// .xyz = imposter center
    /// .w = billboard corner... damn SM 2.0
    Point3F center;
-   float corner;
+   F32 corner;
 
    /// .x = scaled half size
    /// .y = alpha fade out
-   float halfSize;
-   float alpha;
+   F32 halfSize;
+   F32 alpha;
 
    /// The rotation encoded as the up
    /// and right vectors... cross FTW.

--- a/Engine/source/util/fpsTracker.cpp
+++ b/Engine/source/util/fpsTracker.cpp
@@ -46,7 +46,7 @@ void FPSTracker::reset()
 
 void FPSTracker::update()
 {
-   const float alpha  = 0.07f;
+   const F32 alpha  = 0.07f;
    F32 realSeconds    = (F32)Platform::getRealMilliseconds()/1000.0f;
    F32 virtualSeconds = (F32)Platform::getVirtualMilliseconds()/1000.0f;
 


### PR DESCRIPTION
Updates to set consistency in platform type usage. Changed float to F32 and double to F64. Reference to Issue #85
