### PR TITLE
Add RenderPassData::mSamplerNames for OpenGL code. Not used on DX9.

### DIFF
--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -41,7 +41,10 @@ RenderPassData::RenderPassData()
 void RenderPassData::reset()
 {
    for( U32 i = 0; i < Material::MAX_TEX_PER_PASS; ++ i )
+   {
       destructInPlace( &mTexSlot[ i ] );
+      mSamplerNames[ i ].clear();
+   }
 
    dMemset( &mTexSlot, 0, sizeof(mTexSlot) );
    dMemset( &mTexType, 0, sizeof(mTexType) );

--- a/Engine/source/materials/processedMaterial.h
+++ b/Engine/source/materials/processedMaterial.h
@@ -68,6 +68,7 @@ public:
    } mTexSlot[Material::MAX_TEX_PER_PASS];
 
    U32 mTexType[Material::MAX_TEX_PER_PASS];
+   String mSamplerNames[Material::MAX_TEX_PER_PASS];
 
    /// The cubemap to use when the texture type is
    /// set to Material::Cube.


### PR DESCRIPTION
Used on others PRs.
