### PR TITLE
RenderInstType default constructor improvements

### DIFF
--- a/Engine/source/renderInstance/renderPassManager.h
+++ b/Engine/source/renderInstance/renderPassManager.h
@@ -65,12 +65,17 @@ protected:
 
 public:  
 
-   RenderInstType( const RenderInstType &type = Invalid ) 
+   RenderInstType()
+      :  mName( Invalid.mName )
+   {
+   }
+
+   RenderInstType( const RenderInstType &type )
       :  mName( type.mName )
    {
    }
 
-   RenderInstType( const String &name ) 
+   RenderInstType( const String &name )
       :  mName( name )
    {
    }


### PR DESCRIPTION
Refactored the constructor to not use a default reference to a static member
