### PR TITLE
Revert trigger polyhedron change

### DIFF
--- a/Engine/source/T3D/trigger.cpp
+++ b/Engine/source/T3D/trigger.cpp
@@ -263,8 +263,8 @@ ConsoleGetType( TypeTriggerPolyhedron )
    dSprintf(retBuf, 1023, "%7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f",
             origin.x, origin.y, origin.z,
             vecs[0].x, vecs[0].y, vecs[0].z,
-            vecs[1].x, vecs[1].y, vecs[1].z,
-			vecs[2].x, vecs[2].y, vecs[2].z);
+            vecs[2].x, vecs[2].y, vecs[2].z,
+            vecs[1].x, vecs[1].y, vecs[1].z);
             
 
    return retBuf;


### PR DESCRIPTION
Reverts the change made in https://github.com/GarageGames/Torque3D/pull/511.  See http://www.garagegames.com/community/forums/viewthread/136033 for the discussion.
