### PR TITLE
Default value for WaterFogData plane distance

### DIFF
--- a/Engine/source/scene/fogStructs.h
+++ b/Engine/source/scene/fogStructs.h
@@ -59,7 +59,7 @@ struct WaterFogData
       wetDepth = 0.0f;
       wetDarkening = 0.0f;
       color.set( 0.5f, 0.5f, 0.5f, 1.0f );
-      plane.set( 0.0f, 0.0f, 1.0f );
+      plane.set( 0.0f, 0.0f, 1.0f, 1e10 ); // Default to global bounds distance
       depthGradMax = 0.0f;
    }
 };


### PR DESCRIPTION
Set the default WaterFogData plane distance to be the same as global bounds.  This solves an issue with the connection's control object mistakenly thinking it is under a water plane when there are no water objects in the scene.
