### PR TITLE
FIX RenderMeshExample not having a material on mission start even if one...

### DIFF
--- a/Engine/source/T3D/examples/renderMeshExample.cpp
+++ b/Engine/source/T3D/examples/renderMeshExample.cpp
@@ -107,6 +107,8 @@ bool RenderMeshExample::onAdd()
 
    // Add this object to the scene
    addToScene();
+   // Refresh this object's material (if any)
+   updateMaterial();
 
    return true;
 }


### PR DESCRIPTION
... was assigned to it in the mission file.
