### PR TITLE
Mounted image weapon light fix

### DIFF
--- a/Engine/source/T3D/shapeImage.cpp
+++ b/Engine/source/T3D/shapeImage.cpp
@@ -3262,7 +3262,7 @@ void ShapeBase::submitLights( LightManager *lm, bool staticLighting )
             {
             S32 elapsed = Sim::getCurrentTime() - image.lightStart;
             if ( elapsed > imageData->lightDuration )
-               return;
+               continue;
             intensity = ( 1.0 - (F32)elapsed / (F32)imageData->lightDuration ) * imageData->lightBrightness;
             break;
             }


### PR DESCRIPTION
Fix for mounted image lights beyond the first weapon light.  Before this
fix all mounted images that have lights would not function if mounted to
a slot after a mounted image that uses a weapon light.
