### PR TITLE
Projectile decal

### DIFF
--- a/Engine/source/T3D/projectile.cpp
+++ b/Engine/source/T3D/projectile.cpp
@@ -1011,7 +1011,7 @@ void Projectile::explode( const Point3F &p, const Point3F &n, const U32 collideT
 
       // Client (impact) decal.
       if ( mDataBlock->decal )     
-         gDecalManager->addDecal( p, n, 0.0f, mDataBlock->decal );
+         gDecalManager->addDecal(p, n, mRandF(0.0f, M_2PI_F), mDataBlock->decal);
 
       // Client object
       updateSound();


### PR DESCRIPTION
alters **PROJECTILE** _[emphasis mine @eightyeight]_ decal application so that it picks a random rotAroundNormal when adding it to a scene. (keeps em from always pointing north or up
