### PR TITLE
Expand PostFX Viewport Options

### DIFF
--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -849,7 +849,7 @@ void GFXDevice::popActiveRenderTarget()
    mRTStack.pop_back();
 }
 
-void GFXDevice::setActiveRenderTarget( GFXTarget *target )
+void GFXDevice::setActiveRenderTarget( GFXTarget *target, bool updateViewport )
 {
    AssertFatal( target, 
       "GFXDevice::setActiveRenderTarget - must specify a render target!" );
@@ -878,7 +878,10 @@ void GFXDevice::setActiveRenderTarget( GFXTarget *target )
    // We should consider removing this and making it the
    // responsibility of the caller to set a proper viewport
    // when the target is changed.   
-   setViewport( RectI( Point2I::Zero, mCurrentRT->getSize() ) );
+   if ( updateViewport )
+   {
+      setViewport( RectI( Point2I::Zero, mCurrentRT->getSize() ) );
+   }
 }
 
 /// Helper class for GFXDevice::describeResources.

--- a/Engine/source/gfx/gfxDevice.h
+++ b/Engine/source/gfx/gfxDevice.h
@@ -695,7 +695,7 @@ public:
    void popActiveRenderTarget();
 
    /// Assign a new active render target.
-   void setActiveRenderTarget( GFXTarget *target );
+   void setActiveRenderTarget( GFXTarget *target, bool updateViewport=true );
 
    /// Returns the current active render target.
    inline GFXTarget* getActiveRenderTarget() { return mCurrentRT; }

--- a/Engine/source/postFx/postEffectCommon.h
+++ b/Engine/source/postFx/postEffectCommon.h
@@ -77,6 +77,10 @@ enum PFXTargetViewport
 
    /// Use the current GFX viewport
    PFXTargetViewport_GFXViewport,
+
+   /// Use the input texture 0 if it is named, otherwise
+   /// revert to PFXTargetViewport_TargetSize if there is none
+   PFXTargetViewport_NamedInTexture0,
 };
 
 DefineEnumType( PFXTargetViewport );

--- a/Templates/Empty/game/core/scripts/client/postFx/ssao.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/ssao.cs
@@ -190,7 +190,7 @@ singleton PostEffect( SSAOPostFx )
    
    target = "$outTex";
    targetScale = "0.5 0.5";
-   targetViewport = "PFXTargetViewport_GFXViewport";
+   targetViewport = "PFXTargetViewport_NamedInTexture0";
    
    singleton PostEffect()
    {

--- a/Templates/Full/game/core/scripts/client/postFx/ssao.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/ssao.cs
@@ -190,7 +190,7 @@ singleton PostEffect( SSAOPostFx )
    
    target = "$outTex";
    targetScale = "0.5 0.5";
-   targetViewport = "PFXTargetViewport_GFXViewport";
+   targetViewport = "PFXTargetViewport_NamedInTexture0";
    
    singleton PostEffect()
    {


### PR DESCRIPTION
- Added an option for a postFX to get its viewport from a named texture
  in slot 0, if there is one.  This allows the postFX to operate when the
  named input texture's viewport is different than the current viewport.
- Modified the SSAO postFX to use the new
  PFXTargetViewport_NamedInTexture0 option to more closely link SSAO with
  the prepass buffer.
- Modifed the GFX method setActiveRenderTarget() with a new parameter
  that indicates if the current viewport should be modified with the new
  rendering target.  This defaults to true to maintain its previous
  behaviour.  The postFX rendering pipeline sets this to false as it now
  handles its own viewport setup, and removes an unnecessary
  GFX->setViewport() call.
