### PR TITLE
Rename enum GFXTextureProfile::None for avoid conficts on Linux.

### DIFF
--- a/Engine/source/gfx/gFont.cpp
+++ b/Engine/source/gfx/gFont.cpp
@@ -42,7 +42,7 @@ GFX_ImplementTextureProfile(GFXFontTextureProfile,
                             GFXTextureProfile::Static |
                             GFXTextureProfile::KeepBitmap |
                             GFXTextureProfile::NoMipmap, 
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 
 template<> void *Resource<GFont>::create(const Torque::Path &path)
 {

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -1031,7 +1031,7 @@ void GFXTextureManager::_validateTexParams( const U32 width, const U32 height,
    // If the format is non-compressed, and the profile requests a compressed format
    // than change the format.
    GFXFormat testingFormat = inOutFormat;
-   if( profile->getCompression() != GFXTextureProfile::None )
+   if( profile->getCompression() != GFXTextureProfile::NONE )
    {
       const int offset = profile->getCompression() - GFXTextureProfile::DXT1;
       testingFormat = GFXFormat( GFXFormatDXT1 + offset );

--- a/Engine/source/gfx/gfxTextureProfile.cpp
+++ b/Engine/source/gfx/gfxTextureProfile.cpp
@@ -34,15 +34,15 @@
 GFX_ImplementTextureProfile(GFXDefaultRenderTargetProfile, 
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::PreserveSize | GFXTextureProfile::NoMipmap | GFXTextureProfile::RenderTarget, 
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 GFX_ImplementTextureProfile(GFXDefaultStaticDiffuseProfile, 
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::Static, 
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 GFX_ImplementTextureProfile(GFXDefaultStaticNormalMapProfile, 
                             GFXTextureProfile::NormalMap, 
                             GFXTextureProfile::Static, 
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 GFX_ImplementTextureProfile(GFXDefaultStaticDXT5nmProfile, 
                             GFXTextureProfile::NormalMap, 
                             GFXTextureProfile::Static, 
@@ -50,15 +50,15 @@ GFX_ImplementTextureProfile(GFXDefaultStaticDXT5nmProfile,
 GFX_ImplementTextureProfile(GFXDefaultPersistentProfile,
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::PreserveSize | GFXTextureProfile::Static | GFXTextureProfile::KeepBitmap, 
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 GFX_ImplementTextureProfile(GFXSystemMemProfile, 
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::PreserveSize | GFXTextureProfile::NoMipmap | GFXTextureProfile::SystemMemory,
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 GFX_ImplementTextureProfile(GFXDefaultZTargetProfile,
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::PreserveSize | GFXTextureProfile::NoMipmap | GFXTextureProfile::ZTarget | GFXTextureProfile::NoDiscard, 
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 
 //-----------------------------------------------------------------------------
 

--- a/Engine/source/gfx/gfxTextureProfile.h
+++ b/Engine/source/gfx/gfxTextureProfile.h
@@ -106,7 +106,7 @@ public:
 
    enum Compression
    {
-      None,
+      NONE,
       DXT1,
       DXT2,
       DXT3,
@@ -114,7 +114,7 @@ public:
       DXT5,
    };
 
-   GFXTextureProfile(const String &name, Types type, U32 flags, Compression compression = None);
+   GFXTextureProfile(const String &name, Types type, U32 flags, Compression compression = NONE);
 
    // Accessors
    String getName() const { return mName; };

--- a/Engine/source/gfx/video/theoraTexture.cpp
+++ b/Engine/source/gfx/video/theoraTexture.cpp
@@ -60,7 +60,7 @@
 GFX_ImplementTextureProfile(  GFXTheoraTextureProfile,
                               GFXTextureProfile::DiffuseMap,
                               GFXTextureProfile::NoMipmap | GFXTextureProfile::Dynamic,
-                              GFXTextureProfile::None );
+                              GFXTextureProfile::NONE );
 
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/gui/controls/guiMLTextCtrl.cpp
+++ b/Engine/source/gui/controls/guiMLTextCtrl.cpp
@@ -91,7 +91,7 @@ GFX_ImplementTextureProfile(GFXMLTextureProfile,
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::PreserveSize |
                             GFXTextureProfile::Static, 
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 
 const U32 GuiMLTextCtrl::csmTextBufferGrowthSize = 1024;
 

--- a/Engine/source/gui/core/guiTypes.cpp
+++ b/Engine/source/gui/core/guiTypes.cpp
@@ -63,13 +63,13 @@ GFX_ImplementTextureProfile(GFXGuiCursorProfile,
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::PreserveSize |
                             GFXTextureProfile::Static, 
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 GFX_ImplementTextureProfile(GFXDefaultGUIProfile,
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::PreserveSize |
                             GFXTextureProfile::Static |
                             GFXTextureProfile::NoPadding, 
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 
 
 GuiCursor::GuiCursor()

--- a/Engine/source/lighting/common/projectedShadow.cpp
+++ b/Engine/source/lighting/common/projectedShadow.cpp
@@ -62,14 +62,14 @@ GFX_ImplementTextureProfile( BLProjectedShadowProfile,
                               GFXTextureProfile::PreserveSize | 
                               GFXTextureProfile::RenderTarget |
                               GFXTextureProfile::Pooled,
-                              GFXTextureProfile::None );
+                              GFXTextureProfile::NONE );
 
 GFX_ImplementTextureProfile( BLProjectedShadowZProfile,
                               GFXTextureProfile::DiffuseMap,
                               GFXTextureProfile::PreserveSize | 
                               GFXTextureProfile::ZTarget |
                               GFXTextureProfile::Pooled,
-                              GFXTextureProfile::None );
+                              GFXTextureProfile::NONE );
 
 
 ProjectedShadow::ProjectedShadow( SceneObject *object )

--- a/Engine/source/lighting/shadowMap/lightShadowMap.cpp
+++ b/Engine/source/lighting/shadowMap/lightShadowMap.cpp
@@ -70,7 +70,7 @@ GFX_ImplementTextureProfile( ShadowMapProfile,
                               GFXTextureProfile::PreserveSize | 
                               GFXTextureProfile::RenderTarget |
                               GFXTextureProfile::Pooled,
-                              GFXTextureProfile::None );
+                              GFXTextureProfile::NONE );
 
 GFX_ImplementTextureProfile( ShadowMapZProfile,
                              GFXTextureProfile::DiffuseMap, 
@@ -78,7 +78,7 @@ GFX_ImplementTextureProfile( ShadowMapZProfile,
                              GFXTextureProfile::NoMipmap | 
                              GFXTextureProfile::ZTarget |
                              GFXTextureProfile::Pooled,
-                             GFXTextureProfile::None );
+                             GFXTextureProfile::NONE );
 
 
 LightShadowMap::LightShadowMap( LightInfo *light )

--- a/Engine/source/lighting/shadowMap/shadowMapManager.cpp
+++ b/Engine/source/lighting/shadowMap/shadowMapManager.cpp
@@ -37,7 +37,7 @@
 GFX_ImplementTextureProfile(ShadowMapTexProfile,
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::PreserveSize | GFXTextureProfile::Dynamic , 
-                            GFXTextureProfile::None);
+                            GFXTextureProfile::NONE);
 
 
 MODULE_BEGIN( ShadowMapManager )

--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -134,7 +134,7 @@ GFX_ImplementTextureProfile(  PostFxTargetProfile,
                               GFXTextureProfile::PreserveSize |
                               GFXTextureProfile::RenderTarget |
                               GFXTextureProfile::Pooled,
-                              GFXTextureProfile::None );
+                              GFXTextureProfile::NONE );
 
 IMPLEMENT_CONOBJECT(PostEffect);
 
@@ -142,7 +142,7 @@ IMPLEMENT_CONOBJECT(PostEffect);
 GFX_ImplementTextureProfile( PostFxTextureProfile,
                             GFXTextureProfile::DiffuseMap,
                             GFXTextureProfile::Static | GFXTextureProfile::PreserveSize | GFXTextureProfile::NoMipmap,
-                            GFXTextureProfile::None );
+                            GFXTextureProfile::NONE );
 
 
 void PostEffect::EffectConst::set( const String &newVal )

--- a/Engine/source/scene/reflectionManager.cpp
+++ b/Engine/source/scene/reflectionManager.cpp
@@ -59,14 +59,14 @@ MODULE_END;
 GFX_ImplementTextureProfile( ReflectRenderTargetProfile, 
                              GFXTextureProfile::DiffuseMap, 
                              GFXTextureProfile::PreserveSize | GFXTextureProfile::NoMipmap | GFXTextureProfile::RenderTarget | GFXTextureProfile::Pooled, 
-                             GFXTextureProfile::None );
+                             GFXTextureProfile::NONE );
 
 GFX_ImplementTextureProfile( RefractTextureProfile,
                              GFXTextureProfile::DiffuseMap,
                              GFXTextureProfile::PreserveSize | 
                              GFXTextureProfile::RenderTarget |
                              GFXTextureProfile::Pooled,
-                             GFXTextureProfile::None );
+                             GFXTextureProfile::NONE );
 
 static S32 QSORT_CALLBACK compareReflectors( const void *a, const void *b )
 {

--- a/Engine/source/terrain/terrRender.cpp
+++ b/Engine/source/terrain/terrRender.cpp
@@ -62,7 +62,7 @@ GFX_ImplementTextureProfile( TerrainLayerTexProfile,
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::PreserveSize | 
                             GFXTextureProfile::Dynamic,
-                            GFXTextureProfile::None );
+                            GFXTextureProfile::NONE );
 
 
 void TerrainBlock::_onFlushMaterials()


### PR DESCRIPTION
Some Linux headers define None, causing conflic with T3D enum GFXTextureProfile::Compression::None.
