### PR TITLE
Fixed Box3F::overlap

### DIFF
--- a/Engine/source/math/mBox.h
+++ b/Engine/source/math/mBox.h
@@ -334,10 +334,18 @@ inline Box3F Box3F::getOverlap( const Box3F& otherBox ) const
    Box3F overlap;
 
    for( U32 i = 0; i < 3; ++ i )
+   {
       if( minExtents[ i ] > otherBox.maxExtents[ i ] || otherBox.minExtents[ i ] > maxExtents[ i ] )
+      {
          overlap.minExtents[ i ] = 0.f;
+         overlap.maxExtents[ i ] = 0.f;
+      }
       else
+      {
          overlap.minExtents[ i ] = getMax( minExtents[ i ], otherBox.minExtents[ i ] );
+         overlap.maxExtents[ i ] = getMin( maxExtents[ i ], otherBox.maxExtents[ i ] );
+      }
+   }
 
    return overlap;
 }


### PR DESCRIPTION
It was previously leaving the maximum extent of the overlap box uninitialised, and therefore was useless. Turns out this function isn't actually used in the codebase at all at the moment, so nothing is broken. It's just nice to have it working if it's there.

(Also, `Box3F::intersect` is incorrectly named. It actually performs a union. Just sayin'.)
