### PR TITLE
Ejection offset variance defaults

### DIFF
--- a/Templates/Empty/game/tools/particleEditor/particleEmitterEditor.ed.cs
+++ b/Templates/Empty/game/tools/particleEditor/particleEmitterEditor.ed.cs
@@ -84,6 +84,9 @@ function PE_EmitterEditor::guiSync( %this )
    PE_EmitterEditor-->PEE_ejectionOffset_slider.setValue( %data.ejectionOffset );
    PE_EmitterEditor-->PEE_ejectionOffset_textEdit.setText( %data.ejectionOffset );
    
+   PE_EmitterEditor-->PEE_ejectionOffsetVariance_slider.setValue( %data.ejectionOffsetVariance );
+   PE_EmitterEditor-->PEE_ejectionOffsetVariance_textEdit.setText( %data.ejectionOffsetVariance );
+   
    %blendTypeId = PE_EmitterEditor-->PEE_blendType.findText( %data.blendStyle );
    PE_EmitterEditor-->PEE_blendType.setSelected( %blendTypeId, false );
    

--- a/Templates/Full/game/tools/particleEditor/particleEmitterEditor.ed.cs
+++ b/Templates/Full/game/tools/particleEditor/particleEmitterEditor.ed.cs
@@ -84,6 +84,9 @@ function PE_EmitterEditor::guiSync( %this )
    PE_EmitterEditor-->PEE_ejectionOffset_slider.setValue( %data.ejectionOffset );
    PE_EmitterEditor-->PEE_ejectionOffset_textEdit.setText( %data.ejectionOffset );
    
+   PE_EmitterEditor-->PEE_ejectionOffsetVariance_slider.setValue( %data.ejectionOffsetVariance );
+   PE_EmitterEditor-->PEE_ejectionOffsetVariance_textEdit.setText( %data.ejectionOffsetVariance );
+   
    %blendTypeId = PE_EmitterEditor-->PEE_blendType.findText( %data.blendStyle );
    PE_EmitterEditor-->PEE_blendType.setSelected( %blendTypeId, false );
    


### PR DESCRIPTION
editor default and retrieval values for particle emitter ejectionOffsetVariance (sets the sliderbars and text when reloading an emitter DB)
