### PR TITLE
Fixed the crash when using glow material on billboard groundcover

### DIFF
--- a/Engine/source/renderInstance/renderGlowMgr.cpp
+++ b/Engine/source/renderInstance/renderGlowMgr.cpp
@@ -54,6 +54,7 @@ RenderGlowMgr::GlowMaterialHook::GlowMaterialHook( BaseMatInstance *matInst )
 {
    mGlowMatInst = (MatInstance*)matInst->getMaterial()->createMatInstance();
    mGlowMatInst->getFeaturesDelegate().bind( &GlowMaterialHook::_overrideFeatures );
+   mGlowMatInst->setUserObject(matInst->getUserObject());
    mGlowMatInst->init(  matInst->getRequestedFeatures(), 
                         matInst->getVertexFormat() );
 }


### PR DESCRIPTION
Fixed the assert crash by making sure the glow material instance keeps the original material instance's user object for issue [437](https://github.com/GarageGames/Torque3D/issues/437)
