### PR TITLE
Support graphic cards with 2GB+ VRAM

### DIFF
--- a/Engine/source/gfx/gfxCardProfile.cpp
+++ b/Engine/source/gfx/gfxCardProfile.cpp
@@ -106,6 +106,7 @@ void GFXCardProfiler::init()
    Con::printf("   o Chipset : '%s'", getChipString().c_str());
    Con::printf("   o Card    : '%s'", getCardString().c_str());
    Con::printf("   o Version : '%s'", getVersionString().c_str());
+   Con::printf("   o VRAM    : %d MB", getVideoMemoryInMB());
 
    // Do card-specific setup...
    Con::printf("   - Scanning card capabilities...");

--- a/Engine/source/platformWin32/videoInfo/wmiVideoInfo.cpp
+++ b/Engine/source/platformWin32/videoInfo/wmiVideoInfo.cpp
@@ -568,9 +568,20 @@ bool WMIVideoInfo::_queryPropertyWMI( const PVIQueryType queryType, const U32 ad
             LONG longVal = v.lVal;
 
             if( queryType == PVI_VRAM )
+            {
                longVal = longVal >> 20; // Convert to megabytes
 
-            *outValue = String::ToString( (S32)longVal );
+               // While this value is reported as a signed integer, it is possible
+               // for video cards to have 2GB or more.  In those cases the signed
+               // bit is set and will give us a negative number.  Treating this
+               // as unsigned will allows us to handle video cards with up to
+               // 4GB of memory.  After that we'll need a new solution from Microsoft.
+               *outValue = String::ToString( (U32)longVal );
+            }
+            else
+            {
+               *outValue = String::ToString( (S32)longVal );
+            }
             break;
          }
 


### PR DESCRIPTION
- Fix for issue https://github.com/GarageGames/Torque3D/issues/226
- Also extended the card profile reporting to the console to include the graphic card's VRAM.
