### PR TITLE
Fix Dereference of null pointer on String::operator+=

### DIFF
--- a/Engine/source/core/util/str.cpp
+++ b/Engine/source/core/util/str.cpp
@@ -760,7 +760,7 @@ String& String::operator=(const String &src)
 
 String& String::operator+=(const StringChar *src)
 {
-   if( src == NULL && !*src )
+   if( src == NULL || !*src )
       return *this;
 
    // Append the given string into a new string


### PR DESCRIPTION
```
String& String::operator+=(const StringChar *src)
{
   if( src == NULL && !*src ) // Dereference of null pointer
      return *this;
   ...
}
```
