### PR TITLE
FIX RenderMeshExample not having a material on mission start...

### DIFF
--- a/Engine/source/T3D/examples/renderMeshExample.cpp
+++ b/Engine/source/T3D/examples/renderMeshExample.cpp
@@ -107,6 +107,8 @@ bool RenderMeshExample::onAdd()
 
    // Add this object to the scene
    addToScene();
+   // Refresh the applied material
+   updateMaterial();
 
    return true;
 }


### PR DESCRIPTION
 even if one was assigned to it in the mission file.
