### PR TITLE
Adds mViewport to guiTSControl in order to restrict render viewport to a...

### DIFF
--- a/Engine/source/gui/3d/guiTSControl.h
+++ b/Engine/source/gui/3d/guiTSControl.h
@@ -62,6 +62,8 @@ protected:
    /// most likely rendering.
    static Vector<GuiTSCtrl*> smAwakeTSCtrls;
 
+	RectI mViewport;
+
    /// A scalar which controls how much of the reflection
    /// update timeslice for this viewport to get.
    F32 mReflectPriority;
@@ -75,7 +77,7 @@ protected:
    MatrixF     mSaveModelview;
    MatrixF     mSaveProjection;
    RectI       mSaveViewport;
-	Frustum		mSaveFrustum;
+   Frustum	   mSaveFrustum;
    
    /// The saved world to screen space scale.
    /// @see getWorldToScreenScale


### PR DESCRIPTION
... sub-region of the control. This is particularly useful when using a guiTSControl as a container control, as it can restrict the render area to prevent overdraw or dedicate screen space to a panel
