### PR TITLE
Issue 437

### DIFF
--- a/Engine/source/renderInstance/renderGlowMgr.cpp
+++ b/Engine/source/renderInstance/renderGlowMgr.cpp
@@ -54,7 +54,7 @@ RenderGlowMgr::GlowMaterialHook::GlowMaterialHook( BaseMatInstance *matInst )
 {
    mGlowMatInst = (MatInstance*)matInst->getMaterial()->createMatInstance();
    mGlowMatInst->getFeaturesDelegate().bind( &GlowMaterialHook::_overrideFeatures );
-	mGlowMatInst->setUserObject(matInst->getUserObject());
+   mGlowMatInst->setUserObject(matInst->getUserObject());
    mGlowMatInst->init(  matInst->getRequestedFeatures(), 
                         matInst->getVertexFormat() );
 }


### PR DESCRIPTION
Fix for [#437](https://github.com/GarageGames/Torque3D/issues/437)

Imperfect in that the materials still can render weirdly when combined with alpha, but it fixes the assert by making sure the glow material instance retains the user object(which the foliage shader consts check for)
