### PR TITLE
RenderMeshExample won't render transparent materials properly

### DIFF
--- a/Engine/source/T3D/examples/renderMeshExample.cpp
+++ b/Engine/source/T3D/examples/renderMeshExample.cpp
@@ -284,6 +284,13 @@ void RenderMeshExample::prepRenderImage( SceneRenderState *state )
    // Set our RenderInst as a standard mesh render
    ri->type = RenderPassManager::RIT_Mesh;
 
+   //If our material has transparency set on this will redirect it to proper render bin
+   if ( matInst->getMaterial()->isTranslucent() )
+   {
+      ri->type = RenderPassManager::RIT_Translucent;
+      ri->translucentSort = true;
+   }
+
    // Calculate our sorting point
    if ( state )
    {


### PR DESCRIPTION
This commit will fix it. Spent some time figuring out how to render transparent objects, this will make it more clear for other newcomers.
