### PR TITLE
Coverage option for procedural terrain painter

### DIFF
--- a/Engine/source/gui/worldEditor/terrainEditor.cpp
+++ b/Engine/source/gui/worldEditor/terrainEditor.cpp
@@ -34,6 +34,7 @@
 #include "gui/core/guiCanvas.h"
 #include "gui/worldEditor/terrainActions.h"
 #include "terrain/terrMaterial.h"
+#include <ctime>
 
 
 
@@ -2868,7 +2869,7 @@ ConsoleMethod( TerrainEditor, setSlopeLimitMaxAngle, F32, 3, 3, 0)
 }
 
 //------------------------------------------------------------------------------  
-void TerrainEditor::autoMaterialLayer( F32 mMinHeight, F32 mMaxHeight, F32 mMinSlope, F32 mMaxSlope )  
+void TerrainEditor::autoMaterialLayer( F32 mMinHeight, F32 mMaxHeight, F32 mMinSlope, F32 mMaxSlope, F32 mCoverage )  
 {  
    if (!mActiveTerrain)  
       return;  
@@ -2876,7 +2877,12 @@ void TerrainEditor::autoMaterialLayer( F32 mMinHeight, F32 mMaxHeight, F32 mMinS
    S32 mat = getPaintMaterialIndex();  
    if (mat == -1)  
       return;  
-  
+
+   //setup for randomized coverage
+   mCoverage*=100;
+   srand((unsigned)time(0));
+   int randomNumber;
+
    mUndoSel = new Selection;  
           
    U32 terrBlocks = mActiveTerrain->getBlockSize();  
@@ -2894,6 +2900,10 @@ void TerrainEditor::autoMaterialLayer( F32 mMinHeight, F32 mMaxHeight, F32 mMinS
   
          if (gi.mMaterial == mat)  
             continue;  
+
+         randomNumber = (rand() % 10000);
+         if (randomNumber > mCoverage)
+            continue;
   
          Point3F wp;  
          gridToWorld(gp, wp);  
@@ -2933,7 +2943,7 @@ void TerrainEditor::autoMaterialLayer( F32 mMinHeight, F32 mMaxHeight, F32 mMinS
    scheduleMaterialUpdate();     
 }  
   
-ConsoleMethod( TerrainEditor, autoMaterialLayer, void, 6, 6, "(float minHeight, float maxHeight, float minSlope, float maxSlope)")  
+ConsoleMethod( TerrainEditor, autoMaterialLayer, void, 7, 7, "(float minHeight, float maxHeight, float minSlope, float maxSlope, float coverage)")   
 {  
-   object->autoMaterialLayer( dAtof(argv[2]), dAtof(argv[3]), dAtof(argv[4]), dAtof(argv[5]) );  
+   object->autoMaterialLayer( dAtof(argv[2]), dAtof(argv[3]), dAtof(argv[4]), dAtof(argv[5]), dAtof(argv[6]));  
 }  

--- a/Engine/source/gui/worldEditor/terrainEditor.h
+++ b/Engine/source/gui/worldEditor/terrainEditor.h
@@ -230,7 +230,7 @@ class TerrainEditor : public EditTSCtrl
       void submitMaterialUndo( String actionName );
       void onMaterialUndo( TerrainBlock *terr );
 
-      void autoMaterialLayer( F32 mMinHeight, F32 mMaxHeight, F32 mMinSlope, F32 mMaxSlope );
+      void autoMaterialLayer( F32 mMinHeight, F32 mMaxHeight, F32 mMinSlope, F32 mMaxSlope, F32 mCoverage );
 
 	private:	
 

--- a/Templates/Empty/game/tools/worldEditor/gui/ProceduralTerrainPainterGui.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/ProceduralTerrainPainterGui.gui
@@ -20,7 +20,7 @@
       HorizSizing = "right";  
       VertSizing = "bottom";  
       Position = "285 83";  
-      Extent = "175 209";  
+      Extent = "175 233";  
       MinExtent = "8 2";  
       canSave = "1";  
       Visible = "1";  
@@ -52,7 +52,7 @@
          Profile = "ToolsGuiButtonProfile";  
          HorizSizing = "right";  
          VertSizing = "bottom";  
-         Position = "19 164";  
+         Position = "19 193";  
          Extent = "140 30";  
          MinExtent = "8 2";  
          canSave = "1";  
@@ -305,6 +305,83 @@
          sinkAllKeyEvents = "0";  
          passwordMask = "*";  
       };  
+
+
+      new GuiTextCtrl() {
+         text = "COVERAGE";
+         maxLength = "1024";
+         margin = "0 0 0 0";
+         padding = "0 0 0 0";
+         anchorTop = "1";
+         anchorBottom = "0";
+         anchorLeft = "1";
+         anchorRight = "0";
+         position = "10 165";
+         extent = "55 13";
+         minExtent = "8 2";
+         horizSizing = "right";
+         vertSizing = "bottom";
+         profile = "GuiTextProfile";
+         visible = "1";
+         active = "1";
+         tooltipProfile = "GuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "0";
+         canSave = "1";
+         canSaveDynamicFields = "0";
+      };
+      new GuiTextEditCtrl() {
+         historySize = "0";
+         tabComplete = "0";
+         sinkAllKeyEvents = "0";
+         password = "0";
+         passwordMask = "*";
+         text = "1";
+         maxLength = "1024";
+         margin = "0 0 0 0";
+         padding = "0 0 0 0";
+         anchorTop = "1";
+         anchorBottom = "0";
+         anchorLeft = "1";
+         anchorRight = "0";
+         position = "97 162";
+         extent = "66 18";
+         minExtent = "8 2";
+         horizSizing = "right";
+         vertSizing = "bottom";
+         profile = "GuiTextEditProfile";
+         visible = "1";
+         active = "1";
+         variable = "$TPPCoverage";
+         tooltipProfile = "GuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "0";
+         canSave = "1";
+         canSaveDynamicFields = "0";
+      };
+      new GuiTextCtrl() {
+         text = "%";
+         maxLength = "1024";
+         margin = "0 0 0 0";
+         padding = "0 0 0 0";
+         anchorTop = "1";
+         anchorBottom = "0";
+         anchorLeft = "1";
+         anchorRight = "0";
+         position = "77 164";
+         extent = "11 14";
+         minExtent = "8 2";
+         horizSizing = "right";
+         vertSizing = "bottom";
+         profile = "ToolsGuiTextProfile";
+         visible = "1";
+         active = "1";
+         tooltipProfile = "ToolsGuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "0";
+         canSave = "1";
+         canSaveDynamicFields = "0";
+      };
    };  
 };  
 //--- OBJECT WRITE END ---  
@@ -313,6 +390,7 @@ $TPPHeightMin = -10000;
 $TPPHeightMax = 10000;  
 $TPPSlopeMin = 0;  
 $TPPSlopeMax = 90;  
+$TPPCoverage = 100;  
   
 function autoLayers() 
 {  
@@ -322,5 +400,5 @@ function autoLayers()
 function generateProceduralTerrainMask() 
 {  
    Canvas.popDialog(ProceduralTerrainPainterGui);  
-   ETerrainEditor.autoMaterialLayer($TPPHeightMin, $TPPHeightMax, $TPPSlopeMin, $TPPSlopeMax);  
+   ETerrainEditor.autoMaterialLayer($TPPHeightMin, $TPPHeightMax, $TPPSlopeMin, $TPPSlopeMax, $TPPCoverage);  
 }  

--- a/Templates/Full/game/tools/worldEditor/gui/ProceduralTerrainPainterGui.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/ProceduralTerrainPainterGui.gui
@@ -20,7 +20,7 @@
       HorizSizing = "right";  
       VertSizing = "bottom";  
       Position = "285 83";  
-      Extent = "175 209";  
+      Extent = "175 233";  
       MinExtent = "8 2";  
       canSave = "1";  
       Visible = "1";  
@@ -52,7 +52,7 @@
          Profile = "ToolsGuiButtonProfile";  
          HorizSizing = "right";  
          VertSizing = "bottom";  
-         Position = "19 164";  
+         Position = "19 193";  
          Extent = "140 30";  
          MinExtent = "8 2";  
          canSave = "1";  
@@ -305,6 +305,83 @@
          sinkAllKeyEvents = "0";  
          passwordMask = "*";  
       };  
+
+
+      new GuiTextCtrl() {
+         text = "COVERAGE";
+         maxLength = "1024";
+         margin = "0 0 0 0";
+         padding = "0 0 0 0";
+         anchorTop = "1";
+         anchorBottom = "0";
+         anchorLeft = "1";
+         anchorRight = "0";
+         position = "10 165";
+         extent = "55 13";
+         minExtent = "8 2";
+         horizSizing = "right";
+         vertSizing = "bottom";
+         profile = "GuiTextProfile";
+         visible = "1";
+         active = "1";
+         tooltipProfile = "GuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "0";
+         canSave = "1";
+         canSaveDynamicFields = "0";
+      };
+      new GuiTextEditCtrl() {
+         historySize = "0";
+         tabComplete = "0";
+         sinkAllKeyEvents = "0";
+         password = "0";
+         passwordMask = "*";
+         text = "1";
+         maxLength = "1024";
+         margin = "0 0 0 0";
+         padding = "0 0 0 0";
+         anchorTop = "1";
+         anchorBottom = "0";
+         anchorLeft = "1";
+         anchorRight = "0";
+         position = "97 162";
+         extent = "66 18";
+         minExtent = "8 2";
+         horizSizing = "right";
+         vertSizing = "bottom";
+         profile = "GuiTextEditProfile";
+         visible = "1";
+         active = "1";
+         variable = "$TPPCoverage";
+         tooltipProfile = "GuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "0";
+         canSave = "1";
+         canSaveDynamicFields = "0";
+      };
+      new GuiTextCtrl() {
+         text = "%";
+         maxLength = "1024";
+         margin = "0 0 0 0";
+         padding = "0 0 0 0";
+         anchorTop = "1";
+         anchorBottom = "0";
+         anchorLeft = "1";
+         anchorRight = "0";
+         position = "77 164";
+         extent = "11 14";
+         minExtent = "8 2";
+         horizSizing = "right";
+         vertSizing = "bottom";
+         profile = "ToolsGuiTextProfile";
+         visible = "1";
+         active = "1";
+         tooltipProfile = "ToolsGuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "0";
+         canSave = "1";
+         canSaveDynamicFields = "0";
+      };
    };  
 };  
 //--- OBJECT WRITE END ---  
@@ -313,6 +390,7 @@ $TPPHeightMin = -10000;
 $TPPHeightMax = 10000;  
 $TPPSlopeMin = 0;  
 $TPPSlopeMax = 90;  
+$TPPCoverage = 100;  
   
 function autoLayers() 
 {  
@@ -322,5 +400,6 @@ function autoLayers()
 function generateProceduralTerrainMask() 
 {  
    Canvas.popDialog(ProceduralTerrainPainterGui);  
-   ETerrainEditor.autoMaterialLayer($TPPHeightMin, $TPPHeightMax, $TPPSlopeMin, $TPPSlopeMax);  
+   ETerrainEditor.autoMaterialLayer($TPPHeightMin, $TPPHeightMax, $TPPSlopeMin, $TPPSlopeMax, $TPPCoverage);  
 }  
+


### PR DESCRIPTION
This commit adds a "Coverage" option to the procedural terrain
generator. Allows mixing of textures. See
http://www.garagegames.com/community/blogs/view/22371 for more info.
This version has many improvements - coverage is now entered as a
percentage, accepts decimals, and doesn't have any bugs as far as I
know.
