### PR TITLE
Fix for ArrayObject sorting

### DIFF
--- a/Engine/source/console/arrayObject.cpp
+++ b/Engine/source/console/arrayObject.cpp
@@ -76,7 +76,7 @@ S32 QSORT_CALLBACK ArrayObject::_valueNumCompare( const void* a, const void* b )
    F32 bCol = dAtof(eb->value);
    F32 result = aCol - bCol;
    S32 res = result < 0 ? -1 : (result > 0 ? 1 : 0);
-   return ( smDecreasing ? res : -res );
+   return ( smDecreasing ? -res : res );
 }
 
 S32 QSORT_CALLBACK ArrayObject::_keyCompare( const void* a, const void* b )
@@ -95,7 +95,7 @@ S32 QSORT_CALLBACK ArrayObject::_keyNumCompare( const void* a, const void* b )
    const char* bCol = eb->key;
    F32 result = dAtof(aCol) - dAtof(bCol);
    S32 res = result < 0 ? -1 : (result > 0 ? 1 : 0);
-   return ( smDecreasing ? res : -res );
+   return ( smDecreasing ? -res : res );
 }
 
 S32 QSORT_CALLBACK ArrayObject::_keyFunctionCompare( const void* a, const void* b )
@@ -110,7 +110,7 @@ S32 QSORT_CALLBACK ArrayObject::_keyFunctionCompare( const void* a, const void* 
    
    S32 result = dAtoi( Con::execute( 3, argv ) );
    S32 res = result < 0 ? -1 : ( result > 0 ? 1 : 0 );
-   return ( smDecreasing ? res : -res );
+   return ( smDecreasing ? -res : res );
 }
 
 S32 QSORT_CALLBACK ArrayObject::_valueFunctionCompare( const void* a, const void* b )
@@ -125,7 +125,7 @@ S32 QSORT_CALLBACK ArrayObject::_valueFunctionCompare( const void* a, const void
    
    S32 result = dAtoi( Con::execute( 3, argv ) );
    S32 res = result < 0 ? -1 : ( result > 0 ? 1 : 0 );
-   return ( smDecreasing ? res : -res );
+   return ( smDecreasing ? -res : res );
 }
 
 


### PR DESCRIPTION
- This is a fix for issue https://github.com/GarageGames/Torque3D/issues/228
- This fixes sortna() and sortnd() as outlined in the issue.
- This also fixes sortnka() and sortnkd(), as well as the sorting methods that take a console function as a parameter.
