### PR TITLE
Underwater Fixes

### DIFF
--- a/Templates/Empty/game/core/scripts/client/postFx/caustics.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/caustics.cs
@@ -20,7 +20,6 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-
 singleton GFXStateBlockData( PFX_CausticsStateBlock : PFX_DefaultStateBlock )
 {
    blendDefined = true;
@@ -42,16 +41,11 @@ singleton ShaderData( PFX_CausticsShader )
    //OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
    //OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
       
-   samplerNames[0] = "$prepassTex";
-   samplerNames[1] = "$causticsTex1";
-   samplerNames[2] = "$causticsTex2";
-   
    pixVersion = 3.0;
 };
 
 singleton PostEffect( CausticsPFX )
 {
-   requirements = "None";
    isEnabled = false;
    renderTime = "PFXBeforeBin";
    renderBin = "ObjTranslucentBin";      
@@ -63,17 +57,4 @@ singleton PostEffect( CausticsPFX )
    texture[1] = "textures/caustics_1";
    texture[2] = "textures/caustics_2";
    target = "$backBuffer";
-   
 };
-
-// this effects the timing of the animation -
-
-$CausticsPFX::refTime = getSimTime();
-
-function CausticsPFX::setShaderConsts(%this)
-{
-   //echo($Sim::time - %this.timeStart);
-   //echo(%this.timeConst);
-   %this.setShaderConst( "$refTime", $CausticsPFX::refTime ); 
-}
-

--- a/Templates/Empty/game/core/scripts/client/postFx/fog.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/fog.cs
@@ -117,3 +117,16 @@ singleton PostEffect( UnderwaterFogPostFx )
    isEnabled = true;
 };
 
+function UnderwaterFogPostFx::onEnabled( %this )
+{
+   TurbulenceFx.enable();
+   CausticsPFX.enable();
+   return true;
+}
+
+function UnderwaterFogPostFx::onDisabled( %this )
+{
+   TurbulenceFx.disable();
+   CausticsPFX.disable();
+   return false;
+}

--- a/Templates/Empty/game/core/scripts/client/postFx/turbulence.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/turbulence.cs
@@ -40,34 +40,14 @@ singleton ShaderData( PFX_TurbulenceShader )
 
 singleton PostEffect( TurbulenceFx )  
 {  
-   requirements = "None";
    isEnabled = false;    
    allowReflectPass = true;  
          
    renderTime = "PFXAfterBin";
    renderBin = "GlowBin";
-   renderPriority = 10; // Render after the glows themselves
+   renderPriority = 0.5; // Render after the glows themselves
      
    shader = PFX_TurbulenceShader;  
    stateBlock=PFX_TurbulenceStateBlock;
    texture[0] = "$backBuffer";      
-      
-   renderPriority = 0.1;  
  };
-
-function TurbulenceFx::setShaderConsts(%this)
-{
-   %this.setShaderConst(%this.timeConst, $Sim::time - %this.timeStart); 
-}
-
-function UnderwaterFogPostFx::onEnabled( %this )
-{
-   TurbulenceFx.enable();
-   return true;
-}
-
-function UnderwaterFogPostFx::onDisabled( %this )
-{
-   TurbulenceFx.disable();
-   return false;
-}

--- a/Templates/Empty/game/shaders/common/postFx/underwaterFogP.hlsl
+++ b/Templates/Empty/game/shaders/common/postFx/underwaterFogP.hlsl
@@ -132,7 +132,7 @@ float4 main( PFXVertToPix IN ) : COLOR
    inColor.rgb *= 1.0 - saturate( abs( planeDist ) / WET_DEPTH ) * WET_DARKENING;
    //return float4( inColor, 1 );
    
-   float3 outColor = lerp( inColor, fogColor, fogAmt );
+   float3 outColor = lerp( inColor, fogColor.rgb, fogAmt );
    
    return float4( hdrEncode( outColor ), 1 );        
 }

--- a/Templates/Full/game/core/scripts/client/postFx/caustics.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/caustics.cs
@@ -41,16 +41,11 @@ singleton ShaderData( PFX_CausticsShader )
    //OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
    //OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
       
-   samplerNames[0] = "$prepassTex";
-   samplerNames[1] = "$causticsTex1";
-   samplerNames[2] = "$causticsTex2";
-   
    pixVersion = 3.0;
 };
 
 singleton PostEffect( CausticsPFX )
 {
-   requirements = "None";
    isEnabled = false;
    renderTime = "PFXBeforeBin";
    renderBin = "ObjTranslucentBin";      
@@ -62,17 +57,4 @@ singleton PostEffect( CausticsPFX )
    texture[1] = "textures/caustics_1";
    texture[2] = "textures/caustics_2";
    target = "$backBuffer";
-   
 };
-
-// this effects the timing of the animation -
-
-$CausticsPFX::refTime = getSimTime();
-
-function CausticsPFX::setShaderConsts(%this)
-{
-   //echo($Sim::time - %this.timeStart);
-   //echo(%this.timeConst);
-   %this.setShaderConst( "$refTime", $CausticsPFX::refTime ); 
-}
-

--- a/Templates/Full/game/core/scripts/client/postFx/fog.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/fog.cs
@@ -117,3 +117,16 @@ singleton PostEffect( UnderwaterFogPostFx )
    isEnabled = true;
 };
 
+function UnderwaterFogPostFx::onEnabled( %this )
+{
+   TurbulenceFx.enable();
+   CausticsPFX.enable();
+   return true;
+}
+
+function UnderwaterFogPostFx::onDisabled( %this )
+{
+   TurbulenceFx.disable();
+   CausticsPFX.disable();
+   return false;
+}

--- a/Templates/Full/game/core/scripts/client/postFx/turbulence.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/turbulence.cs
@@ -40,34 +40,14 @@ singleton ShaderData( PFX_TurbulenceShader )
 
 singleton PostEffect( TurbulenceFx )  
 {  
-   requirements = "None";
    isEnabled = false;    
    allowReflectPass = true;  
          
    renderTime = "PFXAfterBin";
    renderBin = "GlowBin";
-   renderPriority = 10; // Render after the glows themselves
+   renderPriority = 0.5; // Render after the glows themselves
      
    shader = PFX_TurbulenceShader;  
    stateBlock=PFX_TurbulenceStateBlock;
    texture[0] = "$backBuffer";      
-      
-   renderPriority = 0.1;  
  };
-
-function TurbulenceFx::setShaderConsts(%this)
-{
-   %this.setShaderConst(%this.timeConst, $Sim::time - %this.timeStart); 
-}
-
-function UnderwaterFogPostFx::onEnabled( %this )
-{
-   TurbulenceFx.enable();
-   return true;
-}
-
-function UnderwaterFogPostFx::onDisabled( %this )
-{
-   TurbulenceFx.disable();
-   return false;
-}

--- a/Templates/Full/game/shaders/common/postFx/underwaterFogP.hlsl
+++ b/Templates/Full/game/shaders/common/postFx/underwaterFogP.hlsl
@@ -132,7 +132,7 @@ float4 main( PFXVertToPix IN ) : COLOR
    inColor.rgb *= 1.0 - saturate( abs( planeDist ) / WET_DEPTH ) * WET_DARKENING;
    //return float4( inColor, 1 );
    
-   float3 outColor = lerp( inColor, fogColor, fogAmt );
+   float3 outColor = lerp( inColor, fogColor.rgb, fogAmt );
    
    return float4( hdrEncode( outColor ), 1 );        
 }


### PR DESCRIPTION
- Caustics now respects the passed in water plane rather than assume that the water plane is on the XY plane.  This allows for caustics to work for steep rivers.
- Fixed lerp() warning in underwaterFogP.hlsl.
- Cleaned up turbulence and caustics PostEffect scripts to remove unused items.
- Caustics are now enabled and disabled based on the control object being underwater, just like turbulence.  Moved this code to fog.cs to be with the underwater postFX.
