### PR TITLE
Turbulence respects viewport and projection offset

### DIFF
--- a/Engine/source/postFx/postEffect.h
+++ b/Engine/source/postFx/postEffect.h
@@ -118,6 +118,8 @@ protected:
 
    GFXShaderConstHandle *mViewportOffsetSC;
 
+   GFXShaderConstHandle *mTargetViewportSC;
+
    GFXShaderConstHandle *mFogDataSC;
    GFXShaderConstHandle *mFogColorSC;
    GFXShaderConstHandle *mEyePosSC;
@@ -127,6 +129,7 @@ protected:
    GFXShaderConstHandle *mNearFarSC;
    GFXShaderConstHandle *mInvNearFarSC;   
    GFXShaderConstHandle *mWorldToScreenScaleSC;
+   GFXShaderConstHandle *mProjectionOffsetSC;
    GFXShaderConstHandle *mWaterColorSC;
    GFXShaderConstHandle *mWaterFogDataSC;     
    GFXShaderConstHandle *mAmbientColorSC;

--- a/Templates/Empty/game/core/scripts/client/postFx/turbulence.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/turbulence.cs
@@ -35,7 +35,6 @@ singleton ShaderData( PFX_TurbulenceShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/turbulenceP.hlsl";
            
-   samplerNames[0] = "$inputTex";            
    pixVersion = 3.0;
 };
 
@@ -45,8 +44,9 @@ singleton PostEffect( TurbulenceFx )
    isEnabled = false;    
    allowReflectPass = true;  
          
-   renderTime = "PFXAfterDiffuse";  
-   renderBin = "ObjTranslucentBin";     
+   renderTime = "PFXAfterBin";
+   renderBin = "GlowBin";
+   renderPriority = 10; // Render after the glows themselves
      
    shader = PFX_TurbulenceShader;  
    stateBlock=PFX_TurbulenceStateBlock;

--- a/Templates/Empty/game/shaders/common/postFx/turbulenceP.hlsl
+++ b/Templates/Empty/game/shaders/common/postFx/turbulenceP.hlsl
@@ -23,13 +23,20 @@
 #include "./postFx.hlsl"
 
 uniform float  accumTime;
+uniform float2 projectionOffset;
+uniform float4 targetViewport;
 
 float4 main( PFXVertToPix IN, uniform sampler2D inputTex : register(S0) ) : COLOR
 {
 	float speed = 2.0;
 	float distortion = 6.0;
 	
-	float y = IN.uv0.y + (cos(IN.uv0.y * distortion + accumTime * speed) * 0.01);
-    float x = IN.uv0.x + (sin(IN.uv0.x * distortion + accumTime * speed) * 0.01);
+	float y = IN.uv0.y + (cos((IN.uv0.y+projectionOffset.y) * distortion + accumTime * speed) * 0.01);
+   float x = IN.uv0.x + (sin((IN.uv0.x+projectionOffset.x) * distortion + accumTime * speed) * 0.01);
+
+   // Clamp the calculated uv values to be within the target's viewport
+	y = clamp(y, targetViewport.y, targetViewport.w);
+	x = clamp(x, targetViewport.x, targetViewport.z);
+	
     return tex2D (inputTex, float2(x, y));
 }

--- a/Templates/Full/game/core/scripts/client/postFx/turbulence.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/turbulence.cs
@@ -35,7 +35,6 @@ singleton ShaderData( PFX_TurbulenceShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/turbulenceP.hlsl";
            
-   samplerNames[0] = "$inputTex";   
    pixVersion = 3.0;
 };
 
@@ -45,8 +44,9 @@ singleton PostEffect( TurbulenceFx )
    isEnabled = false;    
    allowReflectPass = true;  
          
-   renderTime = "PFXAfterDiffuse";  
-   renderBin = "ObjTranslucentBin";     
+   renderTime = "PFXAfterBin";
+   renderBin = "GlowBin";
+   renderPriority = 10; // Render after the glows themselves
      
    shader = PFX_TurbulenceShader;  
    stateBlock=PFX_TurbulenceStateBlock;

--- a/Templates/Full/game/shaders/common/postFx/turbulenceP.hlsl
+++ b/Templates/Full/game/shaders/common/postFx/turbulenceP.hlsl
@@ -23,13 +23,20 @@
 #include "./postFx.hlsl"
 
 uniform float  accumTime;
+uniform float2 projectionOffset;
+uniform float4 targetViewport;
 
 float4 main( PFXVertToPix IN, uniform sampler2D inputTex : register(S0) ) : COLOR
 {
 	float speed = 2.0;
 	float distortion = 6.0;
 	
-	float y = IN.uv0.y + (cos(IN.uv0.y * distortion + accumTime * speed) * 0.01);
-    float x = IN.uv0.x + (sin(IN.uv0.x * distortion + accumTime * speed) * 0.01);
+	float y = IN.uv0.y + (cos((IN.uv0.y+projectionOffset.y) * distortion + accumTime * speed) * 0.01);
+   float x = IN.uv0.x + (sin((IN.uv0.x+projectionOffset.x) * distortion + accumTime * speed) * 0.01);
+
+   // Clamp the calculated uv values to be within the target's viewport
+	y = clamp(y, targetViewport.y, targetViewport.w);
+	x = clamp(x, targetViewport.x, targetViewport.z);
+	
     return tex2D (inputTex, float2(x, y));
 }


### PR DESCRIPTION
- PostEffect class now offers the current projection offset and target viewport as shader constants.
- Turbulence postFX now takes the current projection offset into account.
- Turbulence postFX now clamps itself to the current viewport.
- Turbulence postFX now renders after the glow bin, specifically after the glow postFX renders.  This ensures that it can take advantage of knowing the current viewport rather than affecting the entire render target.
