### PR TITLE
DecalManager scene container fix

### DIFF
--- a/Engine/source/scene/sceneContainer.cpp
+++ b/Engine/source/scene/sceneContainer.cpp
@@ -243,7 +243,7 @@ void SceneContainer::insertIntoBins(SceneObject* obj)
 
    // For huge objects, dump them into the overflow bin.  Otherwise, everything
    //  goes into the grid...
-   if ((maxX - minX + 1) < csmNumBins || (maxY - minY + 1) < csmNumBins && !obj->isGlobalBounds())
+   if (!obj->isGlobalBounds() && ((maxX - minX + 1) < csmNumBins || (maxY - minY + 1) < csmNumBins))
    {
       SceneObjectRef** pCurrInsert = &obj->mBinRefHead;
 


### PR DESCRIPTION
In reference to https://github.com/GarageGames/Torque3D/issues/474 this
is a general fix for all global bounds objects.
