### PR TITLE
Seamless terrain.

### DIFF
--- a/Engine/source/terrain/terrCell.cpp
+++ b/Engine/source/terrain/terrCell.cpp
@@ -140,6 +140,7 @@ void TerrCell::createPrimBuffer( GFXPrimitiveBufferHandle *primBuffer )
       }
    }
 
+#if 1
    // Now add indices for the 'skirts'.
    // These could probably be reduced to a loop.
 
@@ -262,6 +263,7 @@ void TerrCell::createPrimBuffer( GFXPrimitiveBufferHandle *primBuffer )
       maxIndex = b1;
       counter += 6;
    }
+#endif
 
    primBuffer->unlock();
 }
@@ -428,47 +430,54 @@ void TerrCell::_updateVertexBuffer()
    mVertexBuffer.set( GFX, smVBSize, GFXBufferTypeStatic );
 
    const F32 squareSize = mTerrain->getSquareSize();
-   const U32 blockSize = mTerrain->getBlockSize();
-   const U32 stepSize = mSize / smMinCellSize;
+   const U32 blockSize  = mTerrain->getBlockSize();
+   const U32 stepSize   = mSize / smMinCellSize;
 
    U32 vbcounter = 0;
 
    TerrVertex *vert = mVertexBuffer.lock();
 
-   Point2I gridPt;
-   Point2F point;
-   F32 height;
-   Point3F normal;   
-   
    const TerrainFile *file = mTerrain->getFile();
 
+   Point2I gridPt = Point2I::Zero;
    for ( U32 y = 0; y < smVBStride; y++ )
    {
+      gridPt.y = mPoint.y + y * stepSize;
       for ( U32 x = 0; x < smVBStride; x++ )
       {
          // We clamp here to keep the geometry from reading across
          // one side of the height map to the other causing walls
          // around the edges of the terrain.
-         gridPt.x = mClamp( mPoint.x + x * stepSize, 0, blockSize - 1 );
-         gridPt.y = mClamp( mPoint.y + y * stepSize, 0, blockSize - 1 );
+         gridPt.x = mPoint.x + x * stepSize;
+
+         // Corrected calc the position for height.
+         const Point2I  p(
+            (gridPt.x < blockSize) ? gridPt.x : (blockSize - 1),
+            (gridPt.y < blockSize) ? gridPt.y : (blockSize - 1)
+         );
+         F32 height;
+         file->getHeight( &height, p );
 
          // Setup this point.
-         point.x = (F32)gridPt.x * squareSize;
-         point.y = (F32)gridPt.y * squareSize;
-         height = fixedToFloat( file->getHeight( gridPt.x, gridPt.y ) );
-         vert->point.x = point.x;
-         vert->point.y = point.y;
+         vert->point.x = (F32)gridPt.x * squareSize;
+         vert->point.y = (F32)gridPt.y * squareSize;
          vert->point.z = height;
 
          // Get the normal.
-         mTerrain->getSmoothNormal( point, &normal, true, false );
-         vert->normal = normal;
+         const Point2F pn(
+            (F32)p.x * squareSize,
+            (F32)p.y * squareSize
+         );
+         mTerrain->getSmoothNormal( pn, &vert->normal, true, false );
 
          // Get the tangent z.
-         vert->tangentZ = fixedToFloat( file->getHeight( gridPt.x + 1, gridPt.y ) ) - height;
+         const Point2I  p1( p.x + 1, p.y );
+         F32 height1;
+         file->getHeight( &height1, p1 );
+         vert->tangentZ = height1 - height;
 
          // Test the empty state for this vert.
-         if ( file->isEmptyAt( gridPt.x, gridPt.y ) )
+         if ( file->isEmptyAt( p.x, p.y ) )
          {
             mHasEmpty = true;
             mEmptyVertexList.push_back( vbcounter );
@@ -479,9 +488,13 @@ void TerrCell::_updateVertexBuffer()
       }
    }
 
+#if 1
    // Add verts for 'skirts' around/beneath the edge verts of this cell.
    // This could probably be reduced to a loop...
    
+   Point2F point  = Point2F::Zero;
+   Point3F normal = Point3F::Zero;
+
    const F32 skirtDepth = mSize / smMinCellSize * mTerrain->getSquareSize();
 
    // Top edge skirt
@@ -492,7 +505,7 @@ void TerrCell::_updateVertexBuffer()
       
       point.x = (F32)gridPt.x * squareSize;
       point.y = (F32)gridPt.y * squareSize;
-      height = fixedToFloat( file->getHeight( gridPt.x, gridPt.y ) );
+      const F32 height = fixedToFloat( file->getHeight( gridPt.x, gridPt.y ) );
       vert->point.x = point.x;
       vert->point.y = point.y;
       vert->point.z = height - skirtDepth;
@@ -516,7 +529,7 @@ void TerrCell::_updateVertexBuffer()
 
       point.x = (F32)gridPt.x * squareSize;
       point.y = (F32)gridPt.y * squareSize;
-      height = fixedToFloat( file->getHeight( gridPt.x, gridPt.y ) );
+      const F32 height = fixedToFloat( file->getHeight( gridPt.x, gridPt.y ) );
       vert->point.x = point.x;
       vert->point.y = point.y;
       vert->point.z = height - skirtDepth;
@@ -540,7 +553,7 @@ void TerrCell::_updateVertexBuffer()
 
       point.x = (F32)gridPt.x * squareSize;
       point.y = (F32)gridPt.y * squareSize;
-      height = fixedToFloat( file->getHeight( gridPt.x, gridPt.y ) );
+      const F32 height = fixedToFloat( file->getHeight( gridPt.x, gridPt.y ) );
       vert->point.x = point.x;
       vert->point.y = point.y;
       vert->point.z = height - skirtDepth;
@@ -564,7 +577,7 @@ void TerrCell::_updateVertexBuffer()
 
       point.x = (F32)gridPt.x * squareSize;
       point.y = (F32)gridPt.y * squareSize;
-      height = fixedToFloat( file->getHeight( gridPt.x, gridPt.y ) );
+      const F32 height = fixedToFloat( file->getHeight( gridPt.x, gridPt.y ) );
       vert->point.x = point.x;
       vert->point.y = point.y;
       vert->point.z = height - skirtDepth;
@@ -579,8 +592,8 @@ void TerrCell::_updateVertexBuffer()
       vbcounter++;
       ++vert;      
    }
+#endif
 
-   AssertFatal( vbcounter == smVBSize, "bad" );
    mVertexBuffer.unlock();
 }
 
@@ -664,6 +677,7 @@ void TerrCell::_updatePrimitiveBuffer()
       }
    }
 
+#if 1
    // Now add indices for the 'skirts'.
    // These could probably be reduced to a loop.
 
@@ -818,6 +832,7 @@ void TerrCell::_updatePrimitiveBuffer()
 
       mTriCount += 2;
    }
+#endif
 
    mPrimBuffer.unlock();
    prim->numPrimitives = mTriCount;
@@ -827,27 +842,33 @@ void TerrCell::_updateMaterials()
 {
    PROFILE_SCOPE( TerrCell_UpdateMaterials );
 
+   const U32 blockSize = mTerrain->getBlockSize();
+
    // This should really only be called for cells of smMinCellSize,
    // in which case stepSize is always one.
-   U32 stepSize = mSize / smMinCellSize;
+   const U32 stepSize = mSize / smMinCellSize;
    mMaterials = 0;
-   U8 index;
-   U32 x, y;
 
    const TerrainFile *file = mTerrain->getFile();
 
    // Step thru the samples in the map then.
-   for ( y = 0; y < smVBStride; y++ )
+   // Calc 'gridPt' by analogy with _updateVertexBuffer().
+   Point2I  gridPt = Point2I::Zero;
+   for ( U32 y = 0; y < smVBStride; y++ )
    {
-      for ( x = 0; x < smVBStride; x++ )
+      gridPt.y = mPoint.y + y * stepSize;
+      for ( U32 x = 0; x < smVBStride; x++ )
       {
-         index = file->getLayerIndex(  mPoint.x + x * stepSize, 
-                                       mPoint.y + y * stepSize );
+         gridPt.x = mPoint.x + x * stepSize;
+         const U32 lx = (gridPt.x < blockSize) ? gridPt.x : (blockSize - 1);
+         const U32 ly = (gridPt.y < blockSize) ? gridPt.y : (blockSize - 1);
+         const U8 index = file->getLayerIndex( lx, ly );
          
          // Skip empty layers and anything that doesn't fit
          // the 64bit material flags.
-         if ( index == U8_MAX || index > 63 )
+         if ( index == U8_MAX || index > 63 ) {
             continue;
+         }
 
          mMaterials |= (U64)(1<<index);
       }

--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -480,10 +480,14 @@ bool TerrainBlock::getHeight( const Point2F &pos, F32 *height ) const
    if ( sq->flags & TerrainSquare::Empty )
       return false;
 
-   F32 zBottomLeft = fixedToFloat( mFile->getHeight( x, y ) );
-   F32 zBottomRight = fixedToFloat( mFile->getHeight( x + 1, y ) );
-   F32 zTopLeft = fixedToFloat( mFile->getHeight( x, y + 1 ) );
-   F32 zTopRight = fixedToFloat( mFile->getHeight( x + 1, y + 1 ) );
+   F32  zBottomLeft, zBottomRight, zTopLeft, zTopRight;
+   mFile->getHeight4(
+      &zBottomLeft, &zBottomRight, &zTopLeft, &zTopRight,
+      Point2I( x, y ),
+      Point2I( x + 1, y ),
+      Point2I( x, y + 1 ),
+      Point2I( x + 1, y + 1 )
+   );
 
    if ( sq->flags & TerrainSquare::Split45 )
    {
@@ -531,10 +535,14 @@ bool TerrainBlock::getNormal( const Point2F &pos, Point3F *normal, bool normaliz
    if ( skipEmpty && sq->flags & TerrainSquare::Empty )
       return false;
 
-   F32 zBottomLeft = fixedToFloat( mFile->getHeight( x, y ) );
-   F32 zBottomRight = fixedToFloat( mFile->getHeight( x + 1, y ) );
-   F32 zTopLeft = fixedToFloat( mFile->getHeight( x, y + 1 ) );
-   F32 zTopRight = fixedToFloat( mFile->getHeight( x + 1, y + 1 ) );
+   F32  zBottomLeft, zBottomRight, zTopLeft, zTopRight;
+   mFile->getHeight4(
+      &zBottomLeft, &zBottomRight, &zTopLeft, &zTopRight,
+      Point2I( x, y ),
+      Point2I( x + 1, y ),
+      Point2I( x, y + 1 ),
+      Point2I( x + 1, y + 1 )
+   );
 
    if ( sq->flags & TerrainSquare::Split45 )
    {
@@ -586,11 +594,14 @@ bool TerrainBlock::getSmoothNormal( const Point2F &pos,
    if ( skipEmpty && sq->flags & TerrainSquare::Empty )
       return false;
 
-   F32 h1 = fixedToFloat( mFile->getHeight( x + 1, y ) );
-   F32 h2 = fixedToFloat( mFile->getHeight( x, y + 1 ) );
-   F32 h3 = fixedToFloat( mFile->getHeight( x - 1, y ) );
-   F32 h4 = fixedToFloat( mFile->getHeight( x, y - 1 ) );
-
+   F32  h1, h2, h3, h4;
+   mFile->getHeight4(
+      &h1, &h2, &h3, &h4,
+      Point2I( x + 1, y     ),
+      Point2I( x,     y + 1 ),
+      Point2I( x - 1, y     ),
+      Point2I( x,     y - 1 )
+   );
    normal->set( h3 - h1, h4 - h2, mSquareSize * 2.0f );
 
    if ( normalize )
@@ -623,10 +634,14 @@ bool TerrainBlock::getNormalAndHeight( const Point2F &pos, Point3F *normal, F32 
    if ( sq->flags & TerrainSquare::Empty )
       return false;
 
-   F32 zBottomLeft  = fixedToFloat( mFile->getHeight(x, y) );
-   F32 zBottomRight = fixedToFloat( mFile->getHeight(x + 1, y) );
-   F32 zTopLeft     = fixedToFloat( mFile->getHeight(x, y + 1) );
-   F32 zTopRight    = fixedToFloat( mFile->getHeight(x + 1, y + 1) );
+   F32  zBottomLeft, zBottomRight, zTopLeft, zTopRight;
+   mFile->getHeight4(
+      &zBottomLeft, &zBottomRight, &zTopLeft, &zTopRight,
+      Point2I( x, y ),
+      Point2I( x + 1, y ),
+      Point2I( x, y + 1 ),
+      Point2I( x + 1, y + 1 )
+   );
 
    if ( sq->flags & TerrainSquare::Split45 )
    {
@@ -695,10 +710,14 @@ bool TerrainBlock::getNormalHeightMaterial(  const Point2F &pos,
    if ( sq->flags & TerrainSquare::Empty )
       return false;
 
-   F32 zBottomLeft  = fixedToFloat( mFile->getHeight(x, y) );
-   F32 zBottomRight = fixedToFloat( mFile->getHeight(x + 1, y) );
-   F32 zTopLeft     = fixedToFloat( mFile->getHeight(x, y + 1) );
-   F32 zTopRight    = fixedToFloat( mFile->getHeight(x + 1, y + 1) );
+   F32  zBottomLeft, zBottomRight, zTopLeft, zTopRight;
+   mFile->getHeight4(
+      &zBottomLeft, &zBottomRight, &zTopLeft, &zTopRight,
+      Point2I( x, y ),
+      Point2I( x + 1, y ),
+      Point2I( x, y + 1 ),
+      Point2I( x + 1, y + 1 )
+   );
 
    matName = mFile->getMaterialName( xm, ym );
 

--- a/Engine/source/terrain/terrFile.h
+++ b/Engine/source/terrain/terrFile.h
@@ -41,6 +41,19 @@ class FileStream;
 class GBitmap;
 
 
+/// Conversion from 11.5 fixed point to floating point.
+inline F32 fixedToFloat( U16 val )
+{
+   return F32(val) * 0.03125f;
+}
+
+/// Conversion from floating point to 11.5 fixed point.
+inline U16 floatToFixed( F32 val )
+{
+   return U16(val * 32.0f + 0.5f);
+}
+
+
 ///
 struct TerrainSquare
 {
@@ -181,6 +194,16 @@ public:
 
    U16 getHeight( U32 x, U32 y ) const;
 
+   void getHeight( F32* h, const Point2I& ) const;
+
+   void getHeight4(
+      F32* a,  F32* b,  F32* c,  F32* d,
+      const Point2I&  pa,
+      const Point2I&  pb,
+      const Point2I&  pc,
+      const Point2I&  pd
+   ) const;
+
    U16 getMaxHeight() const { return mGridMap[mGridLevels]->maxHeight; }
 
    /// Returns the constant heightmap vector.
@@ -191,13 +214,53 @@ public:
 
    /// Check if the given point is valid within the (non-tiled) terrain file.
    bool isPointInTerrain( U32 x, U32 y ) const;
+
+private:
+   // Clamp X and Y to the size of terrain.
+   void clamp( U32* x,  U32* y ) const;
 };
+
+
+// @todo ! Need AssertFatal() and debug all clients.
+// @todo ! Verify all methods of TerrainFile.
+inline void TerrainFile::clamp( U32* x,  U32* y ) const
+{
+#if 0
+   // old clamp
+   *x %= mSize;
+   *y %= mSize;
+#else
+   // new clamp
+   const auto  error = [] ( char c, U32 v ) {
+      static const char* s = "TerrainFile Coord '%c == %d' out of range. Fix it in the algorithm.";
+#if 1
+      // only first error
+      static bool  first = true;
+      if ( first ) {
+         Con::errorf( s,  c, v );
+         first = false;
+      }
+#else
+      // all errors
+      Con::errorf( s,  c, v );
+#endif
+   };
+
+   if (*x >= mSize) {
+      error( 'x', *x );
+      *x = mSize - 1;
+   }
+   if (*y >= mSize) {
+      error( 'y', *y );
+      *y = mSize - 1;
+   }
+#endif
+}
 
 
 inline TerrainSquare* TerrainFile::findSquare( U32 level, U32 x, U32 y ) const
 {
-   x %= mSize;
-   y %= mSize;
+   clamp( &x, &y );
    x >>= level;
    y >>= level;
 
@@ -206,36 +269,54 @@ inline TerrainSquare* TerrainFile::findSquare( U32 level, U32 x, U32 y ) const
 
 inline void TerrainFile::setHeight( U32 x, U32 y, U16 height )
 {
-   x %= mSize;
-   y %= mSize;
+   clamp( &x, &y );
    mHeightMap[ x + ( y * mSize ) ] = height;
 }
 
 inline const U16* TerrainFile::getHeightAddress( U32 x, U32 y ) const
 {
-   x %= mSize;
-   y %= mSize;
+   clamp( &x, &y );
    return &mHeightMap[ x + ( y * mSize ) ];
 }
 
 inline U16 TerrainFile::getHeight( U32 x, U32 y ) const
 {
-   x %= mSize;
-   y %= mSize;
+   clamp( &x, &y );
    return mHeightMap[ x + ( y * mSize ) ];
+}
+
+inline void TerrainFile::getHeight( F32* h,  const Point2I&  p ) const
+{
+   const Point2I pp(
+      mClamp( p.x, 0, mSize - 1 ),
+      mClamp( p.y, 0, mSize - 1 )
+   );
+   *h = fixedToFloat( getHeight( (U32)pp.x, (U32)pp.y ) );
+}
+
+inline void TerrainFile::getHeight4(
+   F32* a,  F32* b,  F32* c,  F32* d,
+   const Point2I&  pa,
+   const Point2I&  pb,
+   const Point2I&  pc,
+   const Point2I&  pd
+) const
+{
+   getHeight( a, pa );
+   getHeight( b, pb );
+   getHeight( c, pc );
+   getHeight( d, pd );
 }
 
 inline U8 TerrainFile::getLayerIndex( U32 x, U32 y ) const
 {
-   x %= mSize;
-   y %= mSize;
+   clamp( &x, &y );
    return mLayerMap[ x + ( y * mSize ) ];
 }
 
 inline void TerrainFile::setLayerIndex( U32 x, U32 y, U8 index )
 {
-   x %= mSize;
-   y %= mSize;
+   clamp( &x, &y );
    mLayerMap[ x + ( y * mSize ) ] = index;
 }
 
@@ -249,27 +330,13 @@ inline BaseMatInstance* TerrainFile::getMaterialMapping( U32 index ) const
 
 inline StringTableEntry TerrainFile::getMaterialName( U32 x, U32 y) const
 {
-   x %= mSize;
-   y %= mSize;
+   clamp( &x, &y );
    const U8 &index = mLayerMap[ x + ( y * mSize ) ];
 
    if ( index < mMaterials.size() )
       return mMaterials[ index ]->getInternalName();
 
    return StringTable->EmptyString();
-}
-
-
-/// Conversion from 11.5 fixed point to floating point.
-inline F32 fixedToFloat( U16 val )
-{
-   return F32(val) * 0.03125f;
-}
-
-/// Conversion from floating point to 11.5 fixed point.
-inline U16 floatToFixed( F32 val )
-{
-   return U16(val * 32.0 + 0.5f);
 }
 
 inline bool TerrainFile::isPointInTerrain( U32 x, U32 y ) const


### PR DESCRIPTION
Heights, sizes and materials on the edges of terrains are corrected.


Before patch (4 terrains)
![image](https://f.cloud.github.com/assets/311074/1994033/62203cc4-84e5-11e3-8fdc-e396d80e1f1d.png)


After patch
![image](https://f.cloud.github.com/assets/311074/1994039/6afc61ba-84e5-11e3-993b-c1c059e3f39e.png)


[Test level](https://drive.google.com/file/d/0B4G7HDT9STV-ZDFrUmg3eDd5eHc/edit?usp=sharing) (extract to the folder 'game/levels/test'). Smart run from the command line
> application.exe -level "test/seamless-terrain/test1.mis"
