### PR TITLE
Use shader data for get sampler register in CloudLayer and BasicClouds.

### DIFF
--- a/Engine/source/environment/basicClouds.cpp
+++ b/Engine/source/environment/basicClouds.cpp
@@ -129,6 +129,7 @@ bool BasicClouds::onAdd()
       mTexScaleSC = mShader->getShaderConstHandle( "$texScale" );
       mTexDirectionSC = mShader->getShaderConstHandle( "$texDirection" );
       mTexOffsetSC = mShader->getShaderConstHandle( "$texOffset" );
+      mDiffuseMapSC = mShader->getShaderConstHandle( "$diffuseMap" );
 
       // Create StateBlocks
       GFXStateBlockDesc desc;
@@ -312,7 +313,7 @@ void BasicClouds::renderObject( ObjectRenderInst *ri, SceneRenderState *state, B
       mShaderConsts->setSafe( mTexDirectionSC, mTexDirection[i] * mTexSpeed[i] );
       mShaderConsts->setSafe( mTexOffsetSC, mTexOffset[i] );         
 
-      GFX->setTexture( 0, mTexture[i] );                            
+      GFX->setTexture( mDiffuseMapSC->getSamplerRegister(), mTexture[i] );                            
       GFX->setVertexBuffer( mVB[i] );            
 
       GFX->drawIndexedPrimitive( GFXTriangleList, 0, 0, smVertCount, 0, smTriangleCount );

--- a/Engine/source/environment/basicClouds.h
+++ b/Engine/source/environment/basicClouds.h
@@ -103,6 +103,7 @@ protected:
    GFXShaderConstHandle *mTexScaleSC;
    GFXShaderConstHandle *mTexDirectionSC;
    GFXShaderConstHandle *mTexOffsetSC;
+   GFXShaderConstHandle *mDiffuseMapSC;
 
    GFXVertexBufferHandle<GFXVertexPT> mVB[TEX_COUNT];
    GFXPrimitiveBufferHandle mPB;    

--- a/Engine/source/environment/cloudLayer.cpp
+++ b/Engine/source/environment/cloudLayer.cpp
@@ -143,6 +143,7 @@ bool CloudLayer::onAdd()
       mCoverageSC = mShader->getShaderConstHandle( "$cloudCoverage" );
       mExposureSC = mShader->getShaderConstHandle( "$cloudExposure" );
       mBaseColorSC = mShader->getShaderConstHandle( "$cloudBaseColor" );
+      mNormalHeightMapSC = mShader->getShaderConstHandle( "$normalHeightMap" );
 
       // Create StateBlocks
       GFXStateBlockDesc desc;
@@ -365,7 +366,7 @@ void CloudLayer::renderObject( ObjectRenderInst *ri, SceneRenderState *state, Ba
 
    mShaderConsts->setSafe( mExposureSC, mExposure );
 
-   GFX->setTexture( 0, mTexture );                            
+   GFX->setTexture( mNormalHeightMapSC->getSamplerRegister(), mTexture );                            
    GFX->setVertexBuffer( mVB );            
    GFX->setPrimitiveBuffer( mPB );
 

--- a/Engine/source/environment/cloudLayer.h
+++ b/Engine/source/environment/cloudLayer.h
@@ -110,6 +110,7 @@ protected:
    GFXShaderConstHandle *mCoverageSC;  
    GFXShaderConstHandle *mExposureSC;  
    GFXShaderConstHandle *mEyePosWorldSC;
+   GFXShaderConstHandle *mNormalHeightMapSC;
 
    GFXVertexBufferHandle<GFXCloudVertex> mVB;
    GFXPrimitiveBufferHandle mPB;


### PR DESCRIPTION
It is better to use data from shader.
If the order of the samplers in the shader is changed, this code will work correctly.
