### PR TITLE
Make GuiShapeNameHud frame and fill rendering useful

### DIFF
--- a/Engine/source/T3D/fps/guiShapeNameHud.cpp
+++ b/Engine/source/T3D/fps/guiShapeNameHud.cpp
@@ -60,6 +60,8 @@ class GuiShapeNameHud : public GuiControl {
    bool     mShowLabelFrame;
    bool     mShowLabelFill;
 
+   Point2I  mLabelPadding;
+
 protected:
    void drawName( Point2I offset, const char *buf, F32 opacity);
 
@@ -119,6 +121,7 @@ GuiShapeNameHud::GuiShapeNameHud()
    mShowFrame = mShowFill = true;
    mVerticalOffset = 0.5f;
    mDistanceFade = 0.1f;
+   mLabelPadding.set(0, 0);
 }
 
 void GuiShapeNameHud::initPersistFields()
@@ -136,6 +139,7 @@ void GuiShapeNameHud::initPersistFields()
    addField( "showFrame",  TypeBool, Offset( mShowFrame, GuiShapeNameHud ), "If true, we draw the frame of the control."  );
    addField( "showLabelFill",  TypeBool, Offset( mShowLabelFill, GuiShapeNameHud ), "If true, we draw a background for each shape name label." );
    addField( "showLabelFrame", TypeBool, Offset( mShowLabelFrame, GuiShapeNameHud ), "If true, we draw a frame around each shape name label."  );
+   addField( "labelPadding", TypePoint2I, Offset( mLabelPadding, GuiShapeNameHud ), "The padding (in pixels) between the label text and the frame." );
    addField( "verticalOffset", TypeF32, Offset( mVerticalOffset, GuiShapeNameHud ), "Amount to vertically offset the control in relation to the ShapeBase object in focus." );
    addField( "distanceFade", TypeF32, Offset( mDistanceFade, GuiShapeNameHud ), "Visibility distance (how far the player must be from the ShapeBase object in focus) for this control to render." );
    endGroup("Misc");
@@ -286,13 +290,13 @@ void GuiShapeNameHud::onRender( Point2I, const RectI &updateRect)
 /// @param   opacity Opacity of name (a fraction).
 void GuiShapeNameHud::drawName(Point2I offset, const char *name, F32 opacity)
 {
-   F32 width = mProfile->mFont->getStrWidth((const UTF8 *)name);
-   F32 height = mProfile->mFont->getHeight();
+   F32 width = mProfile->mFont->getStrWidth((const UTF8 *)name) + mLabelPadding.x * 2;
+   F32 height = mProfile->mFont->getHeight() + mLabelPadding.y * 2;
    Point2I extent = Point2I(width, height);
 
    // Center the name
    offset.x -= width / 2;
-   offset.y -= height;
+   offset.y -= height / 2;
 
    // Background fill first
    if (mShowLabelFill)
@@ -301,7 +305,7 @@ void GuiShapeNameHud::drawName(Point2I offset, const char *name, F32 opacity)
    // Deal with opacity and draw.
    mTextColor.alpha = opacity;
    GFX->getDrawUtil()->setBitmapModulation(mTextColor);
-   GFX->getDrawUtil()->drawText(mProfile->mFont, offset, name);
+   GFX->getDrawUtil()->drawText(mProfile->mFont, offset + mLabelPadding, name);
    GFX->getDrawUtil()->clearBitmapModulation();
 
    // Border last


### PR DESCRIPTION
At the moment, the `fill` and `frame` colours of `GuiShapeNameHud` fill the entire hud area. Which doesn't seem helpful. These changes make the full and outlines happen around each shape name that is rendered. Which AFAIR is how it worked in TGE.
