### PR TITLE
simple alteration to allow for negative damage (repair). 

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -1634,7 +1634,7 @@ void ShapeBase::applyRepair(F32 amount)
 
 void ShapeBase::applyDamage(F32 amount)
 {
-   if (amount > 0)
+   if (amount != 0)
       setDamageLevel(mDamage + amount);
 }
 

--- a/Templates/Full/game/scripts/server/radiusDamage.cs
+++ b/Templates/Full/game/scripts/server/radiusDamage.cs
@@ -56,6 +56,7 @@ function radiusDamage(%sourceObject, %position, %radius, %damage, %damageType, %
       // Full damage is applied to anything less than half the radius away,
       // linear scale from there.
       %distScale = (%dist < %halfRadius)? 1.0 : 1.0 - ((%dist - %halfRadius) / %halfRadius);
+	  %distScale = mClamp(%distScale,0.0,1.0);
 
       // Apply the damage
       %targetObject.damage(%sourceObject, %position, %damage * %coverage * %distScale, %damageType);


### PR DESCRIPTION
This does expose a small miscalculation with damageradius, where the numbers could go negative with large destructible objects. As it's a percentile, clamped it from 0 to 1.
