### PR TITLE
Fix bug in HTTPObject (Fixed)

### DIFF
--- a/Engine/source/app/net/httpObject.cpp
+++ b/Engine/source/app/net/httpObject.cpp
@@ -298,7 +298,7 @@ void HTTPObject::onDisconnect()
    Parent::onDisconnect();
 }
 
-bool HTTPObject::processLine(U8 *line)
+bool HTTPObject::processLine(UTF8 *line)
 {
    if(mParseState == ParsingStatusLine)
    {

--- a/Engine/source/app/net/httpObject.h
+++ b/Engine/source/app/net/httpObject.h
@@ -72,7 +72,7 @@ public:
    virtual void onConnected();
    virtual void onConnectFailed();
    virtual void onDisconnect();
-   bool processLine(U8 *line);
+   bool processLine(UTF8 *line);
 
    DECLARE_CONOBJECT(HTTPObject);
 };


### PR DESCRIPTION
Fixed the pull request.

HTTPObject's processLine function's signature did not match the virtual processLine function on TCPObject. This caused undesired results.

Instead of HTTPObject::onLine containing just the response data, it also included the full HTTP header. I assume this was not the intended functionality because HTTPObject's processLine was never getting called and fixing it gave me the output that I expected from an HTTP helper class.

There is also an issue where the data returned from the server requires a new line appended to the end, but that problem is happening in TCPObject.

Another issue is that HTTPObject seems to leave the socket connection open after receiving the response from the server. I had to add special code to my php file to force the connection closed.

Anyway, this only fixes the first problem.
