### PR TITLE
Added default parameter to GuiMLTextCtrl::addText

### DIFF
--- a/Engine/source/gui/controls/guiMLTextCtrl.cpp
+++ b/Engine/source/gui/controls/guiMLTextCtrl.cpp
@@ -121,10 +121,10 @@ DefineEngineMethod( GuiMLTextCtrl, getText, const char*, (),,
    return( object->getTextContent() );
 }
 
-DefineEngineMethod( GuiMLTextCtrl, addText, void, ( const char* text, bool reformat),,
+DefineEngineMethod( GuiMLTextCtrl, addText, void, ( const char* text, bool reformat), (true),
    "@brief Appends the text in the control with additional text. Also .\n\n"
    "@param text New text to append to the existing text.\n"
-   "@param reformat If true, the control will also be visually reset.\n"
+   "@param reformat If true, the control will also be visually reset (defaults to true).\n"
    "@tsexample\n"
    "// Define new text to add\n"
    "%text = \"New Text to Add\";\n\n"


### PR DESCRIPTION
The `reformat` parameter now defaults to `true`, so the function can be called like:

```
BottomPrintText.addText(" more words");
```

and the control will update, which seems reasonable.
