### PR TITLE
Rename Status enum for avoid conficts on Linux.

### DIFF
--- a/Engine/source/core/fileio.h
+++ b/Engine/source/core/fileio.h
@@ -31,7 +31,7 @@ class File
 {
 public:
    /// What is the status of our file handle?
-   enum Status
+   enum FileStatus
    {
       Ok = 0,           ///< Ok!
       IOError,          ///< Read or Write error
@@ -59,7 +59,7 @@ public:
 
 private:
    void *handle;           ///< Pointer to the file handle.
-   Status currentStatus;   ///< Current status of the file (Ok, IOError, etc.).
+   FileStatus currentStatus;   ///< Current status of the file (Ok, IOError, etc.).
    U32 capability;         ///< Keeps track of file capabilities.
 
    File(const File&);              ///< This is here to disable the copy constructor.
@@ -72,7 +72,7 @@ public:
    /// Opens a file for access using the specified AccessMode
    ///
    /// @returns The status of the file
-   Status open(const char *filename, const AccessMode openMode);
+   FileStatus open(const char *filename, const AccessMode openMode);
 
    /// Gets the current position in the file
    ///
@@ -99,7 +99,7 @@ public:
    /// @endcode
    ///
    /// @returns The status of the file
-   Status setPosition(S32 position, bool absolutePos = true);
+   FileStatus setPosition(S32 position, bool absolutePos = true);
 
    /// Returns the size of the file
    U32 getSize() const;
@@ -107,25 +107,25 @@ public:
    /// Make sure everything that's supposed to be written to the file gets written.
    ///
    /// @returns The status of the file.
-   Status flush();
+   FileStatus flush();
 
    /// Closes the file
    ///
    /// @returns The status of the file.
-   Status close();
+   FileStatus close();
 
    /// Gets the status of the file
-   Status getStatus() const;
+   FileStatus getStatus() const;
 
    /// Reads "size" bytes from the file, and dumps data into "dst".
    /// The number of actual bytes read is returned in bytesRead
    /// @returns The status of the file
-   Status read(U32 size, char *dst, U32 *bytesRead = NULL);
+   FileStatus read(U32 size, char *dst, U32 *bytesRead = NULL);
 
    /// Writes "size" bytes into the file from the pointer "src".
    /// The number of actual bytes written is returned in bytesWritten
    /// @returns The status of the file
-   Status write(U32 size, const char *src, U32 *bytesWritten = NULL);
+   FileStatus write(U32 size, const char *src, U32 *bytesWritten = NULL);
 
    /// Returns whether or not this file is capable of the given function.
    bool hasCapability(Capability cap) const;
@@ -133,8 +133,8 @@ public:
    const void* getHandle() { return handle; }
 
 protected:
-   Status setStatus();                 ///< Called after error encountered.
-   Status setStatus(Status status);    ///< Setter for the current status.
+   FileStatus setStatus();                 ///< Called after error encountered.
+   FileStatus setStatus(FileStatus status);    ///< Setter for the current status.
 };
 
 #endif // _FILE_IO_H_

--- a/Engine/source/core/memVolume.cpp
+++ b/Engine/source/core/memVolume.cpp
@@ -324,7 +324,7 @@ namespace Torque
          return mFileData->mPath;
       }
 
-      FileNode::Status MemFile::getStatus() const
+      FileNode::NodeStatus MemFile::getStatus() const
       {
          return mStatus;
       }
@@ -502,7 +502,7 @@ namespace Torque
          return mDirectoryData->getAttributes(attr);
       }
 
-      FileNode::Status MemDirectory::getStatus() const
+      FileNode::NodeStatus MemDirectory::getStatus() const
       {
          return mStatus;
       }

--- a/Engine/source/core/memVolume.h
+++ b/Engine/source/core/memVolume.h
@@ -74,7 +74,7 @@ namespace Torque
          virtual ~MemFile();
 
          Path getName() const;
-         Status getStatus() const;
+         NodeStatus getStatus() const;
          bool getAttributes(Attributes*);
 
          U32 getPosition();
@@ -91,7 +91,7 @@ namespace Torque
 
          MemFileSystem* mFileSystem;
          MemFileData* mFileData;
-         Status   mStatus;
+         NodeStatus   mStatus;
          U32 mCurrentPos;
 
          bool _updateInfo();
@@ -108,7 +108,7 @@ namespace Torque
          ~MemDirectory();
 
          Path getName() const;
-         Status getStatus() const;
+         NodeStatus getStatus() const;
          bool getAttributes(Attributes*);
 
          bool open();
@@ -122,7 +122,7 @@ namespace Torque
 
          U32 calculateChecksum();         
          
-         Status   mStatus;
+         NodeStatus   mStatus;
          U32 mSearchIndex;         
       };
 

--- a/Engine/source/core/stream/stream.cpp
+++ b/Engine/source/core/stream/stream.cpp
@@ -91,7 +91,7 @@ Stream::Stream()
 {
 }
 
-const char* Stream::getStatusString(const Status in_status)
+const char* Stream::getStatusString(const StreamStatus in_status)
 {
    switch (in_status) {
       case Ok:

--- a/Engine/source/core/stream/stream.h
+++ b/Engine/source/core/stream/stream.h
@@ -57,7 +57,7 @@ class Stream
    // Public structs and enumerations...
 public:
      /// Status constants for the stream
-   enum Status {
+   enum StreamStatus {
       Ok = 0,           ///< Ok!
       IOError,          ///< Read or Write error
       EOS,              ///< End of Stream reached (mostly for reads)
@@ -74,20 +74,20 @@ public:
 
    // Accessible only through inline accessors
 private:
-   Status m_streamStatus;
+   StreamStatus m_streamStatus;
 
    // Derived accessible data modifiers...
 protected:
-   void setStatus(const Status in_newStatus) { m_streamStatus = in_newStatus; }
+   void setStatus(const StreamStatus in_newStatus) { m_streamStatus = in_newStatus; }
 
 public:
    Stream();
    virtual ~Stream() {}
 
    /// Gets the status of the stream
-   Stream::Status getStatus() const { return m_streamStatus; }
+   Stream::StreamStatus getStatus() const { return m_streamStatus; }
    /// Gets a printable string form of the status
-   static const char* getStatusString(const Status in_status);
+   static const char* getStatusString(const StreamStatus in_status);
 
    // Derived classes must override these...
 protected:

--- a/Engine/source/core/util/zip/zipVolume.cpp
+++ b/Engine/source/core/util/zip/zipVolume.cpp
@@ -55,7 +55,7 @@ public:
    }
 
    virtual Path   getName() const { return mZipFilename; }
-   virtual Status getStatus() const
+   virtual NodeStatus getStatus() const
    { 
       if (mZipStream) 
       {
@@ -182,7 +182,7 @@ public:
    Torque::Path getName() const { return mPath; }
 
    // getStatus() doesn't appear to be used for directories
-   Status getStatus() const
+   NodeStatus getStatus() const
    {
       return FileNode::Open;
    }
@@ -274,7 +274,7 @@ public:
    Torque::Path getName() const { return mPath; }
 
    // getStatus() doesn't appear to be used for directories
-   Status getStatus() const
+   NodeStatus getStatus() const
    {
       return FileNode::Open;
    }

--- a/Engine/source/core/volume.h
+++ b/Engine/source/core/volume.h
@@ -79,7 +79,7 @@ public:
 class FileNode : public FileBase
 {
 public:
-   enum Status
+   enum NodeStatus
    {
       Open,                   ///< In an open state
       Closed,                 ///< In a closed state
@@ -122,7 +122,7 @@ public:
 
    // Properties
    virtual Path   getName() const = 0;
-   virtual Status getStatus() const = 0;
+   virtual NodeStatus getStatus() const = 0;
 
    virtual bool   getAttributes(Attributes*) = 0;
 

--- a/Engine/source/platformWin32/winFileio.cpp
+++ b/Engine/source/platformWin32/winFileio.cpp
@@ -248,7 +248,7 @@ File::~File()
 // Sets capability appropriate to the openMode.
 // Returns the currentStatus of the file.
 //-----------------------------------------------------------------------------
-File::Status File::open(const char *filename, const AccessMode openMode)
+File::FileStatus File::open(const char *filename, const AccessMode openMode)
 {
    AssertFatal(NULL != filename, "File::open: NULL fname");
    AssertWarn(INVALID_HANDLE_VALUE == (HANDLE)handle, "File::open: handle already valid");
@@ -363,7 +363,7 @@ U32 File::getPosition() const
 //
 // Returns the currentStatus of the file.
 //-----------------------------------------------------------------------------
-File::Status File::setPosition(S32 position, bool absolutePos)
+File::FileStatus File::setPosition(S32 position, bool absolutePos)
 {
     AssertFatal(Closed != currentStatus, "File::setPosition: file closed");
     AssertFatal(INVALID_HANDLE_VALUE != (HANDLE)handle, "File::setPosition: invalid file handle");
@@ -425,7 +425,7 @@ U32 File::getSize() const
 // It is an error to flush a read-only file.
 // Returns the currentStatus of the file.
 //-----------------------------------------------------------------------------
-File::Status File::flush()
+File::FileStatus File::flush()
 {
     AssertFatal(Closed != currentStatus, "File::flush: file closed");
     AssertFatal(INVALID_HANDLE_VALUE != (HANDLE)handle, "File::flush: invalid file handle");
@@ -442,7 +442,7 @@ File::Status File::flush()
 //
 // Returns the currentStatus
 //-----------------------------------------------------------------------------
-File::Status File::close()
+File::FileStatus File::close()
 {
     // check if it's already closed...
     if (Closed == currentStatus)
@@ -461,7 +461,7 @@ File::Status File::close()
 //-----------------------------------------------------------------------------
 // Self-explanatory.
 //-----------------------------------------------------------------------------
-File::Status File::getStatus() const
+File::FileStatus File::getStatus() const
 {
     return currentStatus;
 }
@@ -469,7 +469,7 @@ File::Status File::getStatus() const
 //-----------------------------------------------------------------------------
 // Sets and returns the currentStatus when an error has been encountered.
 //-----------------------------------------------------------------------------
-File::Status File::setStatus()
+File::FileStatus File::setStatus()
 {
     switch (GetLastError())
     {
@@ -489,7 +489,7 @@ File::Status File::setStatus()
 //-----------------------------------------------------------------------------
 // Sets and returns the currentStatus to status.
 //-----------------------------------------------------------------------------
-File::Status File::setStatus(File::Status status)
+File::FileStatus File::setStatus(File::FileStatus status)
 {
     return currentStatus = status;
 }
@@ -500,7 +500,7 @@ File::Status File::setStatus(File::Status status)
 // The number of bytes read is available in bytesRead if a non-Null pointer is
 // provided.
 //-----------------------------------------------------------------------------
-File::Status File::read(U32 size, char *dst, U32 *bytesRead)
+File::FileStatus File::read(U32 size, char *dst, U32 *bytesRead)
 {
     AssertFatal(Closed != currentStatus, "File::read: file closed");
     AssertFatal(INVALID_HANDLE_VALUE != (HANDLE)handle, "File::read: invalid file handle");
@@ -531,7 +531,7 @@ File::Status File::read(U32 size, char *dst, U32 *bytesRead)
 // The number of bytes written is available in bytesWritten if a non-Null
 // pointer is provided.
 //-----------------------------------------------------------------------------
-File::Status File::write(U32 size, const char *src, U32 *bytesWritten)
+File::FileStatus File::write(U32 size, const char *src, U32 *bytesWritten)
 {
     AssertFatal(Closed != currentStatus, "File::write: file closed");
     AssertFatal(INVALID_HANDLE_VALUE != (HANDLE)handle, "File::write: invalid file handle");

--- a/Engine/source/platformWin32/winVolume.cpp
+++ b/Engine/source/platformWin32/winVolume.cpp
@@ -333,7 +333,7 @@ Path Win32File::getName() const
    return mPath;
 }
 
-FileNode::Status Win32File::getStatus() const
+FileNode::NodeStatus Win32File::getStatus() const
 {
    return mStatus;
 }
@@ -620,7 +620,7 @@ bool Win32Directory::getAttributes(Attributes* attr)
    return true;
 }
 
-FileNode::Status Win32Directory::getStatus() const
+FileNode::NodeStatus Win32Directory::getStatus() const
 {
    return mStatus;
 }

--- a/Engine/source/platformWin32/winVolume.h
+++ b/Engine/source/platformWin32/winVolume.h
@@ -65,7 +65,7 @@ public:
    ~Win32File();
 
    Path getName() const;
-   Status getStatus() const;
+   NodeStatus getStatus() const;
    bool getAttributes(Attributes*);
    U64 getSize();
 
@@ -86,7 +86,7 @@ private:
    Path     mPath;
    String   mName;
    void     *mHandle;
-   Status   mStatus;
+   NodeStatus   mStatus;
 
    Win32File(const Path &path, String name);
 
@@ -103,7 +103,7 @@ public:
    ~Win32Directory();
 
    Path getName() const;
-   Status getStatus() const;
+   NodeStatus getStatus() const;
    bool getAttributes(Attributes*);
 
    bool open();
@@ -118,7 +118,7 @@ private:
    Path     mPath;
    String   mName;
    void     *mHandle;
-   Status   mStatus;
+   NodeStatus   mStatus;
 
    Win32Directory(const Path &path,String name);
 


### PR DESCRIPTION
Some Linux headers define Status, causing conflic with T3D enums.
