### PR TITLE
More fixes

### DIFF
--- a/Engine/source/T3D/physics/physx/pxMultiActor.cpp
+++ b/Engine/source/T3D/physics/physx/pxMultiActor.cpp
@@ -527,7 +527,7 @@ bool PxMultiActorData::preload( bool server, String &errorBuffer )
       return false;
    }
 
-   if (!shapeName || shapeName == '\0')
+   if (!shapeName || shapeName[0] == '\0')
    {
       errorBuffer = "PxMultiActorDatas::preload: no shape name!";
       return false;

--- a/Engine/source/environment/meshRoad.cpp
+++ b/Engine/source/environment/meshRoad.cpp
@@ -1074,7 +1074,7 @@ void MeshRoad::unpackUpdate(NetConnection * con, BitStream * stream)
          stream->read( &mMaterialName[i] );
         
          if ( !Sim::findObject( mMaterialName[i], pMat ) )
-            Con::printf( "DecalRoad::unpackUpdate, failed to find Material of name &s!", mMaterialName[i].c_str() );
+            Con::printf( "DecalRoad::unpackUpdate, failed to find Material of name %s", mMaterialName[i].c_str() );
          else         
             mMaterial[i] = pMat;         
       }

--- a/Engine/source/environment/skyBox.cpp
+++ b/Engine/source/environment/skyBox.cpp
@@ -400,7 +400,11 @@ void SkyBox::_initRender()
    }
 
    GFXVertexPNTT *vertPtr = mVB.lock();
-   if(!vertPtr) return;
+   if (!vertPtr)
+   {
+      delete[] tmpVerts;
+      return;
+   }
 
    dMemcpy( vertPtr, tmpVerts, sizeof ( GFXVertexPNTT ) * vertCount );
 

--- a/Engine/source/gfx/gfxFormatUtils.cpp
+++ b/Engine/source/gfx/gfxFormatUtils.cpp
@@ -81,7 +81,7 @@ void GFXCopyPixels(  GFXFormat fromFormat, U32 fromWidth, U32 fromHeight, U8* fr
 {
    if( fromFormat == toFormat
        && fromWidth == toWidth
-       && fromHeight == fromHeight )
+       && fromHeight == toHeight )
       dMemcpy( toData, fromData, fromWidth * fromHeight * GFXFormatInfo( fromFormat ).getBytesPerPixel() );
    else
    {


### PR DESCRIPTION
- check for an empty shapeName, not just a NULL one twice
- fix "&s" in printf
- fix potential memory leak
- GFXCopyPixels wasn't checking the height properly which could result in some memory corruption unpleasantness
