### PR TITLE
Add sampler names to Templates ShaderData declarations necesary for OpenGL.

### DIFF
--- a/Templates/Empty/game/core/scripts/client/clouds.cs
+++ b/Templates/Empty/game/core/scripts/client/clouds.cs
@@ -32,6 +32,8 @@ singleton ShaderData( CloudLayerShader )
    OGLVertexShaderFile = "shaders/common/gl/cloudLayerV.glsl";
    OGLPixelShaderFile = "shaders/common/gl/cloudLayerP.glsl";
       
+   samplerNames[0] = "$normalHeightMap";
+      
    pixVersion = 2.0;   
 };
 
@@ -44,8 +46,10 @@ singleton ShaderData( BasicCloudsShader )
    DXVertexShaderFile   = "shaders/common/basicCloudsV.hlsl";
    DXPixelShaderFile    = "shaders/common/basicCloudsP.hlsl";
    
-   //OGLVertexShaderFile = "shaders/common/gl/basicCloudsV.glsl";
-   //OGLPixelShaderFile = "shaders/common/gl/basicCloudsP.glsl";
+   OGLVertexShaderFile = "shaders/common/gl/basicCloudsV.glsl";
+   OGLPixelShaderFile = "shaders/common/gl/basicCloudsP.glsl";
+   
+   samplerNames[0] = "$diffuseMap";
       
    pixVersion = 2.0;   
 };

--- a/Templates/Empty/game/core/scripts/client/lighting/advanced/lightViz.cs
+++ b/Templates/Empty/game/core/scripts/client/lighting/advanced/lightViz.cs
@@ -53,7 +53,7 @@ new ShaderData( AL_DepthVisualizeShader )
    DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile  = "shaders/common/lighting/advanced/dbgDepthVisualizeP.hlsl";
 
-   OGLVertexShaderFile = "shaders/common/postFx/postFxV.glsl";
+   OGLVertexShaderFile = "shaders/common/postFx/gl/postFxV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/dbgDepthVisualizeP.glsl";
 
    samplerNames[0] = "prepassBuffer";
@@ -90,10 +90,10 @@ new ShaderData( AL_NormalsVisualizeShader )
    DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile  = "shaders/common/lighting/advanced/dbgNormalVisualizeP.hlsl";
 
-   OGLVertexShaderFile = "shaders/common/postFx/postFxV.glsl";
+   OGLVertexShaderFile = "shaders/common/postFx/gl/postFxV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/dbgNormalVisualizeP.glsl";
    
-   samplerNames[0] = "prepassTex";
+   samplerNames[0] = "prepassBuffer";
    
    pixVersion = 2.0;
 };
@@ -126,8 +126,8 @@ new ShaderData( AL_LightColorVisualizeShader )
    DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile  = "shaders/common/lighting/advanced/dbgLightColorVisualizeP.hlsl";
 
-   OGLVertexShaderFile = "shaders/common/postFx/postFxV.glsl";
-   OGLPixelShaderFile  = "shaders/common/lighting/advanced/dl/dbgLightColorVisualizeP.glsl";
+   OGLVertexShaderFile = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/dbgLightColorVisualizeP.glsl";
    
    samplerNames[0] = "lightInfoBuffer";
    
@@ -161,8 +161,8 @@ new ShaderData( AL_LightSpecularVisualizeShader )
    DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile  = "shaders/common/lighting/advanced/dbgLightSpecularVisualizeP.hlsl";
 
-   OGLVertexShaderFile = "shaders/common/postFx/postFxV.glsl";
-   OGLPixelShaderFile  = "shaders/common/lighting/advanced/dl/dbgLightSpecularVisualizeP.glsl";
+   OGLVertexShaderFile = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/dbgLightSpecularVisualizeP.glsl";
    
    samplerNames[0] = "lightInfoBuffer";
    

--- a/Templates/Empty/game/core/scripts/client/lighting/advanced/shaders.cs
+++ b/Templates/Empty/game/core/scripts/client/lighting/advanced/shaders.cs
@@ -61,6 +61,11 @@ new ShaderData( AL_VectorLightShader )
    OGLVertexShaderFile = "shaders/common/lighting/advanced/gl/farFrustumQuadV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/vectorLightP.glsl";
    
+   samplerNames[0] = "$prePassBuffer";
+   samplerNames[1] = "$ShadowMap";
+   samplerNames[2] = "$ssaoMask";
+   samplerNames[3] = "$gTapRotationTex";
+   
    pixVersion = 3.0;
 };
 
@@ -121,6 +126,11 @@ new ShaderData( AL_PointLightShader )
    OGLVertexShaderFile = "shaders/common/lighting/advanced/gl/convexGeometryV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/pointLightP.glsl";
 
+   samplerNames[0] = "$prePassBuffer";
+   samplerNames[1] = "$shadowMap";
+   samplerNames[2] = "$cookieMap";
+   samplerNames[3] = "$gTapRotationTex";
+   
    pixVersion = 3.0;
 };
 
@@ -131,7 +141,7 @@ new CustomMaterial( AL_PointLightMaterial )
    
    sampler["prePassBuffer"] = "#prepass";
    sampler["shadowMap"] = "$dynamiclight";
-   sampler["cookieTex"] = "$dynamiclightmask";
+   sampler["cookieMap"] = "$dynamiclightmask";
    
    target = "lightinfo";
    
@@ -147,6 +157,11 @@ new ShaderData( AL_SpotLightShader )
    OGLVertexShaderFile = "shaders/common/lighting/advanced/gl/convexGeometryV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/spotLightP.glsl";
    
+   samplerNames[0] = "$prePassBuffer";
+   samplerNames[1] = "$shadowMap";
+   samplerNames[2] = "$cookieMap";
+   samplerNames[3] = "$gTapRotationTex";   
+   
    pixVersion = 3.0;
 };
 
@@ -157,7 +172,7 @@ new CustomMaterial( AL_SpotLightMaterial )
    
    sampler["prePassBuffer"] = "#prepass";
    sampler["shadowMap"] = "$dynamiclight";
-   sampler["cookieTex"] = "$dynamiclightmask";
+   sampler["cookieMap"] = "$dynamiclightmask";
    
    target = "lightinfo";
    
@@ -210,6 +225,8 @@ new ShaderData( AL_ParticlePointLightShader )
 
    OGLVertexShaderFile = "shaders/common/lighting/advanced/gl/convexGeometryV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/pointLightP.glsl";
+   
+   samplerNames[0] = "$prePassBuffer";   
       
    pixVersion = 3.0;
 };

--- a/Templates/Empty/game/core/scripts/client/lighting/advanced/shadowViz.cs
+++ b/Templates/Empty/game/core/scripts/client/lighting/advanced/shadowViz.cs
@@ -28,6 +28,9 @@ new ShaderData( AL_ShadowVisualizeShader )
    OGLVertexShaderFile = "shaders/common/gl/guiMaterialV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/dbgShadowVisualizeP.glsl";
    
+   samplerNames[0] = "$shadowMap";
+   samplerNames[1] = "$depthViz";
+   
    pixVersion = 2.0;
 };
 

--- a/Templates/Empty/game/core/scripts/client/lighting/basic/init.cs
+++ b/Templates/Empty/game/core/scripts/client/lighting/basic/init.cs
@@ -46,6 +46,8 @@ singleton ShaderData( BL_ProjectedShadowShaderData )
    OGLVertexShaderFile     = "shaders/common/gl/projectedShadowV.glsl";
    OGLPixelShaderFile      = "shaders/common/gl/projectedShadowP.glsl";   
       
+   samplerNames[0] = "inputTex";
+   
    pixVersion = 2.0;
 };
 

--- a/Templates/Empty/game/core/scripts/client/lighting/basic/shadowFilter.cs
+++ b/Templates/Empty/game/core/scripts/client/lighting/basic/shadowFilter.cs
@@ -26,8 +26,8 @@ singleton ShaderData( BL_ShadowFilterShaderV )
    DXVertexShaderFile 	= "shaders/common/lighting/basic/shadowFilterV.hlsl";
    DXPixelShaderFile 	= "shaders/common/lighting/basic/shadowFilterP.hlsl";
    
-   OGLVertexShaderFile 	= "shaders/common/lighting/basic/gl/shadowFilterV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/lighting/basic/gl/shadowFilterP.glsl";
+   OGLVertexShaderFile  = "shaders/common/lighting/basic/gl/shadowFilterV.glsl";
+   OGLPixelShaderFile   = "shaders/common/lighting/basic/gl/shadowFilterP.glsl";
 
    samplerNames[0] = "$diffuseMap";
 

--- a/Templates/Empty/game/core/scripts/client/postFx.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx.cs
@@ -36,8 +36,8 @@ singleton ShaderData( PFX_PassthruShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/passthruP.hlsl";
          
-//   OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-//   OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
       
    samplerNames[0] = "$inputTex";
    

--- a/Templates/Empty/game/core/scripts/client/postFx/GammaPostFX.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/GammaPostFX.cs
@@ -25,6 +25,12 @@ singleton ShaderData( GammaShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/gammaP.hlsl";
 
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/gammaP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
+   samplerNames[1] = "$colorCorrectionTex";
+
    pixVersion = 2.0;   
 };
 

--- a/Templates/Empty/game/core/scripts/client/postFx/MLAA.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/MLAA.cs
@@ -47,7 +47,11 @@ singleton ShaderData( MLAA_EdgeDetectionShader )
    DXVertexShaderFile 	= "shaders/common/postFx/mlaa/offsetV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/mlaa/edgeDetectionP.hlsl";
 
+   OGLVertexShaderFile  = "shaders/common/postFx/mlaa/gl/offsetV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/mlaa/gl/edgeDetectionP.glsl";
+
    samplerNames[0] = "$colorMapG";
+   samplerNames[1] = "$prepassMap";
 
    pixVersion = 3.0;
 };
@@ -71,6 +75,9 @@ singleton ShaderData( MLAA_BlendWeightCalculationShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/mlaa/passthruV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/mlaa/blendWeightCalculationP.hlsl";
+
+   OGLVertexShaderFile  = "shaders/common/postFx/mlaa/gl/passthruV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/mlaa/gl/blendWeightCalculationP.glsl";
 
    samplerNames[0] = "$edgesMap";
    samplerNames[1] = "$edgesMapL";
@@ -98,6 +105,9 @@ singleton ShaderData( MLAA_NeighborhoodBlendingShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/mlaa/offsetV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/mlaa/neighborhoodBlendingP.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/mlaa/gl/offsetV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/mlaa/gl/neighborhoodBlendingP.glsl";
 
    samplerNames[0] = "$blendMap";
    samplerNames[1] = "$colorMapL";

--- a/Templates/Empty/game/core/scripts/client/postFx/MotionBlurFx.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/MotionBlurFx.cs
@@ -25,6 +25,12 @@ singleton ShaderData( PFX_MotionBlurShader )
    DXVertexShaderFile   = "shaders/common/postFx/postFxV.hlsl";  //we use the bare-bones postFxV.hlsl
    DXPixelShaderFile    = "shaders/common/postFx/motionBlurP.hlsl";  //new pixel shader
    
+   OGLVertexShaderFile   = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile    = "shaders/common/postFx/gl/motionBlurP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
+   samplerNames[1] = "$prepassTex";
+   
    pixVersion = 3.0;  
 };  
 

--- a/Templates/Empty/game/core/scripts/client/postFx/caustics.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/caustics.cs
@@ -38,9 +38,13 @@ singleton ShaderData( PFX_CausticsShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/caustics/causticsP.hlsl";
          
-   //OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-   //OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/caustics/gl/causticsP.glsl";
       
+   samplerNames[0] = "$prepassTex";
+   samplerNames[1] = "$causticsTex0";
+   samplerNames[2] = "$causticsTex1";
+   
    pixVersion = 3.0;
 };
 

--- a/Templates/Empty/game/core/scripts/client/postFx/chromaticLens.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/chromaticLens.cs
@@ -47,6 +47,12 @@ singleton ShaderData( PFX_ChromaticLensShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/chromaticLens.hlsl"; 
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/chromaticLens.glsl";
+   
+   samplerNames[0] = "$backBuffer";
+   
    pixVersion = 3.0;
 };
 

--- a/Templates/Empty/game/core/scripts/client/postFx/dof.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/dof.cs
@@ -320,6 +320,13 @@ singleton ShaderData( PFX_DOFDownSampleShader )
 {      
    DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_DownSample_V.hlsl";   
    DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_DownSample_P.hlsl";            
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/dof/gl/DOF_DownSample_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/dof/gl/DOF_DownSample_P.glsl";
+   
+   samplerNames[0] = "$colorSampler";
+   samplerNames[1] = "$depthSampler";
+   
    pixVersion = 3.0;
 };
 
@@ -327,6 +334,12 @@ singleton ShaderData( PFX_DOFBlurYShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_Gausian_V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_Gausian_P.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/dof/gl/DOF_Gausian_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/dof/gl/DOF_Gausian_P.glsl";
+   
+   samplerNames[0] = "$diffuseMap";
+   
    pixVersion = 2.0;      
    defines = "BLUR_DIR=float2(0.0,1.0)";         
 };
@@ -340,6 +353,13 @@ singleton ShaderData( PFX_DOFCalcCoCShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_CalcCoC_V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_CalcCoC_P.hlsl";         
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/dof/gl/DOF_CalcCoC_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/dof/gl/DOF_CalcCoC_P.glsl"; 
+
+   samplerNames[0] = "$shrunkSampler";
+   samplerNames[1] = "$blurredSampler";
+   
    pixVersion = 3.0;
 };
 
@@ -347,6 +367,12 @@ singleton ShaderData( PFX_DOFSmallBlurShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_SmallBlur_V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_SmallBlur_P.hlsl";            
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/dof/gl/DOF_SmallBlur_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/dof/gl/DOF_SmallBlur_P.glsl";
+
+   samplerNames[0] = "$colorSampler";
+   
    pixVersion = 3.0;
 };
 
@@ -354,6 +380,15 @@ singleton ShaderData( PFX_DOFFinalShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_Final_V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_Final_P.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/dof/gl/DOF_Final_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/dof/gl/DOF_Final_P.glsl";
+   
+   samplerNames[0] = "$colorSampler";
+   samplerNames[1] = "$smallBlurSampler";
+   samplerNames[2] = "$largeBlurSampler";
+   samplerNames[3] = "$depthSampler";
+   
    pixVersion = 3.0;
 };
 

--- a/Templates/Empty/game/core/scripts/client/postFx/edgeAA.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/edgeAA.cs
@@ -37,10 +37,10 @@ singleton ShaderData( PFX_EdgeAADetectShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/edgeaa/edgeDetectP.hlsl";
          
-   //OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-   //OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/edgeaa/gl/edgeDetectP.glsl";
       
-   samplerNames[0] = "$inputTex";
+   samplerNames[0] = "$prepassBuffer";
    
    pixVersion = 3.0;
 };
@@ -50,10 +50,11 @@ singleton ShaderData( PFX_EdgeAAShader )
    DXVertexShaderFile 	= "shaders/common/postFx/edgeaa/edgeAAV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/edgeaa/edgeAAP.hlsl";
          
-   //OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-   //OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/edgeaa/gl/edgeAAV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/edgeaa/gl/edgeAAP.glsl";
       
-   samplerNames[0] = "$inputTex";
+   samplerNames[0] = "$edgeBuffer";
+   samplerNames[1] = "$backBuffer";
    
    pixVersion = 3.0;
 };
@@ -63,10 +64,10 @@ singleton ShaderData( PFX_EdgeAADebugShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/edgeaa/dbgEdgeDisplayP.hlsl";
          
-   //OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-   //OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/edgeaa/gl/dbgEdgeDisplayP.glsl";
       
-   samplerNames[0] = "$inputTex";
+   samplerNames[0] = "$edgeBuffer";
    
    pixVersion = 3.0;
 };

--- a/Templates/Empty/game/core/scripts/client/postFx/flash.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/flash.cs
@@ -24,6 +24,11 @@ singleton ShaderData( PFX_FlashShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/flashP.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/flashP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
 
    defines = "WHITE_COLOR=float4(1.0,1.0,1.0,0.0);MUL_COLOR=float4(1.0,0.25,0.25,0.0)";
 

--- a/Templates/Empty/game/core/scripts/client/postFx/fog.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/fog.cs
@@ -29,8 +29,8 @@ singleton ShaderData( FogPassShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/fogP.hlsl";
          
-//   OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-//   OGLPixelShaderFile   = "shaders/common/postFx/gl/fogP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/fogP.glsl";
             
    samplerNames[0] = "$prepassTex";
    
@@ -75,10 +75,12 @@ singleton ShaderData( UnderwaterFogPassShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/underwaterFogP.hlsl";
          
-//   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
-//   OGLPixelShaderFile   = "shaders/common/postFx/gl/fogP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/underwaterFogP.glsl";
             
    samplerNames[0] = "$prepassTex";
+   samplerNames[1] = "$backbuffer";
+   samplerNames[2] = "$waterDepthGradMap";
    
    pixVersion = 2.0;      
 };

--- a/Templates/Empty/game/core/scripts/client/postFx/fxaa.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/fxaa.cs
@@ -39,6 +39,9 @@ singleton ShaderData( FXAA_ShaderData )
    DXVertexShaderFile 	= "shaders/common/postFx/fxaa/fxaaV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/fxaa/fxaaP.hlsl";
    
+   OGLVertexShaderFile  = "shaders/common/postFx/fxaa/gl/fxaaV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/fxaa/gl/fxaaP.glsl";
+   
    samplerNames[0] = "$colorTex";
 
    pixVersion = 3.0;

--- a/Templates/Empty/game/core/scripts/client/postFx/glow.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/glow.cs
@@ -26,8 +26,8 @@ singleton ShaderData( PFX_GlowBlurVertShader )
    DXVertexShaderFile 	= "shaders/common/postFx/glowBlurV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/glowBlurP.hlsl";
    
-//   OGLVertexShaderFile  = "shaders/common/postFx/glowBlurV.glsl";
-//   OGLPixelShaderFile   = "shaders/common/postFx/glowBlurP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/glowBlurV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/glowBlurP.glsl";
       
    defines = "BLUR_DIR=float2(0.0,1.0)";
 

--- a/Templates/Empty/game/core/scripts/client/postFx/hdr.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/hdr.cs
@@ -77,7 +77,13 @@ $HDRPostFX::colorCorrectionRamp = "core/scripts/client/postFx/null_color_ramp.pn
 singleton ShaderData( HDR_BrightPassShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
-   DXPixelShaderFile 	= "shaders/common/postFx/hdr/brightPassFilterP.hlsl";
+   DXPixelShaderFile 	= "shaders/common/postFx/hdr/brightPassFilterP.hlsl";   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/brightPassFilterP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   samplerNames[1] = "$luminanceTex";
+   
    pixVersion = 3.0;
 };
 
@@ -85,6 +91,11 @@ singleton ShaderData( HDR_DownScale4x4Shader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/hdr/downScale4x4V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/downScale4x4P.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/hdr/gl/downScale4x4V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/downScale4x4P.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 2.0;
 };
 
@@ -92,6 +103,11 @@ singleton ShaderData( HDR_BloomGaussBlurHShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/bloomGaussBlurHP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/bloomGaussBlurHP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 3.0;
 };
 
@@ -99,6 +115,11 @@ singleton ShaderData( HDR_BloomGaussBlurVShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/bloomGaussBlurVP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/bloomGaussBlurVP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 3.0;
 };
 
@@ -106,6 +127,11 @@ singleton ShaderData( HDR_SampleLumShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/sampleLumInitialP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/sampleLumInitialP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 3.0;
 };
 
@@ -113,6 +139,11 @@ singleton ShaderData( HDR_DownSampleLumShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/sampleLumIterativeP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/sampleLumIterativeP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 3.0;
 };
 
@@ -120,6 +151,12 @@ singleton ShaderData( HDR_CalcAdaptedLumShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/calculateAdaptedLumP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/calculateAdaptedLumP.glsl";
+   
+   samplerNames[0] = "$currLum";
+   samplerNames[1] = "$lastAdaptedLum";
+   
    pixVersion = 3.0;
 };
 
@@ -127,6 +164,14 @@ singleton ShaderData( HDR_CombineShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/finalPassCombineP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/finalPassCombineP.glsl";
+   
+   samplerNames[0] = "$sceneTex";
+   samplerNames[1] = "$luminanceTex";
+   samplerNames[2] = "$bloomTex";
+   samplerNames[3] = "$colorCorrectionTex";
+   
    pixVersion = 3.0;
 };
 
@@ -421,6 +466,11 @@ singleton ShaderData( LuminanceVisShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/luminanceVisP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/luminanceVisP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 3.0;
 };
 

--- a/Templates/Empty/game/core/scripts/client/postFx/lightRay.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/lightRay.cs
@@ -34,6 +34,12 @@ singleton ShaderData( LightRayOccludeShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/lightRay/lightRayOccludeP.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/lightRay/gl/lightRayOccludeP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
+   samplerNames[1] = "$prepassTex";
 
    pixVersion = 3.0;   
 };
@@ -42,6 +48,12 @@ singleton ShaderData( LightRayShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/lightRay/lightRayP.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/lightRay/gl/lightRayP.glsl";
+   
+   samplerNames[0] = "$frameSampler";
+   samplerNames[1] = "$backBuffer";
 
    pixVersion = 3.0;   
 };

--- a/Templates/Empty/game/core/scripts/client/postFx/ovrBarrelDistortion.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/ovrBarrelDistortion.cs
@@ -32,6 +32,11 @@ singleton ShaderData( OVRMonoToStereoShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/oculusvr/monoToStereoP.hlsl";
+   
+   //OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.hlsl";
+   //OGLPixelShaderFile   = "shaders/common/postFx/oculusvr/gl/monoToStereoP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
 
    pixVersion = 2.0;   
 };
@@ -40,6 +45,11 @@ singleton ShaderData( OVRBarrelDistortionShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/oculusvr/barrelDistortionP.hlsl";
+   
+   //OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   //OGLPixelShaderFile   = "shaders/common/postFx/oculusvr/gl/barrelDistortionP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
 
    pixVersion = 2.0;   
 };

--- a/Templates/Empty/game/core/scripts/client/postFx/ssao.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/ssao.cs
@@ -152,6 +152,14 @@ singleton ShaderData( SSAOShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/ssao/SSAO_P.hlsl";            
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/ssao/gl/SSAO_P.glsl";
+
+   samplerNames[0] = "$prepassMap";
+   samplerNames[1] = "$randNormalTex";
+   samplerNames[2] = "$powTable";
+   
    pixVersion = 3.0;
 };
 
@@ -159,6 +167,13 @@ singleton ShaderData( SSAOBlurYShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/ssao/SSAO_Blur_V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/ssao/SSAO_Blur_P.hlsl";   
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/ssao/gl/SSAO_Blur_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/ssao/gl/SSAO_Blur_P.glsl";
+   
+   samplerNames[0] = "$occludeMap";
+   samplerNames[1] = "$prepassMap";
+
    pixVersion = 3.0;      
    
    defines = "BLUR_DIR=float2(0.0,1.0)";         
@@ -266,6 +281,10 @@ singleton ShaderData( SSAOPowTableShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/ssao/SSAO_PowerTable_V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/ssao/SSAO_PowerTable_P.hlsl";            
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/ssao/gl/SSAO_PowerTable_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/ssao/gl/SSAO_PowerTable_P.glsl";   
+   
    pixVersion = 2.0;
 };
 

--- a/Templates/Empty/game/core/scripts/client/postFx/turbulence.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/turbulence.cs
@@ -35,6 +35,10 @@ singleton ShaderData( PFX_TurbulenceShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/turbulenceP.hlsl";
            
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/turbulenceP.glsl";
+           
+   samplerNames[0] = "$inputTex";
    pixVersion = 3.0;
 };
 

--- a/Templates/Empty/game/core/scripts/client/scatterSky.cs
+++ b/Templates/Empty/game/core/scripts/client/scatterSky.cs
@@ -44,5 +44,7 @@ singleton ShaderData( ScatterSkyShaderData )
    OGLVertexShaderFile     = "shaders/common/gl/scatterSkyV.glsl";
    OGLPixelShaderFile      = "shaders/common/gl/scatterSkyP.glsl";   
    
+   samplerNames[0] = "$nightSky";
+   
    pixVersion = 2.0;
 };

--- a/Templates/Empty/game/core/scripts/client/shaders.cs
+++ b/Templates/Empty/game/core/scripts/client/shaders.cs
@@ -33,6 +33,10 @@ singleton ShaderData( ParticlesShaderData )
    OGLVertexShaderFile     = "shaders/common/gl/particlesV.glsl";
    OGLPixelShaderFile      = "shaders/common/gl/particlesP.glsl";
    
+   samplerNames[0] = "$diffuseMap";
+   samplerNames[1] = "$prepassTex";
+   samplerNames[2] = "$paraboloidLightMap";
+   
    pixVersion = 2.0;
 };
 
@@ -43,6 +47,9 @@ singleton ShaderData( OffscreenParticleCompositeShaderData )
    
    OGLVertexShaderFile     = "shaders/common/gl/particleCompositeV.glsl";
    OGLPixelShaderFile      = "shaders/common/gl/particleCompositeP.glsl";
+   
+   samplerNames[0] = "$colorSource";
+   samplerNames[1] = "$edgeSource";
    
    pixVersion = 2.0;
 };
@@ -55,8 +62,8 @@ new ShaderData( ReflectBump )
    DXVertexShaderFile 	= "shaders/common/planarReflectBumpV.hlsl";
    DXPixelShaderFile 	= "shaders/common/planarReflectBumpP.hlsl";
    
-   OGLVertexShaderFile 	= "shaders/common/gl/planarReflectBumpV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/gl/planarReflectBumpP.glsl";
+   OGLVertexShaderFile  = "shaders/common/gl/planarReflectBumpV.glsl";
+   OGLPixelShaderFile   = "shaders/common/gl/planarReflectBumpP.glsl";
               
    samplerNames[0] = "$diffuseMap";
    samplerNames[1] = "$refractMap";
@@ -70,8 +77,8 @@ new ShaderData( Reflect )
    DXVertexShaderFile 	= "shaders/common/planarReflectV.hlsl";
    DXPixelShaderFile 	= "shaders/common/planarReflectP.hlsl";
    
-   OGLVertexShaderFile 	= "shaders/common/gl/planarReflectV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/gl/planarReflectP.glsl";
+   OGLVertexShaderFile  = "shaders/common/gl/planarReflectV.glsl";
+   OGLPixelShaderFile   = "shaders/common/gl/planarReflectP.glsl";
    
    samplerNames[0] = "$diffuseMap";
    samplerNames[1] = "$refractMap";

--- a/Templates/Empty/game/core/scripts/client/terrainBlock.cs
+++ b/Templates/Empty/game/core/scripts/client/terrainBlock.cs
@@ -29,5 +29,8 @@ singleton ShaderData( TerrainBlendShader )
    OGLVertexShaderFile = "shaders/common/terrain/gl/blendV.glsl";
    OGLPixelShaderFile = "shaders/common/terrain/gl/blendP.glsl";
    
+   samplerNames[0] = "layerTex";
+   samplerNames[1] = "textureMap";
+   
    pixVersion = 2.0;
 };

--- a/Templates/Empty/game/core/scripts/client/water.cs
+++ b/Templates/Empty/game/core/scripts/client/water.cs
@@ -34,6 +34,14 @@ singleton ShaderData( WaterShader )
    OGLVertexShaderFile = "shaders/common/water/gl/waterV.glsl";
    OGLPixelShaderFile = "shaders/common/water/gl/waterP.glsl";
    
+   samplerNames[0] = "$bumpMap";  // noise
+   samplerNames[1] = "$prepassTex";  // #prepass
+   samplerNames[2] = "$reflectMap"; // $reflectbuff
+   samplerNames[3] = "$refractBuff";  // $backbuff
+   samplerNames[4] = "$skyMap";  // $cubemap   
+   samplerNames[5] = "$foamMap";  // foam     
+   samplerNames[6] = "$depthGradMap"; // depthMap ( color gradient ) 
+   
    pixVersion = 3.0;
 };
 
@@ -73,6 +81,14 @@ singleton CustomMaterial( WaterMat )
    sampler["prepassTex"] = "#prepass";
    sampler["reflectMap"] = "$reflectbuff";
    sampler["refractBuff"] = "$backbuff";
+   // These samplers are set in code not here.
+   // This is to allow different WaterObject instances
+   // to use this same material but override these textures
+   // per instance.
+   //sampler["bumpMap"] = "";    
+   //sampler["skyMap"] = "";
+   //sampler["foamMap"] = "";  
+   //sampler["depthGradMap"] = "";
    
    shader = WaterShader;
    stateBlock = WaterStateBlock;
@@ -85,16 +101,9 @@ singleton CustomMaterial( WaterMat )
 // Underwater
 //-----------------------------------------------------------------------------
 
-singleton ShaderData( UnderWaterShader )
-{
-   DXVertexShaderFile 	= "shaders/common/water/waterV.hlsl";
-   DXPixelShaderFile 	= "shaders/common/water/waterP.hlsl";   
-   
-   OGLVertexShaderFile 	= "shaders/common/water/gl/waterV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/water/gl/waterP.glsl"; 
-   
+singleton ShaderData( UnderWaterShader : WaterShader )
+{   
    defines = "UNDERWATER";   
-   pixVersion = 3.0;
 };
 
 singleton CustomMaterial( UnderwaterMat )
@@ -125,8 +134,14 @@ singleton ShaderData( WaterBasicShader )
    DXVertexShaderFile 	= "shaders/common/water/waterBasicV.hlsl";
    DXPixelShaderFile 	= "shaders/common/water/waterBasicP.hlsl";
    
-   OGLVertexShaderFile 	= "shaders/common/water/gl/waterBasicV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/water/gl/waterBasicP.glsl"; 
+   OGLVertexShaderFile  = "shaders/common/water/gl/waterBasicV.glsl";
+   OGLPixelShaderFile   = "shaders/common/water/gl/waterBasicP.glsl";
+   
+   samplerNames[0] = "$bumpMap";
+   samplerNames[2] = "$reflectMap";
+   samplerNames[3] = "$refractBuff";
+   samplerNames[4] = "$skyMap";
+   samplerNames[5] = "$depthGradMap";
    
    pixVersion = 2.0;
 };
@@ -170,16 +185,9 @@ singleton CustomMaterial( WaterBasicMat )
 // Basic UnderWater
 //-----------------------------------------------------------------------------
 
-singleton ShaderData( UnderWaterBasicShader )
+singleton ShaderData( UnderWaterBasicShader : WaterBasicShader)
 {
-   DXVertexShaderFile 	= "shaders/common/water/waterBasicV.hlsl";
-   DXPixelShaderFile 	= "shaders/common/water/waterBasicP.hlsl";   
-   
-   OGLVertexShaderFile 	= "shaders/common/water/gl/waterBasicV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/water/gl/waterBasicP.glsl";
-   
-   defines = "UNDERWATER";   
-   pixVersion = 2.0;
+   defines = "UNDERWATER";  
 };
 
 singleton CustomMaterial( UnderwaterBasicMat )

--- a/Templates/Full/game/core/scripts/client/clouds.cs
+++ b/Templates/Full/game/core/scripts/client/clouds.cs
@@ -32,6 +32,8 @@ singleton ShaderData( CloudLayerShader )
    OGLVertexShaderFile = "shaders/common/gl/cloudLayerV.glsl";
    OGLPixelShaderFile = "shaders/common/gl/cloudLayerP.glsl";
       
+   samplerNames[0] = "$normalHeightMap";
+      
    pixVersion = 2.0;   
 };
 
@@ -44,8 +46,10 @@ singleton ShaderData( BasicCloudsShader )
    DXVertexShaderFile   = "shaders/common/basicCloudsV.hlsl";
    DXPixelShaderFile    = "shaders/common/basicCloudsP.hlsl";
    
-   //OGLVertexShaderFile = "shaders/common/gl/basicCloudsV.glsl";
-   //OGLPixelShaderFile = "shaders/common/gl/basicCloudsP.glsl";
+   OGLVertexShaderFile = "shaders/common/gl/basicCloudsV.glsl";
+   OGLPixelShaderFile = "shaders/common/gl/basicCloudsP.glsl";
+   
+   samplerNames[0] = "$diffuseMap";
       
    pixVersion = 2.0;   
 };

--- a/Templates/Full/game/core/scripts/client/lighting/advanced/lightViz.cs
+++ b/Templates/Full/game/core/scripts/client/lighting/advanced/lightViz.cs
@@ -53,7 +53,7 @@ new ShaderData( AL_DepthVisualizeShader )
    DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile  = "shaders/common/lighting/advanced/dbgDepthVisualizeP.hlsl";
 
-   OGLVertexShaderFile = "shaders/common/postFx/postFxV.glsl";
+   OGLVertexShaderFile = "shaders/common/postFx/gl/postFxV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/dbgDepthVisualizeP.glsl";
 
    samplerNames[0] = "prepassBuffer";
@@ -90,10 +90,10 @@ new ShaderData( AL_NormalsVisualizeShader )
    DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile  = "shaders/common/lighting/advanced/dbgNormalVisualizeP.hlsl";
 
-   OGLVertexShaderFile = "shaders/common/postFx/postFxV.glsl";
+   OGLVertexShaderFile = "shaders/common/postFx/gl/postFxV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/dbgNormalVisualizeP.glsl";
    
-   samplerNames[0] = "prepassTex";
+   samplerNames[0] = "prepassBuffer";
    
    pixVersion = 2.0;
 };
@@ -126,8 +126,8 @@ new ShaderData( AL_LightColorVisualizeShader )
    DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile  = "shaders/common/lighting/advanced/dbgLightColorVisualizeP.hlsl";
 
-   OGLVertexShaderFile = "shaders/common/postFx/postFxV.glsl";
-   OGLPixelShaderFile  = "shaders/common/lighting/advanced/dl/dbgLightColorVisualizeP.glsl";
+   OGLVertexShaderFile = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/dbgLightColorVisualizeP.glsl";
    
    samplerNames[0] = "lightInfoBuffer";
    
@@ -161,8 +161,8 @@ new ShaderData( AL_LightSpecularVisualizeShader )
    DXVertexShaderFile = "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile  = "shaders/common/lighting/advanced/dbgLightSpecularVisualizeP.hlsl";
 
-   OGLVertexShaderFile = "shaders/common/postFx/postFxV.glsl";
-   OGLPixelShaderFile  = "shaders/common/lighting/advanced/dl/dbgLightSpecularVisualizeP.glsl";
+   OGLVertexShaderFile = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/dbgLightSpecularVisualizeP.glsl";
    
    samplerNames[0] = "lightInfoBuffer";
    

--- a/Templates/Full/game/core/scripts/client/lighting/advanced/shaders.cs
+++ b/Templates/Full/game/core/scripts/client/lighting/advanced/shaders.cs
@@ -61,6 +61,11 @@ new ShaderData( AL_VectorLightShader )
    OGLVertexShaderFile = "shaders/common/lighting/advanced/gl/farFrustumQuadV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/vectorLightP.glsl";
    
+   samplerNames[0] = "$prePassBuffer";
+   samplerNames[1] = "$ShadowMap";
+   samplerNames[2] = "$ssaoMask";
+   samplerNames[3] = "$gTapRotationTex";
+   
    pixVersion = 3.0;
 };
 
@@ -121,6 +126,11 @@ new ShaderData( AL_PointLightShader )
    OGLVertexShaderFile = "shaders/common/lighting/advanced/gl/convexGeometryV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/pointLightP.glsl";
 
+   samplerNames[0] = "$prePassBuffer";
+   samplerNames[1] = "$shadowMap";
+   samplerNames[2] = "$cookieMap";
+   samplerNames[3] = "$gTapRotationTex";
+   
    pixVersion = 3.0;
 };
 
@@ -131,7 +141,7 @@ new CustomMaterial( AL_PointLightMaterial )
    
    sampler["prePassBuffer"] = "#prepass";
    sampler["shadowMap"] = "$dynamiclight";
-   sampler["cookieTex"] = "$dynamiclightmask";
+   sampler["cookieMap"] = "$dynamiclightmask";
    
    target = "lightinfo";
    
@@ -147,6 +157,11 @@ new ShaderData( AL_SpotLightShader )
    OGLVertexShaderFile = "shaders/common/lighting/advanced/gl/convexGeometryV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/spotLightP.glsl";
    
+   samplerNames[0] = "$prePassBuffer";
+   samplerNames[1] = "$shadowMap";
+   samplerNames[2] = "$cookieMap";
+   samplerNames[3] = "$gTapRotationTex";   
+   
    pixVersion = 3.0;
 };
 
@@ -157,7 +172,7 @@ new CustomMaterial( AL_SpotLightMaterial )
    
    sampler["prePassBuffer"] = "#prepass";
    sampler["shadowMap"] = "$dynamiclight";
-   sampler["cookieTex"] = "$dynamiclightmask";
+   sampler["cookieMap"] = "$dynamiclightmask";
    
    target = "lightinfo";
    
@@ -210,6 +225,8 @@ new ShaderData( AL_ParticlePointLightShader )
 
    OGLVertexShaderFile = "shaders/common/lighting/advanced/gl/convexGeometryV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/pointLightP.glsl";
+   
+   samplerNames[0] = "$prePassBuffer";   
       
    pixVersion = 3.0;
 };

--- a/Templates/Full/game/core/scripts/client/lighting/advanced/shadowViz.cs
+++ b/Templates/Full/game/core/scripts/client/lighting/advanced/shadowViz.cs
@@ -28,6 +28,9 @@ new ShaderData( AL_ShadowVisualizeShader )
    OGLVertexShaderFile = "shaders/common/gl/guiMaterialV.glsl";
    OGLPixelShaderFile  = "shaders/common/lighting/advanced/gl/dbgShadowVisualizeP.glsl";
    
+   samplerNames[0] = "$shadowMap";
+   samplerNames[1] = "$depthViz";
+   
    pixVersion = 2.0;
 };
 

--- a/Templates/Full/game/core/scripts/client/lighting/basic/init.cs
+++ b/Templates/Full/game/core/scripts/client/lighting/basic/init.cs
@@ -46,6 +46,8 @@ singleton ShaderData( BL_ProjectedShadowShaderData )
    OGLVertexShaderFile     = "shaders/common/gl/projectedShadowV.glsl";
    OGLPixelShaderFile      = "shaders/common/gl/projectedShadowP.glsl";   
       
+   samplerNames[0] = "inputTex";
+   
    pixVersion = 2.0;
 };
 

--- a/Templates/Full/game/core/scripts/client/lighting/basic/shadowFilter.cs
+++ b/Templates/Full/game/core/scripts/client/lighting/basic/shadowFilter.cs
@@ -26,8 +26,8 @@ singleton ShaderData( BL_ShadowFilterShaderV )
    DXVertexShaderFile 	= "shaders/common/lighting/basic/shadowFilterV.hlsl";
    DXPixelShaderFile 	= "shaders/common/lighting/basic/shadowFilterP.hlsl";
    
-   OGLVertexShaderFile 	= "shaders/common/lighting/basic/gl/shadowFilterV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/lighting/basic/gl/shadowFilterP.glsl";
+   OGLVertexShaderFile  = "shaders/common/lighting/basic/gl/shadowFilterV.glsl";
+   OGLPixelShaderFile   = "shaders/common/lighting/basic/gl/shadowFilterP.glsl";
 
    samplerNames[0] = "$diffuseMap";
 

--- a/Templates/Full/game/core/scripts/client/postFx.cs
+++ b/Templates/Full/game/core/scripts/client/postFx.cs
@@ -36,8 +36,8 @@ singleton ShaderData( PFX_PassthruShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/passthruP.hlsl";
          
-//   OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-//   OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
       
    samplerNames[0] = "$inputTex";
    

--- a/Templates/Full/game/core/scripts/client/postFx/GammaPostFX.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/GammaPostFX.cs
@@ -25,6 +25,12 @@ singleton ShaderData( GammaShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/gammaP.hlsl";
 
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/gammaP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
+   samplerNames[1] = "$colorCorrectionTex";
+
    pixVersion = 2.0;   
 };
 

--- a/Templates/Full/game/core/scripts/client/postFx/MLAA.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/MLAA.cs
@@ -46,8 +46,12 @@ singleton ShaderData( MLAA_EdgeDetectionShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/mlaa/offsetV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/mlaa/edgeDetectionP.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/mlaa/gl/offsetV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/mlaa/gl/edgeDetectionP.glsl";
 
    samplerNames[0] = "$colorMapG";
+   samplerNames[1] = "$prepassMap";
 
    pixVersion = 3.0;
 };
@@ -71,6 +75,9 @@ singleton ShaderData( MLAA_BlendWeightCalculationShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/mlaa/passthruV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/mlaa/blendWeightCalculationP.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/mlaa/gl/passthruV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/mlaa/gl/blendWeightCalculationP.glsl";
 
    samplerNames[0] = "$edgesMap";
    samplerNames[1] = "$edgesMapL";
@@ -98,6 +105,9 @@ singleton ShaderData( MLAA_NeighborhoodBlendingShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/mlaa/offsetV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/mlaa/neighborhoodBlendingP.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/mlaa/gl/offsetV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/mlaa/gl/neighborhoodBlendingP.glsl";
 
    samplerNames[0] = "$blendMap";
    samplerNames[1] = "$colorMapL";

--- a/Templates/Full/game/core/scripts/client/postFx/MotionBlurFx.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/MotionBlurFx.cs
@@ -25,6 +25,12 @@ singleton ShaderData( PFX_MotionBlurShader )
    DXVertexShaderFile   = "shaders/common/postFx/postFxV.hlsl";  //we use the bare-bones postFxV.hlsl
    DXPixelShaderFile    = "shaders/common/postFx/motionBlurP.hlsl";  //new pixel shader
    
+   OGLVertexShaderFile   = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile    = "shaders/common/postFx/gl/motionBlurP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
+   samplerNames[1] = "$prepassTex";
+   
    pixVersion = 3.0;  
 };  
 

--- a/Templates/Full/game/core/scripts/client/postFx/caustics.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/caustics.cs
@@ -38,9 +38,13 @@ singleton ShaderData( PFX_CausticsShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/caustics/causticsP.hlsl";
          
-   //OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-   //OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/caustics/gl/causticsP.glsl";
       
+   samplerNames[0] = "$prepassTex";
+   samplerNames[1] = "$causticsTex0";
+   samplerNames[2] = "$causticsTex1";
+   
    pixVersion = 3.0;
 };
 

--- a/Templates/Full/game/core/scripts/client/postFx/chromaticLens.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/chromaticLens.cs
@@ -47,6 +47,12 @@ singleton ShaderData( PFX_ChromaticLensShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/chromaticLens.hlsl"; 
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/chromaticLens.glsl";
+   
+   samplerNames[0] = "$backBuffer";
+   
    pixVersion = 3.0;
 };
 

--- a/Templates/Full/game/core/scripts/client/postFx/dof.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/dof.cs
@@ -318,8 +318,15 @@ singleton GFXStateBlockData( PFX_DOFFinalStateBlock )
 
 singleton ShaderData( PFX_DOFDownSampleShader )
 {      
-   DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_DownSample_V.hlsl";   
-   DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_DownSample_P.hlsl";            
+   DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_DownSample_V.hlsl";
+   DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_DownSample_P.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/dof/gl/DOF_DownSample_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/dof/gl/DOF_DownSample_P.glsl";
+   
+   samplerNames[0] = "$colorSampler";
+   samplerNames[1] = "$depthSampler";
+   
    pixVersion = 3.0;
 };
 
@@ -327,6 +334,12 @@ singleton ShaderData( PFX_DOFBlurYShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_Gausian_V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_Gausian_P.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/dof/gl/DOF_Gausian_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/dof/gl/DOF_Gausian_P.glsl";
+   
+   samplerNames[0] = "$diffuseMap";
+   
    pixVersion = 2.0;      
    defines = "BLUR_DIR=float2(0.0,1.0)";         
 };
@@ -339,14 +352,27 @@ singleton ShaderData( PFX_DOFBlurXShader : PFX_DOFBlurYShader )
 singleton ShaderData( PFX_DOFCalcCoCShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_CalcCoC_V.hlsl";
-   DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_CalcCoC_P.hlsl";         
+   DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_CalcCoC_P.hlsl"; 
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/dof/gl/DOF_CalcCoC_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/dof/gl/DOF_CalcCoC_P.glsl"; 
+
+   samplerNames[0] = "$shrunkSampler";
+   samplerNames[1] = "$blurredSampler";
+   
    pixVersion = 3.0;
 };
 
 singleton ShaderData( PFX_DOFSmallBlurShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_SmallBlur_V.hlsl";
-   DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_SmallBlur_P.hlsl";            
+   DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_SmallBlur_P.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/dof/gl/DOF_SmallBlur_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/dof/gl/DOF_SmallBlur_P.glsl";
+
+   samplerNames[0] = "$colorSampler";
+   
    pixVersion = 3.0;
 };
 
@@ -354,6 +380,15 @@ singleton ShaderData( PFX_DOFFinalShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/dof/DOF_Final_V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/dof/DOF_Final_P.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/dof/gl/DOF_Final_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/dof/gl/DOF_Final_P.glsl";
+   
+   samplerNames[0] = "$colorSampler";
+   samplerNames[1] = "$smallBlurSampler";
+   samplerNames[2] = "$largeBlurSampler";
+   samplerNames[3] = "$depthSampler";
+   
    pixVersion = 3.0;
 };
 

--- a/Templates/Full/game/core/scripts/client/postFx/edgeAA.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/edgeAA.cs
@@ -37,10 +37,10 @@ singleton ShaderData( PFX_EdgeAADetectShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/edgeaa/edgeDetectP.hlsl";
          
-   //OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-   //OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/edgeaa/gl/edgeDetectP.glsl";
       
-   samplerNames[0] = "$inputTex";
+   samplerNames[0] = "$prepassBuffer";
    
    pixVersion = 3.0;
 };
@@ -50,10 +50,11 @@ singleton ShaderData( PFX_EdgeAAShader )
    DXVertexShaderFile 	= "shaders/common/postFx/edgeaa/edgeAAV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/edgeaa/edgeAAP.hlsl";
          
-   //OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-   //OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/edgeaa/gl/edgeAAV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/edgeaa/gl/edgeAAP.glsl";
       
-   samplerNames[0] = "$inputTex";
+   samplerNames[0] = "$edgeBuffer";
+   samplerNames[1] = "$backBuffer";
    
    pixVersion = 3.0;
 };
@@ -63,10 +64,10 @@ singleton ShaderData( PFX_EdgeAADebugShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/edgeaa/dbgEdgeDisplayP.hlsl";
          
-   //OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-   //OGLPixelShaderFile   = "shaders/common/postFx/gl/passthruP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/edgeaa/gl/dbgEdgeDisplayP.glsl";
       
-   samplerNames[0] = "$inputTex";
+   samplerNames[0] = "$edgeBuffer";
    
    pixVersion = 3.0;
 };

--- a/Templates/Full/game/core/scripts/client/postFx/flash.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/flash.cs
@@ -24,6 +24,11 @@ singleton ShaderData( PFX_FlashShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/flashP.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/flashP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
 
    defines = "WHITE_COLOR=float4(1.0,1.0,1.0,0.0);MUL_COLOR=float4(1.0,0.25,0.25,0.0)";
 

--- a/Templates/Full/game/core/scripts/client/postFx/fog.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/fog.cs
@@ -29,8 +29,8 @@ singleton ShaderData( FogPassShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/fogP.hlsl";
          
-//   OGLVertexShaderFile  = "shaders/common/postFx/gl//postFxV.glsl";
-//   OGLPixelShaderFile   = "shaders/common/postFx/gl/fogP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/fogP.glsl";
             
    samplerNames[0] = "$prepassTex";
    
@@ -75,10 +75,12 @@ singleton ShaderData( UnderwaterFogPassShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/underwaterFogP.hlsl";
          
-//   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
-//   OGLPixelShaderFile   = "shaders/common/postFx/gl/fogP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/underwaterFogP.glsl";
             
    samplerNames[0] = "$prepassTex";
+   samplerNames[1] = "$backbuffer";
+   samplerNames[2] = "$waterDepthGradMap";
    
    pixVersion = 2.0;      
 };

--- a/Templates/Full/game/core/scripts/client/postFx/fxaa.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/fxaa.cs
@@ -39,6 +39,9 @@ singleton ShaderData( FXAA_ShaderData )
    DXVertexShaderFile 	= "shaders/common/postFx/fxaa/fxaaV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/fxaa/fxaaP.hlsl";
    
+   OGLVertexShaderFile  = "shaders/common/postFx/fxaa/gl/fxaaV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/fxaa/gl/fxaaP.glsl";
+   
    samplerNames[0] = "$colorTex";
 
    pixVersion = 3.0;

--- a/Templates/Full/game/core/scripts/client/postFx/glow.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/glow.cs
@@ -26,8 +26,8 @@ singleton ShaderData( PFX_GlowBlurVertShader )
    DXVertexShaderFile 	= "shaders/common/postFx/glowBlurV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/glowBlurP.hlsl";
    
-//   OGLVertexShaderFile  = "shaders/common/postFx/glowBlurV.glsl";
-//   OGLPixelShaderFile   = "shaders/common/postFx/glowBlurP.glsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/glowBlurV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/glowBlurP.glsl";
       
    defines = "BLUR_DIR=float2(0.0,1.0)";
 

--- a/Templates/Full/game/core/scripts/client/postFx/hdr.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/hdr.cs
@@ -77,7 +77,13 @@ $HDRPostFX::colorCorrectionRamp = "core/scripts/client/postFx/null_color_ramp.pn
 singleton ShaderData( HDR_BrightPassShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
-   DXPixelShaderFile 	= "shaders/common/postFx/hdr/brightPassFilterP.hlsl";
+   DXPixelShaderFile 	= "shaders/common/postFx/hdr/brightPassFilterP.hlsl";   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/brightPassFilterP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   samplerNames[1] = "$luminanceTex";
+   
    pixVersion = 3.0;
 };
 
@@ -85,6 +91,11 @@ singleton ShaderData( HDR_DownScale4x4Shader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/hdr/downScale4x4V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/downScale4x4P.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/hdr/gl/downScale4x4V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/downScale4x4P.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 2.0;
 };
 
@@ -92,6 +103,11 @@ singleton ShaderData( HDR_BloomGaussBlurHShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/bloomGaussBlurHP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/bloomGaussBlurHP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 3.0;
 };
 
@@ -99,6 +115,11 @@ singleton ShaderData( HDR_BloomGaussBlurVShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/bloomGaussBlurVP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/bloomGaussBlurVP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 3.0;
 };
 
@@ -106,6 +127,11 @@ singleton ShaderData( HDR_SampleLumShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/sampleLumInitialP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/sampleLumInitialP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 3.0;
 };
 
@@ -113,6 +139,11 @@ singleton ShaderData( HDR_DownSampleLumShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/sampleLumIterativeP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/sampleLumIterativeP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 3.0;
 };
 
@@ -120,6 +151,12 @@ singleton ShaderData( HDR_CalcAdaptedLumShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/calculateAdaptedLumP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/calculateAdaptedLumP.glsl";
+   
+   samplerNames[0] = "$currLum";
+   samplerNames[1] = "$lastAdaptedLum";
+   
    pixVersion = 3.0;
 };
 
@@ -127,6 +164,14 @@ singleton ShaderData( HDR_CombineShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/finalPassCombineP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/finalPassCombineP.glsl";
+   
+   samplerNames[0] = "$sceneTex";
+   samplerNames[1] = "$luminanceTex";
+   samplerNames[2] = "$bloomTex";
+   samplerNames[3] = "$colorCorrectionTex";
+   
    pixVersion = 3.0;
 };
 
@@ -421,6 +466,11 @@ singleton ShaderData( LuminanceVisShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/hdr/luminanceVisP.hlsl";
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/hdr/gl/luminanceVisP.glsl";
+   
+   samplerNames[0] = "$inputTex";
+   
    pixVersion = 3.0;
 };
 

--- a/Templates/Full/game/core/scripts/client/postFx/lightRay.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/lightRay.cs
@@ -34,6 +34,12 @@ singleton ShaderData( LightRayOccludeShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/lightRay/lightRayOccludeP.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/lightRay/gl/lightRayOccludeP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
+   samplerNames[1] = "$prepassTex";
 
    pixVersion = 3.0;   
 };
@@ -42,6 +48,12 @@ singleton ShaderData( LightRayShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/lightRay/lightRayP.hlsl";
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/lightRay/gl/lightRayP.glsl";
+   
+   samplerNames[0] = "$frameSampler";
+   samplerNames[1] = "$backBuffer";
 
    pixVersion = 3.0;   
 };

--- a/Templates/Full/game/core/scripts/client/postFx/ovrBarrelDistortion.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/ovrBarrelDistortion.cs
@@ -32,6 +32,11 @@ singleton ShaderData( OVRMonoToStereoShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/oculusvr/monoToStereoP.hlsl";
+   
+   //OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.hlsl";
+   //OGLPixelShaderFile   = "shaders/common/postFx/oculusvr/gl/monoToStereoP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
 
    pixVersion = 2.0;   
 };
@@ -40,6 +45,11 @@ singleton ShaderData( OVRBarrelDistortionShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/oculusvr/barrelDistortionP.hlsl";
+   
+   //OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   //OGLPixelShaderFile   = "shaders/common/postFx/oculusvr/gl/barrelDistortionP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
 
    pixVersion = 2.0;   
 };

--- a/Templates/Full/game/core/scripts/client/postFx/ssao.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/ssao.cs
@@ -152,6 +152,14 @@ singleton ShaderData( SSAOShader )
 {   
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/ssao/SSAO_P.hlsl";            
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/ssao/gl/SSAO_P.glsl";
+
+   samplerNames[0] = "$prepassMap";
+   samplerNames[1] = "$randNormalTex";
+   samplerNames[2] = "$powTable";
+   
    pixVersion = 3.0;
 };
 
@@ -159,6 +167,13 @@ singleton ShaderData( SSAOBlurYShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/ssao/SSAO_Blur_V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/ssao/SSAO_Blur_P.hlsl";   
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/ssao/gl/SSAO_Blur_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/ssao/gl/SSAO_Blur_P.glsl";
+   
+   samplerNames[0] = "$occludeMap";
+   samplerNames[1] = "$prepassMap";
+
    pixVersion = 3.0;      
    
    defines = "BLUR_DIR=float2(0.0,1.0)";         
@@ -266,6 +281,10 @@ singleton ShaderData( SSAOPowTableShader )
 {
    DXVertexShaderFile 	= "shaders/common/postFx/ssao/SSAO_PowerTable_V.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/ssao/SSAO_PowerTable_P.hlsl";            
+   
+   OGLVertexShaderFile  = "shaders/common/postFx/ssao/gl/SSAO_PowerTable_V.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/ssao/gl/SSAO_PowerTable_P.glsl";   
+   
    pixVersion = 2.0;
 };
 

--- a/Templates/Full/game/core/scripts/client/postFx/turbulence.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/turbulence.cs
@@ -35,6 +35,10 @@ singleton ShaderData( PFX_TurbulenceShader )
    DXVertexShaderFile 	= "shaders/common/postFx/postFxV.hlsl";
    DXPixelShaderFile 	= "shaders/common/postFx/turbulenceP.hlsl";
            
+   OGLVertexShaderFile  = "shaders/common/postFx/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "shaders/common/postFx/gl/turbulenceP.glsl";
+           
+   samplerNames[0] = "$inputTex";
    pixVersion = 3.0;
 };
 

--- a/Templates/Full/game/core/scripts/client/scatterSky.cs
+++ b/Templates/Full/game/core/scripts/client/scatterSky.cs
@@ -42,7 +42,9 @@ singleton ShaderData( ScatterSkyShaderData )
    DXPixelShaderFile      = "shaders/common/scatterSkyP.hlsl";   
    
    OGLVertexShaderFile     = "shaders/common/gl/scatterSkyV.glsl";
-   OGLPixelShaderFile      = "shaders/common/gl/scatterSkyP.glsl";   
+   OGLPixelShaderFile      = "shaders/common/gl/scatterSkyP.glsl";
+   
+   samplerNames[0] = "$nightSky";
    
    pixVersion = 2.0;
 };

--- a/Templates/Full/game/core/scripts/client/shaders.cs
+++ b/Templates/Full/game/core/scripts/client/shaders.cs
@@ -33,6 +33,10 @@ singleton ShaderData( ParticlesShaderData )
    OGLVertexShaderFile     = "shaders/common/gl/particlesV.glsl";
    OGLPixelShaderFile      = "shaders/common/gl/particlesP.glsl";
    
+   samplerNames[0] = "$diffuseMap";
+   samplerNames[1] = "$prepassTex";
+   samplerNames[2] = "$paraboloidLightMap";
+   
    pixVersion = 2.0;
 };
 
@@ -43,6 +47,9 @@ singleton ShaderData( OffscreenParticleCompositeShaderData )
    
    OGLVertexShaderFile     = "shaders/common/gl/particleCompositeV.glsl";
    OGLPixelShaderFile      = "shaders/common/gl/particleCompositeP.glsl";
+   
+   samplerNames[0] = "$colorSource";
+   samplerNames[1] = "$edgeSource";
    
    pixVersion = 2.0;
 };
@@ -55,8 +62,8 @@ new ShaderData( ReflectBump )
    DXVertexShaderFile 	= "shaders/common/planarReflectBumpV.hlsl";
    DXPixelShaderFile 	= "shaders/common/planarReflectBumpP.hlsl";
    
-   OGLVertexShaderFile 	= "shaders/common/gl/planarReflectBumpV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/gl/planarReflectBumpP.glsl";
+   OGLVertexShaderFile  = "shaders/common/gl/planarReflectBumpV.glsl";
+   OGLPixelShaderFile   = "shaders/common/gl/planarReflectBumpP.glsl";
               
    samplerNames[0] = "$diffuseMap";
    samplerNames[1] = "$refractMap";
@@ -70,8 +77,8 @@ new ShaderData( Reflect )
    DXVertexShaderFile 	= "shaders/common/planarReflectV.hlsl";
    DXPixelShaderFile 	= "shaders/common/planarReflectP.hlsl";
    
-   OGLVertexShaderFile 	= "shaders/common/gl/planarReflectV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/gl/planarReflectP.glsl";
+   OGLVertexShaderFile  = "shaders/common/gl/planarReflectV.glsl";
+   OGLPixelShaderFile   = "shaders/common/gl/planarReflectP.glsl";
    
    samplerNames[0] = "$diffuseMap";
    samplerNames[1] = "$refractMap";

--- a/Templates/Full/game/core/scripts/client/terrainBlock.cs
+++ b/Templates/Full/game/core/scripts/client/terrainBlock.cs
@@ -29,5 +29,8 @@ singleton ShaderData( TerrainBlendShader )
    OGLVertexShaderFile = "shaders/common/terrain/gl/blendV.glsl";
    OGLPixelShaderFile = "shaders/common/terrain/gl/blendP.glsl";
    
+   samplerNames[0] = "layerTex";
+   samplerNames[1] = "textureMap";
+   
    pixVersion = 2.0;
 };

--- a/Templates/Full/game/core/scripts/client/water.cs
+++ b/Templates/Full/game/core/scripts/client/water.cs
@@ -34,6 +34,14 @@ singleton ShaderData( WaterShader )
    OGLVertexShaderFile = "shaders/common/water/gl/waterV.glsl";
    OGLPixelShaderFile = "shaders/common/water/gl/waterP.glsl";
    
+   samplerNames[0] = "$bumpMap";  // noise
+   samplerNames[1] = "$prepassTex";  // #prepass
+   samplerNames[2] = "$reflectMap"; // $reflectbuff
+   samplerNames[3] = "$refractBuff";  // $backbuff
+   samplerNames[4] = "$skyMap";  // $cubemap   
+   samplerNames[5] = "$foamMap";  // foam     
+   samplerNames[6] = "$depthGradMap"; // depthMap ( color gradient ) 
+   
    pixVersion = 3.0;
 };
 
@@ -73,6 +81,14 @@ singleton CustomMaterial( WaterMat )
    sampler["prepassTex"] = "#prepass";
    sampler["reflectMap"] = "$reflectbuff";
    sampler["refractBuff"] = "$backbuff";
+   // These samplers are set in code not here.
+   // This is to allow different WaterObject instances
+   // to use this same material but override these textures
+   // per instance.
+   //sampler["bumpMap"] = "";    
+   //sampler["skyMap"] = "";
+   //sampler["foamMap"] = "";  
+   //sampler["depthGradMap"] = "";
    
    shader = WaterShader;
    stateBlock = WaterStateBlock;
@@ -85,16 +101,9 @@ singleton CustomMaterial( WaterMat )
 // Underwater
 //-----------------------------------------------------------------------------
 
-singleton ShaderData( UnderWaterShader )
+singleton ShaderData( UnderWaterShader : WaterShader )
 {
-   DXVertexShaderFile 	= "shaders/common/water/waterV.hlsl";
-   DXPixelShaderFile 	= "shaders/common/water/waterP.hlsl";   
-   
-   OGLVertexShaderFile 	= "shaders/common/water/gl/waterV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/water/gl/waterP.glsl"; 
-   
    defines = "UNDERWATER";   
-   pixVersion = 3.0;
 };
 
 singleton CustomMaterial( UnderwaterMat )
@@ -125,8 +134,14 @@ singleton ShaderData( WaterBasicShader )
    DXVertexShaderFile 	= "shaders/common/water/waterBasicV.hlsl";
    DXPixelShaderFile 	= "shaders/common/water/waterBasicP.hlsl";
    
-   OGLVertexShaderFile 	= "shaders/common/water/gl/waterBasicV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/water/gl/waterBasicP.glsl"; 
+   OGLVertexShaderFile  = "shaders/common/water/gl/waterBasicV.glsl";
+   OGLPixelShaderFile   = "shaders/common/water/gl/waterBasicP.glsl"; 
+   
+   samplerNames[0] = "$bumpMap";
+   samplerNames[2] = "$reflectMap";
+   samplerNames[3] = "$refractBuff";
+   samplerNames[4] = "$skyMap";
+   samplerNames[5] = "$depthGradMap";
    
    pixVersion = 2.0;
 };
@@ -170,16 +185,9 @@ singleton CustomMaterial( WaterBasicMat )
 // Basic UnderWater
 //-----------------------------------------------------------------------------
 
-singleton ShaderData( UnderWaterBasicShader )
+singleton ShaderData( UnderWaterBasicShader : WaterBasicShader)
 {
-   DXVertexShaderFile 	= "shaders/common/water/waterBasicV.hlsl";
-   DXPixelShaderFile 	= "shaders/common/water/waterBasicP.hlsl";   
-   
-   OGLVertexShaderFile 	= "shaders/common/water/gl/waterBasicV.glsl";
-   OGLPixelShaderFile 	= "shaders/common/water/gl/waterBasicP.glsl";
-   
    defines = "UNDERWATER";   
-   pixVersion = 2.0;
 };
 
 singleton CustomMaterial( UnderwaterBasicMat )


### PR DESCRIPTION
ShaderData changes:
- OGLVertexShaderFile/OGLPixelShaderFile not used in DX9.
- samplerNames[?] not used in DX9.
