### PR TITLE
Fix for DTS Vertex Paint and 2nd UV with LODs

### DIFF
--- a/Engine/source/ts/tsShape.cpp
+++ b/Engine/source/ts/tsShape.cpp
@@ -1177,6 +1177,11 @@ void TSShape::assembleShape()
       {
          TSMesh::smVertsList[i]  = mesh->verts.address();
          TSMesh::smTVertsList[i] = mesh->tverts.address();
+         if (smReadVersion >= 26)
+         {
+            TSMesh::smTVerts2List[i] = mesh->tverts2.address();
+            TSMesh::smColorsList[i] = mesh->colors.address();
+         }
          TSMesh::smNormsList[i]  = mesh->norms.address();
          TSMesh::smEncodedNormsList[i] = mesh->encodedNorms.address();
          TSMesh::smDataCopied[i] = !skip; // as long as we didn't skip this mesh, the data should be in shape now


### PR DESCRIPTION
Fix came from https://github.com/GarageGames/Torque3D/issues/230

Only the first suggested fix in Bank's thread was applied.  The suggested fixes further in the thread appear to be within an if() block that would only execute for older DTS shapes (version < 23) that could never have a 2nd UV set or vertex paint.

Original thread: http://www.garagegames.com/community/forums/viewthread/130594
