### PR TITLE
Handle texel-pixel offset with diferents graphics APIs.

### DIFF
--- a/Engine/source/gfx/util/screenspace.cpp
+++ b/Engine/source/gfx/util/screenspace.cpp
@@ -42,11 +42,11 @@ void ScreenSpace::RenderTargetParameters(const Point3I &targetSize, const RectI 
    Point2F targetScale( (F32)targetViewport.extent.x / (F32)targetSize.x,
                         (F32)targetViewport.extent.y / (F32)targetSize.y );
 
-   bool hasTexelPixelOffset = GFX->getAdapterType() == Direct3D9;
+   const bool hasTexelPixelOffset = GFX->getAdapterType() == Direct3D9;
 
    // Get the target half pixel size.
-   const Point2F halfPixel( hasTexelPixelOffset ? 0.5f / targetSize.x : 0.0,
-                            hasTexelPixelOffset ? 0.5f / targetSize.y : 0.0);
+   const Point2F halfPixel( hasTexelPixelOffset ? (0.5f / targetSize.x) : 0.0f,
+                            hasTexelPixelOffset ? (0.5f / targetSize.y) : 0.0f );
 
    rtParams.set( targetOffset.x + halfPixel.x,
                  targetOffset.y + halfPixel.y,

--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -637,7 +637,9 @@ void PostEffect::_setupConstants( const SceneRenderState *state )
       Point2F offset((F32)viewport.point.x / (F32)targetSize.x, (F32)viewport.point.y / (F32)targetSize.y );
       Point2F scale((F32)viewport.extent.x / (F32)targetSize.x, (F32)viewport.extent.y / (F32)targetSize.y );
 
-      const Point2F halfPixel( 0.5f / targetSize.x, 0.5f / targetSize.y );
+      const bool hasTexelPixelOffset = GFX->getAdapterType() == Direct3D9;
+      const Point2F halfPixel(  hasTexelPixelOffset ? (0.5f / targetSize.x) : 0.0f, 
+                                hasTexelPixelOffset ? (0.5f / targetSize.y) : 0.0f );
 
       Point4F targetParams;
       targetParams.x = offset.x + halfPixel.x;


### PR DESCRIPTION
DX9 has texel-pixel offset. 

Dx11 and OpenGL don't.
