### PR TITLE
Oculus Rift Sensor Data Comparison Change

### DIFF
--- a/Engine/source/platform/input/oculusVR/oculusVRSensorData.cpp
+++ b/Engine/source/platform/input/oculusVR/oculusVRSensorData.cpp
@@ -95,7 +95,7 @@ void OculusVRSensorData::simulateData(const F32& maxAxisRadius)
    mDataSet = true;
 }
 
-U32 OculusVRSensorData::compare(OculusVRSensorData* other)
+U32 OculusVRSensorData::compare(OculusVRSensorData* other, bool doRawCompare)
 {
    S32 result = DIFF_NONE;
 
@@ -116,17 +116,20 @@ U32 OculusVRSensorData::compare(OculusVRSensorData* other)
    }
 
    // Check raw values
-   if(mAcceleration.x != other->mAcceleration.x || mAcceleration.y != other->mAcceleration.y || mAcceleration.z != other->mAcceleration.z || !mDataSet)
+   if(doRawCompare)
    {
-      result |= DIFF_ACCEL;
-   }
-   if(mAngVelocity.x != other->mAngVelocity.x || mAngVelocity.y != other->mAngVelocity.y || mAngVelocity.z != other->mAngVelocity.z || !mDataSet)
-   {
-      result |= DIFF_ANGVEL;
-   }
-   if(mMagnetometer.x != other->mMagnetometer.x || mMagnetometer.y != other->mMagnetometer.y || mMagnetometer.z != other->mMagnetometer.z || !mDataSet)
-   {
-      result |= DIFF_MAG;
+      if(mAcceleration.x != other->mAcceleration.x || mAcceleration.y != other->mAcceleration.y || mAcceleration.z != other->mAcceleration.z || !mDataSet)
+      {
+         result |= DIFF_ACCEL;
+      }
+      if(mAngVelocity.x != other->mAngVelocity.x || mAngVelocity.y != other->mAngVelocity.y || mAngVelocity.z != other->mAngVelocity.z || !mDataSet)
+      {
+         result |= DIFF_ANGVEL;
+      }
+      if(mMagnetometer.x != other->mMagnetometer.x || mMagnetometer.y != other->mMagnetometer.y || mMagnetometer.z != other->mMagnetometer.z || !mDataSet)
+      {
+         result |= DIFF_MAG;
+      }
    }
 
    return result;

--- a/Engine/source/platform/input/oculusVR/oculusVRSensorData.h
+++ b/Engine/source/platform/input/oculusVR/oculusVRSensorData.h
@@ -71,7 +71,7 @@ struct OculusVRSensorData
    void simulateData(const F32& maxAxisRadius);
 
    /// Compare this data and given and return differences
-   U32 compare(OculusVRSensorData* other);
+   U32 compare(OculusVRSensorData* other, bool doRawCompare);
 };
 
 #endif   // _OCULUSVRSENSORDATA_H_

--- a/Engine/source/platform/input/oculusVR/oculusVRSensorDevice.cpp
+++ b/Engine/source/platform/input/oculusVR/oculusVRSensorDevice.cpp
@@ -200,7 +200,7 @@ bool OculusVRSensorDevice::process(U32 deviceType, bool generateRotAsAngAxis, bo
    {
       currentBuffer->simulateData(maxAxisRadius);
    }
-   diff = mPrevData->compare(currentBuffer);
+   diff = mPrevData->compare(currentBuffer, generateRawSensor);
 
    // Update the previous data pointer.  We do this here in case someone calls our
    // console functions during one of the input events below.


### PR DESCRIPTION
- Modified OculusVRSensorData::compare() to only work with the raw
  sensor data when specifically requested.  No need to process those
  values if the user hasn't asked for them.
