### PR TITLE
Added a default keyboard layout for launching the game.

### DIFF
--- a/Engine/source/platform/platformInput.h
+++ b/Engine/source/platform/platformInput.h
@@ -118,6 +118,9 @@ public:
 
    static U8 getModifierKeys() {return smModifierKeys;}
    static void setModifierKeys(U8 mod) {smModifierKeys = mod;}
+
+   static void attemptSwitchToKeyboardLayout( U32 layout );
+
 #ifdef LOG_INPUT
    static void log( const char* format, ... );
 #endif

--- a/Engine/source/platformWin32/winInput.cpp
+++ b/Engine/source/platformWin32/winInput.cpp
@@ -33,6 +33,8 @@
 #include <stdarg.h>
 #endif
 
+#include <sstream>
+
 // Static class variables:
 InputManager*  Input::smManager;
 bool           Input::smActive;
@@ -78,6 +80,10 @@ void Input::init()
    Con::printf( "Input Init:" );
 
    destroy();
+
+#ifdef TORQUE_DEFAULT_KEYBOARD_LAYOUT
+   attemptSwitchToKeyboardLayout( TORQUE_DEFAULT_KEYBOARD_LAYOUT );
+#endif
 
 #ifdef LOG_INPUT
    struct tm* newTime;
@@ -485,6 +491,18 @@ void Input::process()
 InputManager* Input::getManager()
 {
    return( smManager );
+}
+
+//------------------------------------------------------------------------------
+void Input::attemptSwitchToKeyboardLayout( U32 layout )
+{
+   const auto lang = MAKELANGID( layout, SUBLANG_DEFAULT );
+   std::wstringstream ss;
+   ss << std::hex << lang;
+   const auto hexLang = ss.str().c_str();
+   ActivateKeyboardLayout( LoadKeyboardLayout(
+       hexLang,  KLF_ACTIVATE | KLF_REPLACELANG
+   ), KLF_REORDER );
 }
 
 #ifdef LOG_INPUT

--- a/Engine/source/sim/actionMap.cpp
+++ b/Engine/source/sim/actionMap.cpp
@@ -458,8 +458,12 @@ bool ActionMap::createEventDescriptor(const char* pEventString, EventDescriptor*
    }
 
    // Now we need to map the key string to the proper KEY code from event.h
-   //
-   AssertFatal(dStrlen(pObjectString) != 0, "Error, no key was specified!");
+   AssertFatal(
+       dStrlen( pObjectString ) > 0,
+       "Error, no key was specified!\n"
+       "Review file 'scripts/client/config.cs' and remove symbols"
+       " which is not latin. Or delete this file."
+   );
 
    if (dStrlen(pObjectString) == 1)
    {

--- a/Templates/Empty/source/torqueConfig.h
+++ b/Templates/Empty/source/torqueConfig.h
@@ -148,6 +148,13 @@
 /// texture manager.
 #define TORQUE_FRAME_SIZE     16 << 20
 
+// Default keyboard layout for launching the game. It's fixed crash when a
+// game running with the extend unicode keyboard (cyrillic, for example).
+// Windows only.
+// @see For choice language >
+//      http://msdn.microsoft.com/en-us/library/windows/desktop/dd318693%28v=vs.85%29.aspx
+#define TORQUE_DEFAULT_KEYBOARD_LAYOUT  LANG_ENGLISH
+
 // Finally, we define some dependent #defines. This enables some subsidiary
 // functionality to get automatically turned on in certain configurations.
 

--- a/Templates/Full/source/torqueConfig.h
+++ b/Templates/Full/source/torqueConfig.h
@@ -169,6 +169,13 @@
 /// texture manager.
 #define TORQUE_FRAME_SIZE     16 << 20
 
+// Default keyboard layout for launching the game. It's fixed crash when a
+// game running with the extend unicode keyboard (cyrillic, for example).
+// Windows only.
+// @see For choice language >
+//      http://msdn.microsoft.com/en-us/library/windows/desktop/dd318693%28v=vs.85%29.aspx
+#define TORQUE_DEFAULT_KEYBOARD_LAYOUT  LANG_ENGLISH
+
 // Finally, we define some dependent #defines. This enables some subsidiary
 // functionality to get automatically turned on in certain configurations.
 


### PR DESCRIPTION
It's fixed crash when a game running with the extend unicode keyboard (cyrillic, for example).

**How repeat**
1. Choose language with unicode charset (Russian, for example).
2. Run Torque, choice Options.
3. Result:
   ![image](https://f.cloud.github.com/assets/311074/1663873/260691ba-5c1e-11e3-8f24-62e3111d6b30.png)
   ![image](https://f.cloud.github.com/assets/311074/1663876/347135e8-5c1e-11e3-85db-ac4dce7ffb4b.png)

After any restart Torque3D:
![image](https://f.cloud.github.com/assets/311074/1663880/440a942c-5c1e-11e3-9652-a87261d9cce3.png)

**Solution**
Remove 'scripts/client/config.cs'... or accept this patch.

Win8, VC2010
