### PR TITLE
Frustum Comparison Fix

### DIFF
--- a/Engine/source/math/util/frustum.h
+++ b/Engine/source/math/util/frustum.h
@@ -284,7 +284,10 @@ class Frustum : public PolyhedronImpl< FrustumData >
             ( mNearTop == frustum.mNearTop ) &&
             ( mNearBottom == frustum.mNearBottom ) &&
             ( mNearDist == frustum.mNearDist ) &&
-            ( mFarDist == frustum.mFarDist ) );
+            ( mFarDist == frustum.mFarDist ) &&
+            ( mProjectionOffset.x == frustum.mProjectionOffset.x ) &&
+            ( mProjectionOffset.y == frustum.mProjectionOffset.y ) );
+
       }
       bool operator!=( const Frustum& frustum ) const { return !( *this == frustum ); }
 


### PR DESCRIPTION
- Frustum comparison now includes comparing the projection offset.
- Fixes objects that only set the projection matrix if the frustum has
  changed during side-by-side rendering, such as the WaterPlane.
