### PR TITLE
Use GFXDevice::setupGenericShaders for support non Fixed Fuction Pipelines.

### DIFF
--- a/Engine/source/T3D/cameraSpline.cpp
+++ b/Engine/source/T3D/cameraSpline.cpp
@@ -214,7 +214,7 @@ void CameraSpline::renderTimeMap()
 
    // Render the buffer
    GFX->pushWorldMatrix();
-   GFX->disableShaders();
+   GFX->setupGenericShaders();
    GFX->setVertexBuffer(vb);
    GFX->drawPrimitive(GFXLineStrip,0,index);
    GFX->popWorldMatrix();

--- a/Engine/source/T3D/fx/precipitation.cpp
+++ b/Engine/source/T3D/fx/precipitation.cpp
@@ -1668,7 +1668,7 @@ void Precipitation::renderObject(ObjectRenderInst *ri, SceneRenderState *state, 
    }
    else
    {
-      GFX->disableShaders();
+      GFX->setupGenericShaders(GFXDevice::GSTexture);
 
       // We don't support distance fade or lighting without shaders.
       GFX->setStateBlock(mDistantSB);
@@ -1801,7 +1801,7 @@ void Precipitation::renderObject(ObjectRenderInst *ri, SceneRenderState *state, 
       GFX->setShaderConstBuffer(mSplashShaderConsts);
    }
    else
-      GFX->disableShaders();
+      GFX->setupGenericShaders(GFXDevice::GSTexture);
 
    while (curr)
    {

--- a/Engine/source/environment/waterObject.cpp
+++ b/Engine/source/environment/waterObject.cpp
@@ -775,7 +775,7 @@ void WaterObject::drawUnderwaterFilter( SceneRenderState *state )
    GFX->setWorldMatrix( newMat );   
 
    // set up render states
-   GFX->disableShaders();
+   GFX->setupGenericShaders();
    GFX->setStateBlock( mUnderwaterSB );
 
    /*

--- a/Engine/source/gfx/gfxDevice.h
+++ b/Engine/source/gfx/gfxDevice.h
@@ -720,7 +720,7 @@ public:
    virtual U32 getNumRenderTargets() const = 0;
 
    virtual void setShader( GFXShader *shader ) {}
-   virtual void disableShaders() {}
+   virtual void disableShaders() {} // TODO Remove when T3D 4.0
 
    /// Set the buffer! (Actual set happens on the next draw call, just like textures, state blocks, etc)
    void setShaderConstBuffer(GFXShaderConstBuffer* buffer);

--- a/Engine/source/gfx/gfxFontRenderBatcher.cpp
+++ b/Engine/source/gfx/gfxFontRenderBatcher.cpp
@@ -60,7 +60,6 @@ void FontRenderBatcher::render( F32 rot, const Point2F &offset )
       return;
 
    GFX->setStateBlock(mFontSB);
-   GFX->disableShaders();
    for(U32 i = 0; i < GFX->getNumSamplers(); i++)
       GFX->setTexture(i, NULL);
 
@@ -177,6 +176,7 @@ void FontRenderBatcher::render( F32 rot, const Point2F &offset )
    AssertFatal(currentPt <= mLength * 6, "FontRenderBatcher::render - too many verts for length of string!");
 
    GFX->setVertexBuffer(verts);
+   GFX->setupGenericShaders( GFXDevice::GSAddColorTexture );
 
    // Now do an optimal render!
    for( S32 i = 0; i < mSheets.size(); i++ )
@@ -186,8 +186,7 @@ void FontRenderBatcher::render( F32 rot, const Point2F &offset )
 
       if(!mSheets[i]->numChars )
          continue;
-
-      GFX->setupGenericShaders( GFXDevice::GSAddColorTexture );
+      
       GFX->setTexture( 0, mFont->getTextureHandle(i) );
       GFX->drawPrimitive(GFXTriangleList, mSheets[i]->startVertex, mSheets[i]->numChars * 2);
    }

--- a/Engine/source/gfx/sim/debugDraw.cpp
+++ b/Engine/source/gfx/sim/debugDraw.cpp
@@ -150,11 +150,10 @@ void DebugDrawer::render()
    }
 
    SimTime curTime = Sim::getCurrentTime();
-  
-   GFX->disableShaders();   
    
    for(DebugPrim **walk = &mHead; *walk; )
    {
+      GFX->setupGenericShaders();   
       DebugPrim *p = *walk;
 
       // Set up the state block...

--- a/Engine/source/gui/worldEditor/guiTerrPreviewCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiTerrPreviewCtrl.cpp
@@ -245,7 +245,7 @@ void GuiTerrPreviewCtrl::onRender(Point2I offset, const RectI &updateRect)
    for(U32 i = 0; i < GFX->getNumSamplers(); i++)
       GFX->setTexture(i, NULL);
    
-   GFX->disableShaders();
+   GFX->setupGenericShaders(GFXDevice::GSModColorTexture);
    
    Point2F terrPos(terrBlock->getPosition().x, terrBlock->getPosition().y);
 

--- a/Engine/source/lighting/common/blobShadow.cpp
+++ b/Engine/source/lighting/common/blobShadow.cpp
@@ -331,7 +331,7 @@ void BlobShadow::render( F32 camDist, const TSRenderState &rdata )
    world.mul(mLightToWorld);
    GFX->setWorldMatrix(world);
 
-   GFX->disableShaders();
+   GFX->setupGenericShaders(GFXDevice::GSModColorTexture);
 
    GFX->setStateBlock(mShadowSB);
    GFX->setTexture(0, smGenericShadowTexture);

--- a/Engine/source/materials/processedCustomMaterial.cpp
+++ b/Engine/source/materials/processedCustomMaterial.cpp
@@ -273,7 +273,7 @@ bool ProcessedCustomMaterial::setupPass( SceneRenderState *state, const SceneDat
    if ( rpd->shader )
       GFX->setShader( rpd->shader );
    else
-      GFX->disableShaders();
+      GFX->setupGenericShaders();
 
    // Set our textures   
    setTextureStages( state, sgData, pass );   

--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -688,7 +688,7 @@ bool ProcessedShaderMaterial::setupPass( SceneRenderState *state, const SceneDat
    }
    else
    {
-      GFX->disableShaders();
+      GFX->setupGenericShaders();
       GFX->setShaderConstBuffer(NULL);
    } 
 

--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -1215,7 +1215,7 @@ void PostEffect::process(  const SceneRenderState *state,
       GFX->setShaderConstBuffer( mShaderConsts );
    }
    else
-      GFX->disableShaders();
+      GFX->setupGenericShaders();
 
    Frustum frustum;
    if ( state )

--- a/Engine/source/renderInstance/renderPassManager.cpp
+++ b/Engine/source/renderInstance/renderPassManager.cpp
@@ -255,7 +255,7 @@ void RenderPassManager::render(SceneRenderState * state)
    GFX->setProjectionMatrix( proj );
       
    // Restore a clean state for subsequent rendering.
-   GFX->disableShaders();
+   GFX->setupGenericShaders();
    for(S32 i = 0; i < GFX->getNumSamplers(); ++i)
       GFX->setTexture(i, NULL);
 }


### PR DESCRIPTION
OpenGL and DirectX11 not support FFP, and GFDevice::disableShaders has not the necessary information to decide the shader to be used.

GFDevice::SetupGenericShaders is used instead of GFDevice::disableShaders.

GFDevice::disableShaders will be deprecated on T3D 4.0
