### PR TITLE
Particle Accumulation on Damage (Yet another one-liner)

### DIFF
--- a/Engine/source/T3D/vehicles/vehicle.cpp
+++ b/Engine/source/T3D/vehicles/vehicle.cpp
@@ -1827,7 +1827,6 @@ void Vehicle::updateDamageSmoke( F32 dt )
                }
             }
          }
-         break;
       }
    }
 


### PR DESCRIPTION
Given that T3D does not allow for mixed particle blend types (smoke and fire particularly), this allows the accumulation, rather than the replacement of particle emissions based on damage levels. If this is desirable, player and rigidshape methods are (relatively) simple to port on over as well. (Though player, vehicle, and rigidshape naming conventions for the VC_BUBBLE_EMITTER vs VC_NUM_BUBBLE_EMITTERS differ, so likely best to pick an Enum nomenclature first.)
