### PR TITLE
revised #568. abs and max.

### DIFF
--- a/Engine/source/lighting/advanced/glsl/advancedLightingFeaturesGLSL.cpp
+++ b/Engine/source/lighting/advanced/glsl/advancedLightingFeaturesGLSL.cpp
@@ -533,7 +533,8 @@ void DeferredPixelSpecularGLSL::processPix(  Vector<ShaderComponent*> &component
    AssertFatal( lightInfoSamp, "Something hosed the deferred features! Can't find lightInfoSample" );
 
    // (a^m)^n = a^(m*n)
-   meta->addStatement( new GenOp( "   @ = pow(d_specular, ceil(@ / @)) * @;\r\n", specDecl, specPow, constSpecPow, specStrength ) );
+   meta->addStatement( new GenOp( "   @ = pow( abs(@), max((@ / AL_ConstantSpecularPower),1.0f)) * @;\r\n", 
+      specDecl, d_specular, specPow, specStrength ) );
 
    LangElement *specMul = new GenOp( "@ * @", specCol, specular );
    LangElement *final = specMul;

--- a/Engine/source/lighting/advanced/hlsl/advancedLightingFeaturesHLSL.cpp
+++ b/Engine/source/lighting/advanced/hlsl/advancedLightingFeaturesHLSL.cpp
@@ -479,7 +479,7 @@ void DeferredPixelSpecularHLSL::processPix(  Vector<ShaderComponent*> &component
       "DeferredPixelSpecularHLSL::processPix - Something hosed the deferred features!" );
 
    // (a^m)^n = a^(m*n)
-   meta->addStatement( new GenOp( "   @ = pow( @, ceil(@ / AL_ConstantSpecularPower)) * @;\r\n", 
+   meta->addStatement( new GenOp( "   @ = pow( abs(@), max((@ / AL_ConstantSpecularPower),1.0f)) * @;\r\n", 
       specDecl, d_specular, specPow, specStrength ) );
 
    LangElement *specMul = new GenOp( "float4( @.rgb, 0 ) * @", specCol, specular );


### PR DESCRIPTION
clipping the lighting result via ciel was causing banding issues with specular maps with alpha channels. rev2. also addresses the warning:

"warning X3571: pow(f, e) will not work for negative f, use abs(f) or conditionally handle negative values if you expect them" since it was coming from the same line, and included the comparable openGL entry
