### PR TITLE
Allow audioData.cs.dso to execute

### DIFF
--- a/Templates/Empty/game/scripts/client/init.cs
+++ b/Templates/Empty/game/scripts/client/init.cs
@@ -110,7 +110,7 @@ function initClient()
    setDefaultFov( $pref::Player::defaultFov );
    setZoomSpeed( $pref::Player::zoomSpeed );
 
-   if( isFile( "./audioData.cs" ) )
+   if( isScriptFile( expandFilename("./audioData.cs") ) )
       exec( "./audioData.cs" );
 
    // Start up the main menu... this is separated out into a

--- a/Templates/Full/game/scripts/client/init.cs
+++ b/Templates/Full/game/scripts/client/init.cs
@@ -124,7 +124,7 @@ function initClient()
    setDefaultFov( $pref::Player::defaultFov );
    setZoomSpeed( $pref::Player::zoomSpeed );
 
-   if( isFile( "./audioData.cs" ) )
+   if( isScriptFile( expandFilename("./audioData.cs") ) )
       exec( "./audioData.cs" );
 
    // Start up the main menu... this is separated out into a


### PR DESCRIPTION
When using only compiled scripts, the isFile( "./audioData.cs" ) would fail for audioData.cs.dso causing none of the audio data to load.  The correct method is to use isScriptFile(), along with a fully qualified file path, to check for either the .dso or .cs files.
