### PR TITLE
Add GFXShader::init with support for ordered vector of sampler names for shader.

### DIFF
--- a/Engine/source/gfx/gfxShader.cpp
+++ b/Engine/source/gfx/gfxShader.cpp
@@ -45,16 +45,29 @@ GFXShader::~GFXShader()
    Torque::FS::RemoveChangeNotification( mPixelFile, this, &GFXShader::_onFileChanged );
 }
 
+#ifndef TORQUE_OPENGL
 bool GFXShader::init(   const Torque::Path &vertFile, 
                         const Torque::Path &pixFile, 
                         F32 pixVersion, 
                         const Vector<GFXShaderMacro> &macros )
+{
+   Vector<String> samplerNames;
+   return init( vertFile, pixFile, pixVersion, macros, samplerNames );
+}
+#endif
+
+bool GFXShader::init(   const Torque::Path &vertFile, 
+                        const Torque::Path &pixFile, 
+                        F32 pixVersion, 
+                        const Vector<GFXShaderMacro> &macros,
+                        const Vector<String> &samplerNames)
 {
    // Store the inputs for use in reloading.
    mVertexFile = vertFile;
    mPixelFile = pixFile;
    mPixVersion = pixVersion;
    mMacros = macros;
+   mSamplerNamesOrdered = samplerNames;
 
    // Before we compile the shader make sure the
    // conditioner features have been updated.

--- a/Engine/source/gfx/gfxShader.h
+++ b/Engine/source/gfx/gfxShader.h
@@ -237,6 +237,13 @@ protected:
    /// The macros to be passed to the shader.      
    Vector<GFXShaderMacro> mMacros;
 
+   /// Ordered SamplerNames
+   /// We need to store a list of sampler for allow OpenGL to
+   /// assign correct location for each sampler.
+   /// GLSL 150 not allow explicit uniform location.
+   /// Only used on OpenGL   
+   Vector<String> mSamplerNamesOrdered;
+
    /// The pixel version this is compiled for.
    F32 mPixVersion;
 
@@ -292,10 +299,20 @@ public:
    virtual ~GFXShader();
 
    ///
+   /// Deprecated. Remove on T3D 4.0
+#ifndef TORQUE_OPENGL
    bool init(  const Torque::Path &vertFile, 
                const Torque::Path &pixFile, 
                F32 pixVersion, 
                const Vector<GFXShaderMacro> &macros );
+#endif
+
+   ///
+   bool init(  const Torque::Path &vertFile, 
+               const Torque::Path &pixFile, 
+               F32 pixVersion, 
+               const Vector<GFXShaderMacro> &macros,
+               const Vector<String> &samplerNames);
 
    /// Reloads the shader from disk.
    bool reload();


### PR DESCRIPTION
These changes do anything in DX9, the "sampler register" are asigned on hlsl files.

In OpenGL is necessary to pass the position of the samplers before compiling the glsl program for assign ShaderData samplers to correct index used with CustomMaterial, PostEffect and GFXStateBlockData. 
