### PR TITLE
Fix for avoid a zero division on _StringTable::resize.

### DIFF
--- a/Engine/source/core/stringTable.cpp
+++ b/Engine/source/core/stringTable.cpp
@@ -195,8 +195,11 @@ StringTableEntry _StringTable::lookupn(const char* val, S32 len, const bool  cas
 }
 
 //--------------------------------------
-void _StringTable::resize(const U32 newSize)
+void _StringTable::resize(const U32 _newSize)
 {
+   /// avoid a possible 0 division
+   const U32 newSize = _newSize ? _newSize : 1;
+
    Node *head = NULL, *walk, *temp;
    U32 i;
    // reverse individual bucket lists


### PR DESCRIPTION
```
void _StringTable::resize(const U32 _newSize)
{   
   ...
   temp->next = buckets[key % newSize]; // possible 0 division
   buckets[key % newSize] = temp; // possible 0 division
}
```
