### PR TITLE
Revision of #605: requested alterations.

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -5871,14 +5871,17 @@ bool Player::castRay(const Point3F &start, const Point3F &end, RayInfo* info)
       {
          if (mDataBlock->HBIndex[i] != -1)
          {
-            if (mShapeInstance->castRayEA(start, end, info, 0, mDataBlock->HBIndex[i]))
+            for (U32 j = 0; j < mDataBlock->mShape->details.size(); j++)
             {
-               info->object = this;
-               if (info->t < shortest.t)
-               {
-                  shortest = *info;
-                  shortest.HitBoxNum = i + 1;		//  +1 because the meshes HB## begin from 1
-               }
+                if (mShapeInstance->castRayEA(start, end, info, j, mDataBlock->HBIndex[i]))
+                {
+                    info->object = this;
+                    if (info->t < shortest.t)
+                    {
+                        shortest = *info;
+                        shortest.HitBoxNum = i + 1;		//  +1 because the meshes HB## begin from 1
+                    }
+                }
             }
          }
       }

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -5847,12 +5847,49 @@ bool Player::castRay(const Point3F &start, const Point3F &end, RayInfo* info)
 
    info->normal = start - end;
    info->normal.normalizeSafe();
-   getTransform().mulV( info->normal );
+   getTransform().mulV(info->normal);
 
    info->t = fst;
    info->object = this;
-   info->point.interpolate(start,end,fst);
+   info->point.interpolate(start, end, fst);
    info->material = 0;
+
+   if (mDataBlock->HBIndex[0] == -1) return true;
+   //if we are here means that the ray has hit the bounding box, now check if an hit box was hit
+   //if it hit a collision box the HitBoxNum
+   //in the info struct is filled with the number of the box otherwise it remains -1
+   if (mShapeInstance)
+   {
+      RayInfo shortest;
+      shortest.t = 1e8;
+      if (isServerObject())
+      {
+         mShapeInstance->animate(0);	//Animate the model on the server
+      }
+
+      for (U32 i = 0; i < ShapeBaseData::Max_Hitboxes; i++)
+      {
+         if (mDataBlock->HBIndex[i] != -1)
+         {
+            if (mShapeInstance->castRayEA(start, end, info, 0, mDataBlock->HBIndex[i]))
+            {
+               info->object = this;
+               if (info->t < shortest.t)
+               {
+                  shortest = *info;
+                  shortest.HitBoxNum = i + 1;		//  +1 because the meshes HB## begin from 1
+               }
+            }
+         }
+      }
+      if (info->object == this)
+      {
+         // Copy out the shortest time...
+         *info = shortest;
+      }
+      if (info->HitBoxNum == -1) return false;
+      info->point.interpolate(start, end, info->t);
+   }
    return true;
 }
 

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -5867,7 +5867,7 @@ bool Player::castRay(const Point3F &start, const Point3F &end, RayInfo* info)
          mShapeInstance->animate(0);	//Animate the model on the server
       }
 
-      for (U32 i = 0; i < ShapeBaseData::Max_Hitboxes; i++)
+      for (U32 i = 0; i < ShapeBaseData::MaxHitboxes; i++)
       {
          if (mDataBlock->HBIndex[i] != -1)
          {

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -5854,9 +5854,9 @@ bool Player::castRay(const Point3F &start, const Point3F &end, RayInfo* info)
    info->point.interpolate(start, end, fst);
    info->material = 0;
 
-   if (mDataBlock->HBIndex[0] == -1) return true;
+   if (mDataBlock->mHitMeshID[0] == -1) return true;
    //if we are here means that the ray has hit the bounding box, now check if an hit box was hit
-   //if it hit a collision box the HitBoxNum
+   //if it hit a collision box the hitArea
    //in the info struct is filled with the number of the box otherwise it remains -1
    if (mShapeInstance)
    {
@@ -5869,17 +5869,17 @@ bool Player::castRay(const Point3F &start, const Point3F &end, RayInfo* info)
 
       for (U32 i = 0; i < ShapeBaseData::MaxHitboxes; i++)
       {
-         if (mDataBlock->HBIndex[i] != -1)
+         if (mDataBlock->mHitMeshID[i] != -1)
          {
             for (U32 j = 0; j < mDataBlock->mShape->details.size(); j++)
             {
-                if (mShapeInstance->castRayEA(start, end, info, j, mDataBlock->HBIndex[i]))
+                if (mShapeInstance->castRayEA(start, end, info, j, mDataBlock->mHitMeshID[i]))
                 {
                     info->object = this;
                     if (info->t < shortest.t)
                     {
                         shortest = *info;
-                        shortest.HitBoxNum = i + 1;		//  +1 because the meshes HB## begin from 1
+                        shortest.hitArea = i + 1;		//  +1 because the meshes HB## begin from 1
                     }
                 }
             }
@@ -5890,7 +5890,7 @@ bool Player::castRay(const Point3F &start, const Point3F &end, RayInfo* info)
          // Copy out the shortest time...
          *info = shortest;
       }
-      if (info->HitBoxNum == -1) return false;
+      if (info->hitArea == -1) return false;
       info->point.interpolate(start, end, info->t);
    }
    return true;

--- a/Engine/source/T3D/projectile.cpp
+++ b/Engine/source/T3D/projectile.cpp
@@ -123,7 +123,7 @@ IMPLEMENT_CALLBACK(ProjectileData, onCollision, void, (Projectile* proj, SceneOb
                   "@param fade The current fadeValue of the projectile, affects its visibility.\n"
                   "@param pos The position of the collision.\n"
                   "@param normal The normal of the collision.\n"
-                  "@param the struck hitbox suffix.\n"
+                  "@param hitBoxNum the struck hitbox suffix.\n"
                   "@see Projectile\n"
    );
 

--- a/Engine/source/T3D/projectile.cpp
+++ b/Engine/source/T3D/projectile.cpp
@@ -114,17 +114,18 @@ IMPLEMENT_CALLBACK( ProjectileData, onExplode, void, ( Projectile* proj, Point3F
 				   "@see Projectile\n"
 				  );
 
-IMPLEMENT_CALLBACK( ProjectileData, onCollision, void, ( Projectile* proj, SceneObject* col, F32 fade, Point3F pos, Point3F normal ),
-                   ( proj, col, fade, pos, normal ),
-				   "@brief Called when a projectile collides with another object.\n\n"
-                   "This function is only called on server objects."
-				   "@param proj The projectile colliding with SceneObject col.\n"
-				   "@param col The SceneObject hit by the projectile.\n"
-				   "@param fade The current fadeValue of the projectile, affects its visibility.\n"
-				   "@param pos The position of the collision.\n"
-                   "@param normal The normal of the collision.\n"
-				   "@see Projectile\n"
-				  );
+IMPLEMENT_CALLBACK(ProjectileData, onCollision, void, (Projectile* proj, SceneObject* col, F32 fade, Point3F pos, Point3F normal, S32 hitBoxNum),
+                  (proj, col, fade, pos, normal, hitBoxNum),
+                  "@brief Called when a projectile collides with another object.\n\n"
+                  "This function is only called on server objects."
+                  "@param proj The projectile colliding with SceneObject col.\n"
+                  "@param col The SceneObject hit by the projectile.\n"
+                  "@param fade The current fadeValue of the projectile, affects its visibility.\n"
+                  "@param pos The position of the collision.\n"
+                  "@param normal The normal of the collision.\n"
+                  "@param the struck hitbox suffix.\n"
+                  "@see Projectile\n"
+   );
 
 const U32 Projectile::csmStaticCollisionMask =  TerrainObjectType | StaticShapeObjectType;
 
@@ -1137,7 +1138,7 @@ void Projectile::simulate( F32 dt )
       // during the next packet update, due to the ExplosionMask network bit being set.
       // onCollision will remain uncalled on the client however, therefore no client
       // specific code should be placed inside the function!
-      onCollision( rInfo.point, rInfo.normal, rInfo.object );
+      onCollision(rInfo.point, rInfo.normal, rInfo.object, rInfo.HitBoxNum);
       // Next order of business: do we explode on this hit?
       if ( mCurrTick > mDataBlock->armingDelay || mDataBlock->armingDelay == 0 )
       {
@@ -1256,7 +1257,7 @@ void Projectile::interpolateTick(F32 delta)
 
 
 //--------------------------------------------------------------------------
-void Projectile::onCollision(const Point3F& hitPosition, const Point3F& hitNormal, SceneObject* hitObject)
+void Projectile::onCollision(const Point3F& hitPosition, const Point3F& hitNormal, SceneObject* hitObject, S32 collisionBox)
 {
    // No client specific code should be placed or branched from this function
    if(isClientObject())
@@ -1264,7 +1265,7 @@ void Projectile::onCollision(const Point3F& hitPosition, const Point3F& hitNorma
 
    if (hitObject != NULL && isServerObject())
    {
-	   mDataBlock->onCollision_callback( this, hitObject, mFadeValue, hitPosition, hitNormal );
+      mDataBlock->onCollision_callback(this, hitObject, mFadeValue, hitPosition, hitNormal, collisionBox);
    }
 }
 

--- a/Engine/source/T3D/projectile.cpp
+++ b/Engine/source/T3D/projectile.cpp
@@ -114,8 +114,8 @@ IMPLEMENT_CALLBACK( ProjectileData, onExplode, void, ( Projectile* proj, Point3F
 				   "@see Projectile\n"
 				  );
 
-IMPLEMENT_CALLBACK(ProjectileData, onCollision, void, (Projectile* proj, SceneObject* col, F32 fade, Point3F pos, Point3F normal, S32 hitBoxNum),
-                  (proj, col, fade, pos, normal, hitBoxNum),
+IMPLEMENT_CALLBACK(ProjectileData, onCollision, void, (Projectile* proj, SceneObject* col, F32 fade, Point3F pos, Point3F normal, S32 hitArea),
+                  (proj, col, fade, pos, normal, hitArea),
                   "@brief Called when a projectile collides with another object.\n\n"
                   "This function is only called on server objects."
                   "@param proj The projectile colliding with SceneObject col.\n"
@@ -123,7 +123,7 @@ IMPLEMENT_CALLBACK(ProjectileData, onCollision, void, (Projectile* proj, SceneOb
                   "@param fade The current fadeValue of the projectile, affects its visibility.\n"
                   "@param pos The position of the collision.\n"
                   "@param normal The normal of the collision.\n"
-                  "@param hitBoxNum the struck hitbox suffix.\n"
+                  "@param hitArea the struck hitArea suffix.\n"
                   "@see Projectile\n"
    );
 
@@ -1138,7 +1138,7 @@ void Projectile::simulate( F32 dt )
       // during the next packet update, due to the ExplosionMask network bit being set.
       // onCollision will remain uncalled on the client however, therefore no client
       // specific code should be placed inside the function!
-      onCollision(rInfo.point, rInfo.normal, rInfo.object, rInfo.HitBoxNum);
+      onCollision(rInfo.point, rInfo.normal, rInfo.object, rInfo.hitArea);
       // Next order of business: do we explode on this hit?
       if ( mCurrTick > mDataBlock->armingDelay || mDataBlock->armingDelay == 0 )
       {

--- a/Engine/source/T3D/projectile.h
+++ b/Engine/source/T3D/projectile.h
@@ -143,7 +143,7 @@ public:
 
    
    DECLARE_CALLBACK( void, onExplode, ( Projectile* proj, Point3F pos, F32 fade ) );
-   DECLARE_CALLBACK( void, onCollision, ( Projectile* proj, SceneObject* col, F32 fade, Point3F pos, Point3F normal ) );
+   DECLARE_CALLBACK( void, onCollision, ( Projectile* proj, SceneObject* col, F32 fade, Point3F pos, Point3F normal, S32 collisionBox) );
 };
 
 
@@ -204,7 +204,7 @@ public:
    void simulate( F32 dt );
 
    /// What to do once this projectile collides with something
-   virtual void onCollision(const Point3F& p, const Point3F& n, SceneObject*);
+   virtual void onCollision(const Point3F& p, const Point3F& n, SceneObject*, S32 collisionBox);
 
    /// What to do when this projectile explodes
    virtual void explode(const Point3F& p, const Point3F& n, const U32 collideType );

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -193,6 +193,8 @@ ShapeBaseData::ShapeBaseData()
    debrisDetail( -1 )
 {      
    dMemset( mountPointNode, -1, sizeof( S32 ) * SceneObject::NumMountPoints );
+
+   for (int i=0; i< Max_Hitboxes; i++) HBIndex[i] = -1;
 }
 
 struct ShapeBaseDataProto
@@ -380,6 +382,14 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
             if (!found)
                LOSDetails.push_back(i);
          }
+         //find the HitBox mesh
+         //The hit box mesh is a convex mesh named Hitbox$DDD where DDD is the detail level, the same used for the model and $ is a number from 1 to 20
+         for (i=0; i< Max_Hitboxes; i++)
+         {
+            char buff[8];
+            dSprintf(buff,sizeof(buff),"Hitbox%d",i+1);
+            HBIndex[i] = mShape->findObject(buff);
+         }
       }
 
       debrisDetail = mShape->findDetail("Debris-17");
@@ -502,7 +512,6 @@ void ShapeBaseData::initPersistFields()
          "Drag factor.\nReduces velocity of moving objects." );
       addField( "density", TypeF32, Offset(density, ShapeBaseData),
          "Shape density.\nUsed when computing buoyancy when in water.\n" );
-
    endGroup( "Physics" );
 
    addGroup( "Damage/Energy" );

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -194,7 +194,7 @@ ShapeBaseData::ShapeBaseData()
 {      
    dMemset( mountPointNode, -1, sizeof( S32 ) * SceneObject::NumMountPoints );
 
-   for (int i=0; i< Max_Hitboxes; i++) HBIndex[i] = -1;
+   for (int i=0; i< MaxHitboxes; i++) HBIndex[i] = -1;
 }
 
 struct ShapeBaseDataProto
@@ -386,7 +386,7 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
 	  
 	  //find the HitBox mesh
 	  //The hit box mesh is a convex mesh named Hitbox$DDD where DDD is the detail level, the same used for the model and $ is a number from 1 to 20
-	  for (i=0; i< Max_Hitboxes; i++)
+	  for (i=0; i< MaxHitboxes; i++)
 	  {
 		  char buff[16];
 		  dSprintf(buff,sizeof(buff),"Hitbox%d",i+1);

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -382,15 +382,16 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
             if (!found)
                LOSDetails.push_back(i);
          }
-         //find the HitBox mesh
-         //The hit box mesh is a convex mesh named Hitbox$DDD where DDD is the detail level, the same used for the model and $ is a number from 1 to 20
-         for (i=0; i< Max_Hitboxes; i++)
-         {
-            char buff[8];
-            dSprintf(buff,sizeof(buff),"Hitbox%d",i+1);
-            HBIndex[i] = mShape->findObject(buff);
-         }
       }
+	  
+	  //find the HitBox mesh
+	  //The hit box mesh is a convex mesh named Hitbox$DDD where DDD is the detail level, the same used for the model and $ is a number from 1 to 20
+	  for (i=0; i< Max_Hitboxes; i++)
+	  {
+		  char buff[16];
+		  dSprintf(buff,sizeof(buff),"Hitbox%d",i+1);
+		  HBIndex[i] = mShape->findObject(buff);
+	  }
 
       debrisDetail = mShape->findDetail("Debris-17");
       eyeNode = mShape->findNode("eye");

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -194,7 +194,7 @@ ShapeBaseData::ShapeBaseData()
 {      
    dMemset( mountPointNode, -1, sizeof( S32 ) * SceneObject::NumMountPoints );
 
-   for (int i=0; i< MaxHitboxes; i++) HBIndex[i] = -1;
+   for (int i=0; i< MaxHitboxes; i++) mHitMeshID[i] = -1;
 }
 
 struct ShapeBaseDataProto
@@ -390,7 +390,7 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
 	  {
 		  char buff[16];
 		  dSprintf(buff,sizeof(buff),"Hitbox%d",i+1);
-		  HBIndex[i] = mShape->findObject(buff);
+		  mHitMeshID[i] = mShape->findObject(buff);
 	  }
 
       debrisDetail = mShape->findDetail("Debris-17");

--- a/Engine/source/T3D/shapeBase.h
+++ b/Engine/source/T3D/shapeBase.h
@@ -516,7 +516,7 @@ public:
    enum Constants {
       MaxCollisionShapes = 8,
       AIRepairNode		= 31,
-      Max_Hitboxes      = 20    // Max number of hitboxes allowed per player
+      MaxHitboxes      = 20    // Max number of hitboxes allowed per player
    };
 
    // TODO: These are only really used in Basic Lighting
@@ -527,7 +527,7 @@ public:
    F32 shadowProjectionDistance;
    F32 shadowSphereAdjust;
 
-   S32 HBIndex[Max_Hitboxes];
+   S32 HBIndex[MaxHitboxes];
    StringTableEntry  shapeName;
    StringTableEntry  cloakTexName;
 

--- a/Engine/source/T3D/shapeBase.h
+++ b/Engine/source/T3D/shapeBase.h
@@ -527,7 +527,7 @@ public:
    F32 shadowProjectionDistance;
    F32 shadowSphereAdjust;
 
-   S32 HBIndex[MaxHitboxes];
+   S32 mHitMeshID[MaxHitboxes];   /// Hit Mesh ID
    StringTableEntry  shapeName;
    StringTableEntry  cloakTexName;
 

--- a/Engine/source/T3D/shapeBase.h
+++ b/Engine/source/T3D/shapeBase.h
@@ -515,7 +515,8 @@ public:
    /// Various constants relating to the ShapeBaseData
    enum Constants {
       MaxCollisionShapes = 8,
-      AIRepairNode = 31
+      AIRepairNode		= 31,
+      Max_Hitboxes      = 20    // Max number of hitboxes allowed per player
    };
 
    // TODO: These are only really used in Basic Lighting
@@ -526,7 +527,7 @@ public:
    F32 shadowProjectionDistance;
    F32 shadowSphereAdjust;
 
-
+   S32 HBIndex[Max_Hitboxes];
    StringTableEntry  shapeName;
    StringTableEntry  cloakTexName;
 

--- a/Engine/source/collision/collision.h
+++ b/Engine/source/collision/collision.h
@@ -156,13 +156,13 @@ typedef Chunker<BSPNode> BSPTree;
 /// @see Collision
 struct RayInfo : public Collision 
 {
-   RayInfo() : userData( NULL ) {}
+   RayInfo() : userData( NULL ), HitBoxNum(-1) {}           //DA added HitBoxNum
 
    // The collision struct has object, point, normal & material.
 
    /// Distance along ray to contact point.
    F32 t; 
-
+   S32  HitBoxNum;                              //DA
    /// Set the point of intersection according to t and the given ray.
    ///
    /// Several pieces of code will not use ray information but rather rely

--- a/Engine/source/collision/collision.h
+++ b/Engine/source/collision/collision.h
@@ -156,13 +156,13 @@ typedef Chunker<BSPNode> BSPTree;
 /// @see Collision
 struct RayInfo : public Collision 
 {
-   RayInfo() : userData( NULL ), HitBoxNum(-1) {}           //DA added HitBoxNum
+   RayInfo() : userData( NULL ), HitBoxNum(-1) {}
 
-   // The collision struct has object, point, normal & material.
+   // The collision struct has object, point, normal, material and situationally, hitboxNum.
 
    /// Distance along ray to contact point.
    F32 t; 
-   S32  HitBoxNum;                              //DA
+   S32  HitBoxNum;
    /// Set the point of intersection according to t and the given ray.
    ///
    /// Several pieces of code will not use ray information but rather rely

--- a/Engine/source/collision/collision.h
+++ b/Engine/source/collision/collision.h
@@ -156,13 +156,13 @@ typedef Chunker<BSPNode> BSPTree;
 /// @see Collision
 struct RayInfo : public Collision 
 {
-   RayInfo() : userData( NULL ), HitBoxNum(-1) {}
+   RayInfo() : userData( NULL ), hitArea(-1) {}
 
-   // The collision struct has object, point, normal, material and situationally, hitboxNum.
+   // The collision struct has object, point, normal, material and situationally, hitArea.
 
    /// Distance along ray to contact point.
    F32 t; 
-   S32  HitBoxNum;
+   S32  hitArea;
    /// Set the point of intersection according to t and the given ray.
    ///
    /// Several pieces of code will not use ray information but rather rely

--- a/Engine/source/ts/tsCollision.cpp
+++ b/Engine/source/ts/tsCollision.cpp
@@ -249,10 +249,10 @@ bool TSShapeInstance::castRay(const Point3F & a, const Point3F & b, RayInfo * ra
    return found;
 }
 
-bool TSShapeInstance::castRayEA(const Point3F & a, const Point3F & b, RayInfo * rayInfo, S32 dl, S32 HBIndex)
+bool TSShapeInstance::castRayEA(const Point3F & a, const Point3F & b, RayInfo * rayInfo, S32 dl, S32 _hitMeshID)
 {
    // if dl==-1, or there is no hitbox list, nothing to do
-   if ((dl == -1)||(HBIndex == -1))
+   if ((dl == -1)||(_hitMeshID == -1))
       return false;
 
    AssertFatal(dl >= 0 && dl<mShape->details.size(), "TSShapeInstance::castRay");
@@ -272,7 +272,7 @@ bool TSShapeInstance::castRayEA(const Point3F & a, const Point3F & b, RayInfo * 
       Point3F ta, tb;
 
       // set up for first object's node
-      MeshObjectInstance * mesh = &mMeshObjects[HBIndex];
+      MeshObjectInstance * mesh = &mMeshObjects[_hitMeshID];
       mat = mesh->getTransform();
       mat.inverse();
       mat.mulP(a, &ta);

--- a/Engine/source/ts/tsCollision.cpp
+++ b/Engine/source/ts/tsCollision.cpp
@@ -249,6 +249,62 @@ bool TSShapeInstance::castRay(const Point3F & a, const Point3F & b, RayInfo * ra
    return found;
 }
 
+bool TSShapeInstance::castRayEA(const Point3F & a, const Point3F & b, RayInfo * rayInfo, S32 dl, S32 HBIndex)
+{
+   // if dl==-1, nothing to do
+   if (dl == -1)
+      return false;
+
+   if (HBIndex == -1)				//No hit box to test
+      return false;
+
+   AssertFatal(dl >= 0 && dl<mShape->details.size(), "TSShapeInstance::castRay");
+
+   // get subshape and object detail
+   const TSDetail * detail = &mShape->details[dl];
+   S32 ss = detail->subShapeNum;
+   S32 od = detail->objectDetailNum;
+
+   S32 start = mShape->subShapeFirstObject[ss];
+   S32 end = mShape->subShapeNumObjects[ss] + start;
+
+   bool found = false;
+   MatrixF mat;
+   if (start<end)
+   {
+      Point3F ta, tb;
+
+      // set up for first object's node
+      MeshObjectInstance * mesh = &mMeshObjects[HBIndex];
+      mat = mesh->getTransform();
+      mat.inverse();
+      mat.mulP(a, &ta);
+      mat.mulP(b, &tb);
+
+      // collide...
+      if (mesh->castRayEA(od, ta, tb, rayInfo, mMaterialList))
+      {
+         if (!rayInfo)
+            return true;
+
+         found = true;
+      }
+   }
+
+   // collide with any skins for this detail level...
+   // TODO: if ever...
+
+   // finalize the deal...
+   if (found)
+   {
+      mat.mulV(rayInfo->normal);
+      rayInfo->point = b - a;
+      rayInfo->point *= rayInfo->t;
+      rayInfo->point += a;
+   }
+   return found;
+}
+
 bool TSShapeInstance::castRayRendered(const Point3F & a, const Point3F & b, RayInfo * rayInfo, S32 dl)
 {
    // if dl==-1, nothing to do
@@ -513,6 +569,15 @@ bool TSShapeInstance::MeshObjectInstance::castRay( S32 objectDetail, const Point
    TSMesh* mesh = getMesh( objectDetail );
    if( mesh && !forceHidden && visible > 0.01f )
       return mesh->castRay( frame, start, end, rayInfo, materials );
+   return false;
+}
+
+bool TSShapeInstance::MeshObjectInstance::castRayEA(S32 objectDetail, const Point3F & start, const Point3F & end, RayInfo * rayInfo, TSMaterialList* materials)
+{
+   TSMesh * mesh = getMesh(objectDetail);
+
+   if (mesh)    //You have to remove the && visible>0.01f because the hitBoxes are hidden
+      return mesh->castRay(frame, start, end, rayInfo, materials);
    return false;
 }
 

--- a/Engine/source/ts/tsCollision.cpp
+++ b/Engine/source/ts/tsCollision.cpp
@@ -251,11 +251,8 @@ bool TSShapeInstance::castRay(const Point3F & a, const Point3F & b, RayInfo * ra
 
 bool TSShapeInstance::castRayEA(const Point3F & a, const Point3F & b, RayInfo * rayInfo, S32 dl, S32 HBIndex)
 {
-   // if dl==-1, nothing to do
-   if (dl == -1)
-      return false;
-
-   if (HBIndex == -1)				//No hit box to test
+   // if dl==-1, or there is no hitbox list, nothing to do
+   if ((dl == -1)||(HBIndex == -1))
       return false;
 
    AssertFatal(dl >= 0 && dl<mShape->details.size(), "TSShapeInstance::castRay");
@@ -576,7 +573,7 @@ bool TSShapeInstance::MeshObjectInstance::castRayEA(S32 objectDetail, const Poin
 {
    TSMesh * mesh = getMesh(objectDetail);
 
-   if (mesh)    //You have to remove the && visible>0.01f because the hitBoxes are hidden
+   if (mesh)
       return mesh->castRay(frame, start, end, rayInfo, materials);
    return false;
 }

--- a/Engine/source/ts/tsShapeInstance.h
+++ b/Engine/source/ts/tsShapeInstance.h
@@ -576,7 +576,7 @@ protected:
    bool buildPolyList(AbstractPolyList *, S32 dl);
    bool getFeatures(const MatrixF& mat, const Point3F& n, ConvexFeature*, S32 dl);
    bool castRay(const Point3F & start, const Point3F & end, RayInfo *,S32 dl);
-   bool castRayEA(const Point3F & start, const Point3F & end, RayInfo *,S32 dl,S32 HBIndex);
+   bool castRayEA(const Point3F & start, const Point3F & end, RayInfo *,S32 dl,S32 _hitMeshID);
    bool castRayRendered(const Point3F & start, const Point3F & end, RayInfo *,S32 dl);
    bool quickLOS(const Point3F & start, const Point3F & end, S32 dl) { return castRay(start,end,NULL,dl); }
    Point3F support(const Point3F & v, S32 dl);

--- a/Engine/source/ts/tsShapeInstance.h
+++ b/Engine/source/ts/tsShapeInstance.h
@@ -180,6 +180,7 @@ class TSShapeInstance
       bool getFeatures( S32 objectDetail, const MatrixF &mat, const Point3F &n, ConvexFeature *feature, U32 &surfaceKey );
       void support( S32 od, const Point3F &v, F32 *currMaxDP, Point3F *currSupport );
       bool castRay( S32 objectDetail, const Point3F &start, const Point3F &end, RayInfo *info, TSMaterialList *materials );
+      bool castRayEA(S32 objectDetail, const Point3F & start, const Point3F & end, RayInfo *, TSMaterialList* materials);
       bool castRayRendered( S32 objectDetail, const Point3F &start, const Point3F &end, RayInfo *info, TSMaterialList *materials );
 
       bool buildPolyListOpcode( S32 objectDetail, AbstractPolyList *polyList, const Box3F &box, TSMaterialList* materials );
@@ -575,6 +576,7 @@ protected:
    bool buildPolyList(AbstractPolyList *, S32 dl);
    bool getFeatures(const MatrixF& mat, const Point3F& n, ConvexFeature*, S32 dl);
    bool castRay(const Point3F & start, const Point3F & end, RayInfo *,S32 dl);
+   bool castRayEA(const Point3F & start, const Point3F & end, RayInfo *,S32 dl,S32 HBIndex);
    bool castRayRendered(const Point3F & start, const Point3F & end, RayInfo *,S32 dl);
    bool quickLOS(const Point3F & start, const Point3F & end, S32 dl) { return castRay(start,end,NULL,dl); }
    Point3F support(const Point3F & v, S32 dl);

--- a/Templates/Full/game/scripts/server/projectile.cs
+++ b/Templates/Full/game/scripts/server/projectile.cs
@@ -23,10 +23,9 @@
 // "Universal" script methods for projectile damage handling.  You can easily
 // override these support functions with an equivalent namespace method if your
 // weapon needs a unique solution for applying damage.
-
-function ProjectileData::onCollision(%data, %proj, %col, %fade, %pos, %normal)
+function ProjectileData::onCollision(%data, %proj, %col, %fade, %pos, %normal, %hitbox)
 {
-   //echo("ProjectileData::onCollision("@%data.getName()@", "@%proj@", "@%col.getClassName()@", "@%fade@", "@%pos@", "@%normal@")");
+   //echo("ProjectileData::onCollision("@%data.getName()@", "@%proj@", "@%col.getClassName()@", "@%fade@", "@%pos@", "@%normal@", "@%hitbox@")");
 
    // Apply damage to the object all shape base objects
    if (%data.directDamage > 0)


### PR DESCRIPTION
origin: http://www.garagegames.com/community/resource/view/6538/1

Verification methodology/usage:
Functions for stock player physics.
1) Add a convex shape named Hitbox0, Hitbox1 ect (up to 20) to a player model. Can be children of bones so that they animate. (If not, falls back to stock bounding box + percentile lookups.)
2) Go to game scripts\server\projectile.cs
in the method ProjectileData::onCollision(%data, %proj, %col, %fade, %pos, %normal, %hitbox), flip on the remmed out comment. %hitbox should reflect a given hitbox mesh struck.