### PR TITLE
Heap corruption caused by incorrect Torque Script naming

### DIFF
--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -652,7 +652,7 @@ breakContinue:
 
                AbstractClassRep* rep = AbstractClassRep::findClassRep( objectName );
                if (rep != NULL) {
-                  Con::errorf(ConsoleLogEntry::General, "%s: Cannot name object %s the same name as a script class.",
+                  Con::errorf(ConsoleLogEntry::General, "%s: Cannot name object [%s] the same name as a script class.",
                      getFileLine(ip), objectName);
                   ip = failJump;
                   STR.popFrame();


### PR DESCRIPTION
Adds a check to make sure a dynamic variable won't be named the same as a ts class name. The change to the original solution is that the object is rejected instead of being renamed. 

References Issue #84
<a href="http://www.garagegames.com/community/forums/viewthread/131958">Credit to Tim Newell</a>
