### PR TITLE
AIPlayer path node slowdown

### DIFF
--- a/Templates/Full/game/scripts/server/aiPlayer.cs
+++ b/Templates/Full/game/scripts/server/aiPlayer.cs
@@ -140,26 +140,31 @@ function AIPlayer::followPath(%this,%path,%node)
 
 function AIPlayer::moveToNextNode(%this)
 {
-   if (%this.targetNode < 0 || %this.currentNode < %this.targetNode)
-   {
-      if (%this.currentNode < %this.path.getCount() - 1)
-         %this.moveToNode(%this.currentNode + 1);
-      else
-         %this.moveToNode(0);
+   %pathNodeCount=%this.path.getCount();
+   %slowdown=0;
+
+   %targetNode=%this.currentNode + 1;
+
+   if (%this.path.isLooping) {
+      %targetNode %= %pathNodeCount;
+   } else {
+      if (%targetNode >= %pathNodeCount-1) {
+         %targetNode=%pathNodeCount-1;
+
+         if (%currentNode < %targetNode)
+            %slowdown=1;
+      }
    }
-   else
-      if (%this.currentNode == 0)
-         %this.moveToNode(%this.path.getCount() - 1);
-      else
-         %this.moveToNode(%this.currentNode - 1);
+
+   %this.moveToNode(%targetNode, %slowdown);
 }
 
-function AIPlayer::moveToNode(%this,%index)
+function AIPlayer::moveToNode(%this,%index,%slowdown)
 {
    // Move to the given path node index
    %this.currentNode = %index;
    %node = %this.path.getObject(%index);
-   %this.setMoveDestination(%node.getTransform());
+   %this.setMoveDestination(%node.getTransform(),%slowdown);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Updates AIPlayer script class to account for looping paths and slows the aiplayer down on the last node if it's not a looping path.

References issue #60

To check the fix.. Setup a path w/ pathnodes and spawn an ai player to that path, following that path. I used 7 nodes in a circular formation so I could ensure that when I selected checked the isLooping flag on the path in the editor, that the ai would pay attention. Once your ai is following the path you'll notice they do slow down at each of those nodes in the path. Make sure to save your level. Then apply the fix and reload your game and test level. Respawn the ai on the path again and watch them follow the path, but notice they don't slow down anymore at each node. If is looping is checked the ai will not slow down at any of the nodes. Now uncheck islooping on the path so it won't loop and do this before you ai reaches the second to last node. Notice now, that the ai will slow down while approaching the last node in that path. If you recheck islooping on the path, the ai will just resume following the path and continue from it's position.
