### PR TITLE
Viewport fix for PostFX and SSAO

### DIFF
--- a/Engine/source/postFx/postEffect.h
+++ b/Engine/source/postFx/postEffect.h
@@ -170,6 +170,7 @@ protected:
 
    PFXRenderTime mRenderTime;
    PFXTargetClear mTargetClear;
+   PFXTargetViewport mTargetViewport;
 
    String mRenderBin;
 

--- a/Engine/source/postFx/postEffectCommon.h
+++ b/Engine/source/postFx/postEffectCommon.h
@@ -67,6 +67,20 @@ enum PFXTargetClear
 
 DefineEnumType( PFXTargetClear );
 
+
+/// PFXTargetViewport specifies how the viewport should be
+/// set up for a PostEffect's target.
+enum PFXTargetViewport
+{
+   /// The default viewport set up to match the target size
+   PFXTargetViewport_TargetSize,
+
+   /// Use the current GFX viewport
+   PFXTargetViewport_GFXViewport,
+};
+
+DefineEnumType( PFXTargetViewport );
+
 ///
 struct PFXFrameState
 {

--- a/Templates/Empty/game/core/scripts/client/postFx/ssao.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/ssao.cs
@@ -190,6 +190,7 @@ singleton PostEffect( SSAOPostFx )
    
    target = "$outTex";
    targetScale = "0.5 0.5";
+   targetViewport = "PFXTargetViewport_GFXViewport";
    
    singleton PostEffect()
    {

--- a/Templates/Full/game/core/scripts/client/postFx/ssao.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/ssao.cs
@@ -190,6 +190,7 @@ singleton PostEffect( SSAOPostFx )
    
    target = "$outTex";
    targetScale = "0.5 0.5";
+   targetViewport = "PFXTargetViewport_GFXViewport";
    
    singleton PostEffect()
    {


### PR DESCRIPTION
- General fix for PostFX render targets to properly support the GFX
  viewport setting.  This is an opt-in change through the use of the new
  mTargetViewport property as most PostFX run fine with their assumption
  of the viewport being the whole rendering target.
- The SSAO PostFX has been modified to use the new mTargetViewport
  property.  This allows correct rendering in a side-by-side view such as
  with the Oculus Rift, or any other constrained viewport rendering.
