### PR TITLE
Fix ScatterSkyVertex::color declaration.

### DIFF
--- a/Engine/source/environment/scatterSky.h
+++ b/Engine/source/environment/scatterSky.h
@@ -62,7 +62,7 @@ GFXDeclareVertexFormat( ScatterSkyVertex )
 {
    Point3F point;
    VectorF normal;
-   ColorF color;
+   GFXVertexColor color;
 };
 
 class ScatterSky : public SceneObject, public ISceneLight


### PR DESCRIPTION
Fixes ScatterSkyVertex size. 

Not a problem in DX9 because currently, the vertex attribute is not used. But in OpenGL, the size of the vertices is checked and produces a AssertFatal.

```
GFXDeclareVertexFormat( ScatterSkyVertex )
{
   Point3F point;
   VectorF normal;
   ColorF color; // size of 16 bytes, need to change to GFXVertexColor (size of 4 bytes)
};

GFXImplementVertexFormat( ScatterSkyVertex )
{
   addElement( "POSITION", GFXDeclType_Float3 );
   addElement( "NORMAL", GFXDeclType_Float3 );
   addElement( "COLOR", GFXDeclType_Color ); // size of 4 bytes
}
```
