### PR TITLE
Make TinyXML and SimXMLDocument use the virtual file system.

### DIFF
--- a/Engine/lib/tinyxml/tinyxml.h
+++ b/Engine/lib/tinyxml/tinyxml.h
@@ -283,10 +283,8 @@ public:
 		TIXML_ERROR_STRING_COUNT
 	};
 
-protected:
-
 	static const char* SkipWhiteSpace( const char*, TiXmlEncoding encoding );
-
+protected:
 	inline static bool IsWhiteSpace( char c )		
 	{ 
 		return ( isspace( (unsigned char) c ) || c == '\n' || c == '\r' ); 
@@ -359,7 +357,7 @@ protected:
 			return 0;
 		}
 	}
-
+public:
 	// Return true if the next characters in the stream are any of the endTag sequences.
 	// Ignore case only works for english, and should only be relied on when comparing
 	// to English words: StringEqual( p, "version", true ) is fine.
@@ -367,7 +365,7 @@ protected:
 								const char* endTag,
 								bool ignoreCase,
 								TiXmlEncoding encoding );
-
+protected:
 	static const char* errorString[ TIXML_ERROR_STRING_COUNT ];
 
 	TiXmlCursor location;
@@ -375,9 +373,11 @@ protected:
     /// Field containing a generic user pointer
 	void*			userData;
 	
+public:
 	// None of these methods are reliable for any language except English.
 	// Good for approximation, not great for accuracy.
 	static int IsAlpha( unsigned char anyByte, TiXmlEncoding encoding );
+protected:
 	static int IsAlphaNum( unsigned char anyByte, TiXmlEncoding encoding );
 	inline static int ToLower( int v, TiXmlEncoding encoding )
 	{
@@ -750,9 +750,10 @@ protected:
 	#endif
 
 	// Figure out what is at *p, and parse it. Returns null if it is not an xml node.
-	TiXmlNode* Identify( const char* start, TiXmlEncoding encoding );
-
+	virtual TiXmlNode* Identify( const char* start, TiXmlEncoding encoding );
+public:
 	TiXmlNode*		parent;
+protected:
 	NodeType		type;
 
 	TiXmlNode*		firstChild;
@@ -1047,7 +1048,7 @@ public:
 	/** Sets an attribute of name to a given value. The attribute
 		will be created if it does not exist, or changed if it does.
 	*/
-	void SetAttribute( const char* name, const char * _value );
+	virtual void SetAttribute( const char* name, const char * _value );
 
     #ifdef TIXML_USE_STL
 	const std::string* Attribute( const std::string& name ) const;
@@ -1067,7 +1068,7 @@ public:
 	/** Sets an attribute of name to a given value. The attribute
 		will be created if it does not exist, or changed if it does.
 	*/
-	void SetAttribute( const char * name, int value );
+	virtual void SetAttribute( const char * name, int value );
 
 	/** Sets an attribute of name to a given value. The attribute
 		will be created if it does not exist, or changed if it does.
@@ -1152,7 +1153,6 @@ protected:
 	*/
 	const char* ReadValue( const char* in, TiXmlParsingData* prevData, TiXmlEncoding encoding );
 
-private:
 	TiXmlAttributeSet attributeSet;
 };
 
@@ -1264,7 +1264,6 @@ protected :
 	virtual void StreamIn( std::istream * in, TIXML_STRING * tag );
 	#endif
 
-private:
 	bool cdata;			// true if this should be input and output as a CDATA style text element
 };
 
@@ -1336,7 +1335,6 @@ protected:
 	virtual void StreamIn( std::istream * in, TIXML_STRING * tag );
 	#endif
 
-private:
 
 	TIXML_STRING version;
 	TIXML_STRING encoding;
@@ -1416,9 +1414,9 @@ public:
 	/// Save a file using the current document value. Returns true if successful.
 	bool SaveFile() const;
 	/// Load a file using the given filename. Returns true if successful.
-	bool LoadFile( const char * filename, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING );
+	virtual bool LoadFile( const char * filename, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING );
 	/// Save a file using the given filename. Returns true if successful.
-	bool SaveFile( const char * filename ) const;
+	virtual bool SaveFile( const char * filename ) const;
 	/** Load a file using the given FILE*. Returns true if successful. Note that this method
 		doesn't stream - the entire object pointed at by the FILE*
 		will be interpreted as an XML file. TinyXML doesn't stream in XML from the current
@@ -1543,14 +1541,15 @@ protected :
 	virtual void StreamIn( std::istream * in, TIXML_STRING * tag );
 	#endif
 
-private:
 	void CopyTo( TiXmlDocument* target ) const;
-
+   
+private:
 	bool error;
 	int  errorId;
 	TIXML_STRING errorDesc;
 	int tabsize;
 	TiXmlCursor errorLocation;
+protected:
 	bool useMicrosoftBOM;		// the UTF-8 BOM were found when read. Note this, and try to write.
 };
 
@@ -1797,6 +1796,29 @@ private:
 	TIXML_STRING lineBreak;
 };
 
+class TiXmlParsingData
+{
+	friend class TiXmlDocument;
+  public:
+	void Stamp( const char* now, TiXmlEncoding encoding );
+
+	const TiXmlCursor& Cursor() const	{ return cursor; }
+
+  private:
+	// Only used by the document!
+	TiXmlParsingData( const char* start, int _tabsize, int row, int col )
+	{
+		assert( start );
+		stamp = start;
+		tabsize = _tabsize;
+		cursor.row = row;
+		cursor.col = col;
+	}
+
+	TiXmlCursor		cursor;
+	const char*		stamp;
+	int				tabsize;
+};
 
 #ifdef _MSC_VER
 #pragma warning( pop )

--- a/Engine/lib/tinyxml/tinyxmlparser.cpp
+++ b/Engine/lib/tinyxml/tinyxmlparser.cpp
@@ -168,29 +168,6 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 }
 
 
-class TiXmlParsingData
-{
-	friend class TiXmlDocument;
-  public:
-	void Stamp( const char* now, TiXmlEncoding encoding );
-
-	const TiXmlCursor& Cursor() const	{ return cursor; }
-
-  private:
-	// Only used by the document!
-	TiXmlParsingData( const char* start, int _tabsize, int row, int col )
-	{
-		assert( start );
-		stamp = start;
-		tabsize = _tabsize;
-		cursor.row = row;
-		cursor.col = col;
-	}
-
-	TiXmlCursor		cursor;
-	const char*		stamp;
-	int				tabsize;
-};
 
 
 void TiXmlParsingData::Stamp( const char* now, TiXmlEncoding encoding )

--- a/Engine/source/console/SimXMLDocument.cpp
+++ b/Engine/source/console/SimXMLDocument.cpp
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "tinyxml/tinyxml.h"
+#include "taml/fsTinyXml.h"
 
 //-----------------------------------------------------------------------------
 // Console implementation of STL map.
@@ -175,7 +175,7 @@ bool SimXMLDocument::onAdd()
 
    if(!m_qDocument)
    {
-      m_qDocument = new TiXmlDocument();
+      m_qDocument = new fsTiXmlDocument();
    }
    return true;
 }
@@ -345,16 +345,16 @@ bool SimXMLDocument::pushFirstChildElement(const char* rName)
    m_CurrentAttribute = 0;
 
    // Push the first element found under the current element of the given name
-   TiXmlElement* pElement;
+   fsTiXmlElement* pElement;
    if(!m_paNode.empty())
    {
       const int iLastElement = m_paNode.size() - 1;
-      TiXmlElement* pNode = m_paNode[iLastElement];
+      fsTiXmlElement* pNode = m_paNode[iLastElement];
       if(!pNode)
       {
          return false;
       }
-      pElement = pNode->FirstChildElement(rName);
+      pElement = static_cast<fsTiXmlElement*>(pNode->FirstChildElement(rName));
    }
    else
    {
@@ -362,7 +362,7 @@ bool SimXMLDocument::pushFirstChildElement(const char* rName)
       {
          return false;
       }
-      pElement = m_qDocument->FirstChildElement(rName);
+      pElement = static_cast<fsTiXmlElement*>(m_qDocument->FirstChildElement(rName));
    }
 
    if(!pElement)
@@ -409,22 +409,22 @@ bool SimXMLDocument::pushChildElement(S32 index)
    m_CurrentAttribute = 0;
 
    // Push the first element found under the current element of the given name
-   TiXmlElement* pElement;
+   fsTiXmlElement* pElement;
    if(!m_paNode.empty())
    {
       const int iLastElement = m_paNode.size() - 1;
-      TiXmlElement* pNode = m_paNode[iLastElement];
+      fsTiXmlElement* pNode = m_paNode[iLastElement];
       if(!pNode)
       {
          return false;
       }
-      pElement = pNode->FirstChildElement();
+      pElement = static_cast<fsTiXmlElement*>(pNode->FirstChildElement());
       for( S32 i = 0; i < index; i++ )
       {
          if( !pElement )
             return false;
 
-         pElement = pElement->NextSiblingElement();
+         pElement = static_cast<fsTiXmlElement*>(pElement->NextSiblingElement());
       }
    }
    else
@@ -433,13 +433,13 @@ bool SimXMLDocument::pushChildElement(S32 index)
       {
          return false;
       }
-      pElement = m_qDocument->FirstChildElement();
+      pElement = static_cast<fsTiXmlElement*>(m_qDocument->FirstChildElement());
       for( S32 i = 0; i < index; i++ )
       {
          if( !pElement )
             return false;
 
-         pElement = pElement->NextSiblingElement();
+         pElement = static_cast<fsTiXmlElement*>(pElement->NextSiblingElement());
       }
    }
 
@@ -473,13 +473,13 @@ bool SimXMLDocument::nextSiblingElement(const char* rName)
       return false;
    }
    const int iLastElement = m_paNode.size() - 1;
-   TiXmlElement*& pElement = m_paNode[iLastElement];
+   fsTiXmlElement*& pElement = m_paNode[iLastElement];
    if(!pElement)
    {
       return false;
    }
 
-   pElement = pElement->NextSiblingElement(rName);
+   pElement = static_cast<fsTiXmlElement*>(pElement->NextSiblingElement(rName));
    if(!pElement)
    {
       return false;
@@ -507,7 +507,7 @@ const char* SimXMLDocument::elementValue()
       return StringTable->insert("");
    }
    const int iLastElement = m_paNode.size() - 1;
-   TiXmlElement* pNode = m_paNode[iLastElement];
+   fsTiXmlElement* pNode = m_paNode[iLastElement];
    if(!pNode)
    {
       return StringTable->insert("");
@@ -548,7 +548,7 @@ const char* SimXMLDocument::attribute(const char* rAttribute)
       return StringTable->insert("");
    }
    const int iLastElement = m_paNode.size() - 1;
-   TiXmlElement* pNode = m_paNode[iLastElement];
+   fsTiXmlElement* pNode = m_paNode[iLastElement];
    if(!pNode)
    {
       return StringTable->insert("");
@@ -598,7 +598,7 @@ bool SimXMLDocument::attributeExists(const char* rAttribute)
       return false;
    }
    const int iLastElement = m_paNode.size() - 1;
-   TiXmlElement* pNode = m_paNode[iLastElement];
+   fsTiXmlElement* pNode = m_paNode[iLastElement];
    if(!pNode)
    {
       return false;
@@ -631,14 +631,14 @@ const char* SimXMLDocument::firstAttribute()
       return StringTable->insert("");
    }
    const int iLastElement = m_paNode.size() - 1;
-   TiXmlElement* pNode = m_paNode[iLastElement];
+   fsTiXmlElement* pNode = m_paNode[iLastElement];
    if(!pNode)
    {
       return StringTable->insert("");
    }
 
    // Gets its first attribute, if any
-   m_CurrentAttribute = pNode->FirstAttribute();
+   m_CurrentAttribute = static_cast<fsTiXmlAttribute*>(pNode->FirstAttribute());
    if(!m_CurrentAttribute)
    {
       return StringTable->insert("");
@@ -668,14 +668,14 @@ const char* SimXMLDocument::lastAttribute()
       return StringTable->insert("");
    }
    const int iLastElement = m_paNode.size() - 1;
-   TiXmlElement* pNode = m_paNode[iLastElement];
+   fsTiXmlElement* pNode = m_paNode[iLastElement];
    if(!pNode)
    {
       return StringTable->insert("");
    }
 
    // Gets its last attribute, if any
-   m_CurrentAttribute = pNode->LastAttribute();
+   m_CurrentAttribute = static_cast<fsTiXmlAttribute*>(pNode->LastAttribute());
    if(!m_CurrentAttribute)
    {
       return StringTable->insert("");
@@ -706,7 +706,7 @@ const char* SimXMLDocument::nextAttribute()
    }
 
    // Gets its next attribute, if any
-   m_CurrentAttribute = m_CurrentAttribute->Next();
+   m_CurrentAttribute = static_cast<fsTiXmlAttribute*>(m_CurrentAttribute->Next());
    if(!m_CurrentAttribute)
    {
       return StringTable->insert("");
@@ -737,7 +737,7 @@ const char* SimXMLDocument::prevAttribute()
    }
 
    // Gets its next attribute, if any
-   m_CurrentAttribute = m_CurrentAttribute->Previous();
+   m_CurrentAttribute = static_cast<fsTiXmlAttribute*>(m_CurrentAttribute->Previous());
    if(!m_CurrentAttribute)
    {
       return StringTable->insert("");
@@ -767,7 +767,7 @@ void SimXMLDocument::setAttribute(const char* rAttribute, const char* rVal)
    }
 
    const int iLastElement = m_paNode.size() - 1;
-   TiXmlElement* pElement = m_paNode[iLastElement];
+   fsTiXmlElement* pElement = m_paNode[iLastElement];
    if(!pElement)
    {
       return;
@@ -799,13 +799,13 @@ void SimXMLDocument::setObjectAttributes(const char* objectID)
       return;
 
    const int iLastElement = m_paNode.size() - 1;
-   TiXmlElement* pElement = m_paNode[iLastElement];
+   fsTiXmlElement* pElement = m_paNode[iLastElement];
    if(!pElement)
       return;
 
    char textbuf[1024];
-   TiXmlElement field( "Field" );
-   TiXmlElement group( "FieldGroup" );
+   fsTiXmlElement field( "Field" );
+   fsTiXmlElement group( "FieldGroup" );
    pElement->SetAttribute( "Name", pObject->getName() );
 
 
@@ -916,22 +916,22 @@ DefineEngineMethod( SimXMLDocument, setObjectAttributes, void, ( const char* obj
 // -----------------------------------------------------------------------------
 void SimXMLDocument::pushNewElement(const char* rName)
 {    
-   TiXmlElement cElement( rName );
-   TiXmlElement* pStackTop = 0;
+   fsTiXmlElement cElement( rName );
+   fsTiXmlElement* pStackTop = 0;
    if(m_paNode.empty())
    {
-      pStackTop = dynamic_cast<TiXmlElement*>
+      pStackTop = dynamic_cast<fsTiXmlElement*>
          (m_qDocument->InsertEndChild( cElement ) );
    }
    else
    {
       const int iFinalElement = m_paNode.size() - 1;
-      TiXmlElement* pNode = m_paNode[iFinalElement];
+      fsTiXmlElement* pNode = m_paNode[iFinalElement];
       if(!pNode)
       {
          return;
       }
-      pStackTop = dynamic_cast<TiXmlElement*>
+      pStackTop = dynamic_cast<fsTiXmlElement*>
          (pNode->InsertEndChild( cElement ));
    }
    if(!pStackTop)
@@ -961,11 +961,11 @@ DefineEngineMethod( SimXMLDocument, pushNewElement, void, ( const char* name ),,
 // -----------------------------------------------------------------------------
 void SimXMLDocument::addNewElement(const char* rName)
 {    
-   TiXmlElement cElement( rName );
-   TiXmlElement* pStackTop = 0;
+   fsTiXmlElement cElement( rName );
+   fsTiXmlElement* pStackTop = 0;
    if(m_paNode.empty())
    {
-      pStackTop = dynamic_cast<TiXmlElement*>
+      pStackTop = dynamic_cast<fsTiXmlElement*>
          (m_qDocument->InsertEndChild( cElement ));
       if(!pStackTop)
       {
@@ -978,7 +978,7 @@ void SimXMLDocument::addNewElement(const char* rName)
    const int iParentElement = m_paNode.size() - 2;
    if(iParentElement < 0)
    {
-      pStackTop = dynamic_cast<TiXmlElement*>
+      pStackTop = dynamic_cast<fsTiXmlElement*>
          (m_qDocument->InsertEndChild( cElement ));
       if(!pStackTop)
       {
@@ -989,12 +989,12 @@ void SimXMLDocument::addNewElement(const char* rName)
    }
    else
    {
-      TiXmlElement* pNode = m_paNode[iParentElement];
+      fsTiXmlElement* pNode = m_paNode[iParentElement];
       if(!pNode)
       {
          return;
       }   
-      pStackTop = dynamic_cast<TiXmlElement*>
+      pStackTop = dynamic_cast<fsTiXmlElement*>
          (pNode->InsertEndChild( cElement ));
       if(!pStackTop)
       {
@@ -1028,7 +1028,7 @@ DefineEngineMethod( SimXMLDocument, addNewElement, void, ( const char* name ),,
 // -----------------------------------------------------------------------------
 void SimXMLDocument::addHeader(void)
 {
-   TiXmlDeclaration cDeclaration("1.0", "utf-8", "yes");
+   fsTiXmlDeclaration cDeclaration("1.0", "utf-8", "yes");
    m_qDocument->InsertEndChild(cDeclaration);
 }
 
@@ -1056,7 +1056,7 @@ DefineEngineMethod( SimXMLDocument, addHeader, void, (),,
 
 void SimXMLDocument::addComment(const char* comment)
 {
-   TiXmlComment cComment;
+   fsTiXmlComment cComment;
    cComment.SetValue(comment);
    m_qDocument->InsertEndChild(cComment);
 }
@@ -1160,11 +1160,11 @@ void SimXMLDocument::addText(const char* text)
       return;
 
    const int iFinalElement = m_paNode.size() - 1;
-   TiXmlElement* pNode = m_paNode[iFinalElement];
+   fsTiXmlElement* pNode = m_paNode[iFinalElement];
    if(!pNode)
       return;
 
-   TiXmlText cText(text);
+   fsTiXmlText cText(text);
    pNode->InsertEndChild( cText );
 }
 
@@ -1265,7 +1265,7 @@ void SimXMLDocument::removeText()
       return;
 
    const int iFinalElement = m_paNode.size() - 1;
-   TiXmlElement* pNode = m_paNode[iFinalElement];
+   fsTiXmlElement* pNode = m_paNode[iFinalElement];
    if(!pNode)
       return;
 
@@ -1301,11 +1301,11 @@ void SimXMLDocument::addData(const char* text)
       return;
 
    const int iFinalElement = m_paNode.size() - 1;
-   TiXmlElement* pNode = m_paNode[iFinalElement];
+   fsTiXmlElement* pNode = m_paNode[iFinalElement];
    if(!pNode)
       return;
 
-   TiXmlText cText(text);
+   fsTiXmlText cText(text);
    pNode->InsertEndChild( cText );
 }
 

--- a/Engine/source/console/SimXMLDocument.h
+++ b/Engine/source/console/SimXMLDocument.h
@@ -36,9 +36,9 @@
 #endif // _TVECTOR_H_
 
 
-class TiXmlDocument;
-class TiXmlElement;
-class TiXmlAttribute;
+class fsTiXmlDocument;
+class fsTiXmlElement;
+class fsTiXmlAttribute;
 
 
 class SimXMLDocument: public SimObject
@@ -136,11 +136,11 @@ class SimXMLDocument: public SimObject
       
    private:
       // Document.
-      TiXmlDocument* m_qDocument;
+      fsTiXmlDocument* m_qDocument;
       // Stack of nodes.
-      Vector<TiXmlElement*> m_paNode;
+      Vector<fsTiXmlElement*> m_paNode;
 	  // The current attribute
-	  TiXmlAttribute* m_CurrentAttribute;
+	  fsTiXmlAttribute* m_CurrentAttribute;
 
    public:
       DECLARE_CONOBJECT(SimXMLDocument);

--- a/Engine/source/core/stream/stream.cpp
+++ b/Engine/source/core/stream/stream.cpp
@@ -123,6 +123,15 @@ void Stream::writeString(const char *string, S32 maxLen)
       write(len, string);
 }
 
+bool Stream::writeFormattedBuffer(const char *format, ...)
+{
+   char buffer[4096];
+   va_list args;
+   va_start(args, format);
+   const S32 length = dVsprintf(buffer, sizeof(buffer), format, args);
+   return write( length, buffer );
+}
+
 void Stream::readString(char buf[256])
 {
    U8 len;

--- a/Engine/source/core/stream/stream.h
+++ b/Engine/source/core/stream/stream.h
@@ -30,6 +30,7 @@
 #include "core/util/endian.h"
 #endif
 
+#include <core/strings/stringFunctions.h>
 
 /// @defgroup stream_overload Primitive Type Stream Operation Overloads
 /// These macros declare the read and write functions for all primitive types.
@@ -130,11 +131,20 @@ public:
    /// writeString is safer.
    void writeLongString(U32 maxStringLen, const char *string);
 
+   inline bool Put( char character ) { return write( character ); }
+
    /// Write raw text to the stream
    void writeText(const char *text);
 
    /// Writes a string to the stream.
    virtual void writeString(const char *stringBuf, S32 maxLen=255);
+
+   /// Writes a formatted buffer to the stream.
+   /// NOTE: A maximum string length of 4K is allowed.
+   bool writeFormattedBuffer(const char *format, ...);
+
+   /// Writes a NULL terminated string buffer.
+   bool writeStringBuffer(const char* buffer) { return write( dStrlen(buffer), buffer ); }
 
    // read/write real strings
    void write(const String & str) { _write(str); }

--- a/Engine/source/taml/fsTinyXml.cpp
+++ b/Engine/source/taml/fsTinyXml.cpp
@@ -1,0 +1,747 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2013 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
+#include "fsTinyXml.h"
+#include "console/console.h"
+
+bool fsTiXmlDocument::LoadFile( const char * pFilename, TiXmlEncoding encoding )
+{
+   // Expand the file-path.
+   char filenameBuffer[1024];
+   Con::expandToolScriptFilename( filenameBuffer, sizeof(filenameBuffer), pFilename );
+
+   FileStream stream;
+
+#ifdef TORQUE_OS_ANDROID
+   if (strlen(pFilename) > strlen(filenameBuffer)) {
+      strcpy(filenameBuffer, pFilename);
+   }
+#endif
+
+   // File open for read?
+   if ( !stream.open( filenameBuffer, Torque::FS::File::AccessMode::Read ) )
+   {
+      // No, so warn.
+      Con::warnf("TamlXmlParser::parse() - Could not open filename '%s' for parse.", filenameBuffer );
+      return false;
+   }
+
+   // Load document from stream.
+   if ( !LoadFile( stream ) )
+   {
+      // Warn!
+      Con::warnf("TamlXmlParser: Could not load Taml XML file from stream.");
+      return false;
+   }
+
+   // Close the stream.
+   stream.close();
+   return true;
+}
+
+bool fsTiXmlDocument::SaveFile( const char * pFilename ) const
+{
+   // Expand the file-name into the file-path buffer.
+   char filenameBuffer[1024];
+   Con::expandToolScriptFilename( filenameBuffer, sizeof(filenameBuffer), pFilename );
+
+   FileStream stream;
+
+   // File opened?
+   if ( !stream.open( filenameBuffer, Torque::FS::File::AccessMode::Write ) )
+   {
+      // No, so warn.
+      Con::warnf("Taml::writeFile() - Could not open filename '%s' for write.", filenameBuffer );
+      return false;
+   }
+
+   bool ret = SaveFile(stream);
+
+   stream.close();
+   return ret;
+}
+
+bool fsTiXmlDocument::LoadFile( FileStream &stream, TiXmlEncoding encoding )
+{
+   // Delete the existing data:
+   Clear();
+   //TODO: Can't clear location, investigate if this gives issues.
+   //doc.location.Clear();
+
+   // Get the file size, so we can pre-allocate the string. HUGE speed impact.
+   long length = stream.getStreamSize();
+
+   // Strange case, but good to handle up front.
+   if ( length <= 0 )
+   {
+      SetError( TiXmlDocument::TIXML_ERROR_DOCUMENT_EMPTY, 0, 0, TIXML_ENCODING_UNKNOWN );
+      return false;
+   }
+
+   // Subtle bug here. TinyXml did use fgets. But from the XML spec:
+   // 2.11 End-of-Line Handling
+   // <snip>
+   // <quote>
+   // ...the XML processor MUST behave as if it normalized all line breaks in external 
+   // parsed entities (including the document entity) on input, before parsing, by translating 
+   // both the two-character sequence #xD #xA and any #xD that is not followed by #xA to 
+   // a single #xA character.
+   // </quote>
+   //
+   // It is not clear fgets does that, and certainly isn't clear it works cross platform. 
+   // Generally, you expect fgets to translate from the convention of the OS to the c/unix
+   // convention, and not work generally.
+
+   /*
+   while( fgets( buf, sizeof(buf), file ) )
+   {
+   data += buf;
+   }
+   */
+
+   char* buf = new char[ length+1 ];
+   buf[0] = 0;
+
+   if ( !stream.read( length, buf ) ) {
+      delete [] buf;
+      SetError( TiXmlDocument::TIXML_ERROR_OPENING_FILE, 0, 0, TIXML_ENCODING_UNKNOWN );
+      return false;
+   }
+
+   // Process the buffer in place to normalize new lines. (See comment above.)
+   // Copies from the 'p' to 'q' pointer, where p can advance faster if
+   // a newline-carriage return is hit.
+   //
+   // Wikipedia:
+   // Systems based on ASCII or a compatible character set use either LF  (Line feed, '\n', 0x0A, 10 in decimal) or 
+   // CR (Carriage return, '\r', 0x0D, 13 in decimal) individually, or CR followed by LF (CR+LF, 0x0D 0x0A)...
+   //                * LF:    Multics, Unix and Unix-like systems (GNU/Linux, AIX, Xenix, Mac OS X, FreeBSD, etc.), BeOS, Amiga, RISC OS, and others
+   //                * CR+LF: DEC RT-11 and most other early non-Unix, non-IBM OSes, CP/M, MP/M, DOS, OS/2, Microsoft Windows, Symbian OS
+   //                * CR:    Commodore 8-bit machines, Apple II family, Mac OS up to version 9 and OS-9
+
+   const char* p = buf;        // the read head
+   char* q = buf;                        // the write head
+   const char CR = 0x0d;
+   const char LF = 0x0a;
+
+   buf[length] = 0;
+   while( *p ) {
+      assert( p < (buf+length) );
+      assert( q <= (buf+length) );
+      assert( q <= p );
+
+      if ( *p == CR ) {
+         *q++ = LF;
+         p++;
+         if ( *p == LF ) {                // check for CR+LF (and skip LF)
+            p++;
+         }
+      }
+      else {
+         *q++ = *p++;
+      }
+   }
+   assert( q <= (buf+length) );
+   *q = 0;
+
+   Parse( buf, 0, encoding );
+
+   delete [] buf;
+   return !Error();
+}
+
+bool fsTiXmlDocument::SaveFile( FileStream &stream ) const
+{
+   if ( useMicrosoftBOM ) 
+   {
+      const unsigned char TIXML_UTF_LEAD_0 = 0xefU;
+      const unsigned char TIXML_UTF_LEAD_1 = 0xbbU;
+      const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
+
+      stream.write( TIXML_UTF_LEAD_0 );
+      stream.write( TIXML_UTF_LEAD_1 );
+      stream.write( TIXML_UTF_LEAD_2 );
+   }
+   Print( stream, 0 );
+   return true;
+}
+
+void fsTiXmlDocument::Print( FileStream& stream, int depth ) const
+{
+   for ( const TiXmlNode* node=FirstChild(); node; node=node->NextSibling() )
+   {
+      //AttemptPrintTiNode(const_cast<TiXmlNode*>(node), stream, depth);
+      dynamic_cast<const fsTiXmlNode*>(node)->Print( stream, depth );
+      stream.writeText( "\n" );
+   }
+}
+
+void fsTiXmlAttribute::Print( FileStream& stream, int depth, TIXML_STRING* str ) const
+{
+   TIXML_STRING n, v;
+
+   TiXmlString value = TiXmlString(Value());
+
+   EncodeString( NameTStr(), &n );
+   EncodeString( value, &v );
+
+   for ( int i=0; i< depth; i++ ) {
+      stream.writeText( "    " );
+   }
+
+   if (value.find ('\"') == TIXML_STRING::npos) {
+      const char* pValue = v.c_str();
+      char buffer[4096];
+      const S32 length = dSprintf(buffer, sizeof(buffer), "%s=\"%s\"", n.c_str(), pValue);
+      stream.write(length, buffer);
+      if ( str ) {
+         (*str) += n; (*str) += "=\""; (*str) += v; (*str) += "\"";
+      }
+   }
+   else {
+      char buffer[4096];
+      const S32 length = dSprintf(buffer, sizeof(buffer), "%s='%s'", n.c_str(), v.c_str());
+      stream.write(length, buffer);
+      if ( str ) {
+         (*str) += n; (*str) += "='"; (*str) += v; (*str) += "'";
+      }
+   }
+}
+
+void fsTiXmlDeclaration::Print(FileStream& stream, int depth, TiXmlString* str) const
+{
+   stream.writeStringBuffer( "<?xml " );
+   if ( str )	 (*str) += "<?xml ";
+
+   if ( !version.empty() ) {
+      stream.writeFormattedBuffer( "version=\"%s\" ", version.c_str ());
+      if ( str ) { (*str) += "version=\""; (*str) += version; (*str) += "\" "; }
+   }
+   if ( !encoding.empty() ) {
+      stream.writeFormattedBuffer( "encoding=\"%s\" ", encoding.c_str ());
+      if ( str ) { (*str) += "encoding=\""; (*str) += encoding; (*str) += "\" "; }
+   }
+   if ( !standalone.empty() ) {
+      stream.writeFormattedBuffer( "standalone=\"%s\" ", standalone.c_str ());
+      if ( str ) { (*str) += "standalone=\""; (*str) += standalone; (*str) += "\" "; }
+   }
+   stream.writeStringBuffer( "?>" );
+   if ( str )	 (*str) += "?>";
+}
+
+void fsTiXmlElement::Print(FileStream& stream, int depth) const
+{
+   int i;
+   for ( i=0; i<depth; i++ ) {
+      stream.writeStringBuffer( "    " );
+   }
+
+   stream.writeFormattedBuffer( "<%s", value.c_str() );
+
+   const TiXmlAttribute* attrib;
+   for ( attrib = attributeSet.First(); attrib; attrib = attrib->Next() )
+   {
+      stream.writeStringBuffer( "\n" );
+      dynamic_cast<const fsTiXmlAttribute*>(attrib)->Print( stream, depth+1 );
+   }
+
+   // There are 3 different formatting approaches:
+   // 1) An element without children is printed as a <foo /> node
+   // 2) An element with only a text child is printed as <foo> text </foo>
+   // 3) An element with children is printed on multiple lines.
+   TiXmlNode* node;
+   if ( !firstChild )
+   {
+      stream.writeStringBuffer( " />" );
+   }
+   else if ( firstChild == lastChild && firstChild->ToText() )
+   {
+      stream.writeStringBuffer( ">" );
+      dynamic_cast<const fsTiXmlNode*>(firstChild)->Print( stream, depth + 1 );
+      stream.writeFormattedBuffer( "</%s>", value.c_str() );
+   }
+   else
+   {
+      stream.writeStringBuffer( ">" );
+
+      for ( node = firstChild; node; node=node->NextSibling() )
+      {
+         if ( !node->ToText() )
+         {
+            stream.writeStringBuffer( "\n" );
+         }
+         dynamic_cast<const fsTiXmlNode*>(node)->Print( stream, depth+1 );
+      }
+      stream.writeStringBuffer( "\n" );
+      for( i=0; i<depth; ++i ) {
+         stream.writeStringBuffer( "    " );
+      }
+      stream.writeFormattedBuffer( "</%s>", value.c_str() );
+   }
+}
+
+void fsTiXmlComment::Print(FileStream& stream, int depth) const
+{
+   for ( int i=0; i<depth; i++ )
+   {
+      stream.writeStringBuffer( "    " );
+   }
+   stream.writeFormattedBuffer( "<!--%s-->", value.c_str() );
+}
+
+void fsTiXmlText::Print(FileStream& stream, int depth) const
+{ 
+   if ( cdata )
+   {
+      int i;
+      stream.writeStringBuffer( "\n" );
+      for ( i=0; i<depth; i++ ) {
+         stream.writeStringBuffer( "    " );
+      }
+      stream.writeFormattedBuffer( "<![CDATA[%s]]>\n", value.c_str() );	// unformatted output
+   }
+   else
+   {
+      TIXML_STRING buffer;
+      EncodeString( value, &buffer );
+      stream.writeFormattedBuffer( "%s", buffer.c_str() );
+   }
+}
+
+void fsTiXmlUnknown::Print(FileStream& stream, int depth) const
+{
+   for ( int i=0; i<depth; i++ )
+      stream.writeStringBuffer( "    " );
+
+   stream.writeFormattedBuffer( "<%s>", value.c_str() );
+}
+
+static TiXmlNode* TiNodeIdentify( TiXmlNode* parent, const char* p, TiXmlEncoding encoding )
+{
+   	TiXmlNode* returnNode = 0;
+
+	p = TiXmlNode::SkipWhiteSpace( p, encoding );
+	if( !p || !*p || *p != '<' )
+	{
+		return 0;
+	}
+
+	p = TiXmlNode::SkipWhiteSpace( p, encoding );
+
+	if ( !p || !*p )
+	{
+		return 0;
+	}
+
+	// What is this thing? 
+	// - Elements start with a letter or underscore, but xml is reserved.
+	// - Comments: <!--
+	// - Decleration: <?xml
+	// - Everthing else is unknown to tinyxml.
+	//
+
+	const char* xmlHeader = { "<?xml" };
+	const char* commentHeader = { "<!--" };
+	const char* dtdHeader = { "<!" };
+	const char* cdataHeader = { "<![CDATA[" };
+
+	if ( TiXmlNode::StringEqual( p, xmlHeader, true, encoding ) )
+	{
+		#ifdef DEBUG_PARSER
+			TIXML_LOG( "XML parsing Declaration\n" );
+		#endif
+		returnNode = new fsTiXmlDeclaration();
+	}
+	else if ( TiXmlNode::StringEqual( p, commentHeader, false, encoding ) )
+	{
+		#ifdef DEBUG_PARSER
+			TIXML_LOG( "XML parsing Comment\n" );
+		#endif
+		returnNode = new fsTiXmlComment();
+	}
+	else if ( TiXmlNode::StringEqual( p, cdataHeader, false, encoding ) )
+	{
+		#ifdef DEBUG_PARSER
+			TIXML_LOG( "XML parsing CDATA\n" );
+		#endif
+		TiXmlText* text = new fsTiXmlText( "" );
+		text->SetCDATA( true );
+		returnNode = text;
+	}
+	else if ( TiXmlNode::StringEqual( p, dtdHeader, false, encoding ) )
+	{
+		#ifdef DEBUG_PARSER
+			TIXML_LOG( "XML parsing Unknown(1)\n" );
+		#endif
+		returnNode = new fsTiXmlUnknown();
+	}
+	else if (    TiXmlNode::IsAlpha( *(p+1), encoding )
+			  || *(p+1) == '_' )
+	{
+		#ifdef DEBUG_PARSER
+			TIXML_LOG( "XML parsing Element\n" );
+		#endif
+		returnNode = new fsTiXmlElement( "" );
+	}
+	else
+	{
+		#ifdef DEBUG_PARSER
+			TIXML_LOG( "XML parsing Unknown(2)\n" );
+		#endif
+		returnNode = new fsTiXmlUnknown();
+	}
+
+	if ( returnNode )
+	{
+		// Set the parent, so it can report errors
+		returnNode->parent = parent;
+	}
+	return returnNode;
+}
+
+TiXmlNode* fsTiXmlDocument::Identify(  const char* p, TiXmlEncoding encoding )
+{
+   return TiNodeIdentify(this, p, encoding);
+}
+
+TiXmlNode* fsTiXmlElement::Identify(  const char* p, TiXmlEncoding encoding )
+{
+   return TiNodeIdentify(this, p, encoding);
+}
+
+const char* fsTiXmlElement::Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding )
+{
+	p = SkipWhiteSpace( p, encoding );
+	TiXmlDocument* document = GetDocument();
+
+	if ( !p || !*p )
+	{
+		if ( document ) document->SetError( TIXML_ERROR_PARSING_ELEMENT, 0, 0, encoding );
+		return 0;
+	}
+
+	if ( data )
+	{
+		data->Stamp( p, encoding );
+		location = data->Cursor();
+	}
+
+	if ( *p != '<' )
+	{
+		if ( document ) document->SetError( TIXML_ERROR_PARSING_ELEMENT, p, data, encoding );
+		return 0;
+	}
+
+	p = SkipWhiteSpace( p+1, encoding );
+
+	// Read the name.
+	const char* pErr = p;
+
+    p = ReadName( p, &value, encoding );
+	if ( !p || !*p )
+	{
+		if ( document )	document->SetError( TIXML_ERROR_FAILED_TO_READ_ELEMENT_NAME, pErr, data, encoding );
+		return 0;
+	}
+
+    TIXML_STRING endTag ("</");
+	endTag += value;
+
+	// Check for and read attributes. Also look for an empty
+	// tag or an end tag.
+	while ( p && *p )
+	{
+		pErr = p;
+		p = SkipWhiteSpace( p, encoding );
+		if ( !p || !*p )
+		{
+			if ( document ) document->SetError( TIXML_ERROR_READING_ATTRIBUTES, pErr, data, encoding );
+			return 0;
+		}
+		if ( *p == '/' )
+		{
+			++p;
+			// Empty tag.
+			if ( *p  != '>' )
+			{
+				if ( document ) document->SetError( TIXML_ERROR_PARSING_EMPTY, p, data, encoding );		
+				return 0;
+			}
+			return (p+1);
+		}
+		else if ( *p == '>' )
+		{
+			// Done with attributes (if there were any.)
+			// Read the value -- which can include other
+			// elements -- read the end tag, and return.
+			++p;
+			p = ReadValue( p, data, encoding );		// Note this is an Element method, and will set the error if one happens.
+			if ( !p || !*p ) {
+				// We were looking for the end tag, but found nothing.
+				// Fix for [ 1663758 ] Failure to report error on bad XML
+				if ( document ) document->SetError( TIXML_ERROR_READING_END_TAG, p, data, encoding );
+				return 0;
+			}
+
+			// We should find the end tag now
+			// note that:
+			// </foo > and
+			// </foo> 
+			// are both valid end tags.
+			if ( StringEqual( p, endTag.c_str(), false, encoding ) )
+			{
+				p += endTag.length();
+				p = SkipWhiteSpace( p, encoding );
+				if ( p && *p && *p == '>' ) {
+					++p;
+					return p;
+				}
+				if ( document ) document->SetError( TIXML_ERROR_READING_END_TAG, p, data, encoding );
+				return 0;
+			}
+			else
+			{
+				if ( document ) document->SetError( TIXML_ERROR_READING_END_TAG, p, data, encoding );
+				return 0;
+			}
+		}
+		else
+		{
+			// Try to read an attribute:
+			TiXmlAttribute* attrib = new fsTiXmlAttribute();
+			if ( !attrib )
+			{
+				return 0;
+			}
+
+			attrib->SetDocument( document );
+			pErr = p;
+			p = attrib->Parse( p, data, encoding );
+
+			if ( !p || !*p )
+			{
+				if ( document ) document->SetError( TIXML_ERROR_PARSING_ELEMENT, pErr, data, encoding );
+				delete attrib;
+				return 0;
+			}
+
+			// Handle the strange case of double attributes:
+			#ifdef TIXML_USE_STL
+			TiXmlAttribute* node = attributeSet.Find( attrib->NameTStr() );
+			#else
+			TiXmlAttribute* node = attributeSet.Find( attrib->Name() );
+			#endif
+			if ( node )
+			{
+				if ( document ) document->SetError( TIXML_ERROR_PARSING_ELEMENT, pErr, data, encoding );
+				delete attrib;
+				return 0;
+			}
+
+			attributeSet.Add( attrib );
+		}
+	}
+	return p;
+}
+
+/*
+TiXmlNode* fsTiXmlNode::Identify(char const* p, TiXmlEncoding encoding)
+{	
+TiXmlNode* returnNode = 0;
+
+p = TiXmlBase::SkipWhiteSpace( p, encoding );
+if( !p || !*p || *p != '<' )
+{
+return 0;
+}
+
+p = TiXmlBase::SkipWhiteSpace( p, encoding );
+
+if ( !p || !*p )
+{
+return 0;
+}
+
+// What is this thing? 
+// - Elements start with a letter or underscore, but xml is reserved.
+// - Comments: <!--
+// - Decleration: <?xml
+// - Everthing else is unknown to tinyxml.
+//
+
+const char* xmlHeader = { "<?xml" };
+const char* commentHeader = { "<!--" };
+const char* dtdHeader = { "<!" };
+const char* cdataHeader = { "<![CDATA[" };
+
+if ( TiXmlBase::StringEqual( p, xmlHeader, true, encoding ) )
+{
+#ifdef DEBUG_PARSER
+TIXML_LOG( "XML parsing Declaration\n" );
+#endif
+returnNode = new fsTiXmlDeclaration();
+}
+else if ( TiXmlBase::StringEqual( p, commentHeader, false, encoding ) )
+{
+#ifdef DEBUG_PARSER
+TIXML_LOG( "XML parsing Comment\n" );
+#endif
+returnNode = new fsTiXmlComment();
+}
+else if ( TiXmlBase::StringEqual( p, cdataHeader, false, encoding ) )
+{
+#ifdef DEBUG_PARSER
+TIXML_LOG( "XML parsing CDATA\n" );
+#endif
+fsTiXmlText* text = new fsTiXmlText( "" );
+text->SetCDATA( true );
+returnNode = text;
+}
+else if ( TiXmlBase::StringEqual( p, dtdHeader, false, encoding ) )
+{
+#ifdef DEBUG_PARSER
+TIXML_LOG( "XML parsing Unknown(1)\n" );
+#endif
+returnNode = new fsTiXmlUnknown();
+}
+else if (    TiXmlBase::IsAlpha( *(p+1), encoding )
+|| *(p+1) == '_' )
+{
+#ifdef DEBUG_PARSER
+TIXML_LOG( "XML parsing Element\n" );
+#endif
+returnNode = new fsTiXmlElement( "" );
+}
+else
+{
+#ifdef DEBUG_PARSER
+TIXML_LOG( "XML parsing Unknown(2)\n" );
+#endif
+returnNode = new fsTiXmlUnknown();
+}
+
+if ( returnNode )
+{
+// Set the parent, so it can report errors
+returnNode->parent = this;
+}
+return returnNode;
+}
+
+const unsigned char TIXML_UTF_LEAD_0 = 0xefU;
+const unsigned char TIXML_UTF_LEAD_1 = 0xbbU;
+const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
+
+char const* fsTiXmlDocument::Parse(char const* p, TiXmlParsingData* prevData, TiXmlEncoding encoding)
+{
+ClearError();
+
+// Parse away, at the document level. Since a document
+// contains nothing but other tags, most of what happens
+// here is skipping white space.
+if ( !p || !*p )
+{
+SetError( TiXmlBase::TIXML_ERROR_DOCUMENT_EMPTY, 0, 0, TIXML_ENCODING_UNKNOWN );
+return 0;
+}
+
+// Note that, for a document, this needs to come
+// before the while space skip, so that parsing
+// starts from the pointer we are given.
+location.Clear();
+if ( prevData )
+{
+location.row = prevData->Cursor().row;
+location.col = prevData->Cursor().col;
+}
+else
+{
+location.row = 0;
+location.col = 0;
+}
+TiXmlParsingData data( p, TabSize(), location.row, location.col );
+location = data.Cursor();
+
+if ( encoding == TIXML_ENCODING_UNKNOWN )
+{
+// Check for the Microsoft UTF-8 lead bytes.
+const unsigned char* pU = (const unsigned char*)p;
+if (	*(pU+0) && *(pU+0) == TIXML_UTF_LEAD_0
+&& *(pU+1) && *(pU+1) == TIXML_UTF_LEAD_1
+&& *(pU+2) && *(pU+2) == TIXML_UTF_LEAD_2 )
+{
+encoding = TIXML_ENCODING_UTF8;
+useMicrosoftBOM = true;
+}
+}
+
+p = TiXmlBase::SkipWhiteSpace( p, encoding );
+if ( !p )
+{
+SetError( TiXmlBase::TIXML_ERROR_DOCUMENT_EMPTY, 0, 0, TIXML_ENCODING_UNKNOWN );
+return 0;
+}
+
+while ( p && *p )
+{
+TiXmlNode* node = fsTiXmlNode::Identify( p, encoding );
+if ( node )
+{
+p = node->Parse( p, &data, encoding );
+LinkEndChild( node );
+}
+else
+{
+break;
+}
+
+// Did we get encoding info?
+if (    encoding == TIXML_ENCODING_UNKNOWN
+&& node->ToDeclaration() )
+{
+TiXmlDeclaration* dec = node->ToDeclaration();
+const char* enc = dec->Encoding();
+assert( enc );
+
+if ( *enc == 0 )
+encoding = TIXML_ENCODING_UTF8;
+else if ( TiXmlBase::StringEqual( enc, "UTF-8", true, TIXML_ENCODING_UNKNOWN ) )
+encoding = TIXML_ENCODING_UTF8;
+else if ( TiXmlBase::StringEqual( enc, "UTF8", true, TIXML_ENCODING_UNKNOWN ) )
+encoding = TIXML_ENCODING_UTF8;	// incorrect, but be nice
+else 
+encoding = TIXML_ENCODING_LEGACY;
+}
+
+p = TiXmlBase::SkipWhiteSpace( p, encoding );
+}
+
+// Was this empty?
+if ( !firstChild ) {
+SetError( TiXmlBase::TIXML_ERROR_DOCUMENT_EMPTY, 0, 0, encoding );
+return 0;
+}
+
+// All is well.
+return p;
+}
+*/

--- a/Engine/source/taml/fsTinyXml.h
+++ b/Engine/source/taml/fsTinyXml.h
@@ -1,0 +1,248 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2013 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
+#ifndef _FSTINYXML_H_
+#define _FSTINYXML_H_
+
+
+#ifndef TINYXML_INCLUDED
+#include "tinyXML/tinyxml.h"
+#endif
+
+#include "platform/platform.h"
+
+#ifndef _FILESTREAM_H_
+#include "core/stream/fileStream.h"
+#endif
+
+class fsTiXmlNode
+{
+public:
+   virtual void Print( FileStream& stream, int depth ) const = 0;
+};
+
+class fsTiXmlDocument : public TiXmlDocument, public fsTiXmlNode
+{
+public:
+   bool LoadFile( FileStream &stream, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING );
+   bool SaveFile( FileStream &stream ) const;
+	/// Load a file using the given filename. Returns true if successful.
+	bool LoadFile( const char * filename, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING );
+	/// Save a file using the given filename. Returns true if successful.
+	bool SaveFile( const char * filename ) const;
+   virtual void Print( FileStream& stream, int depth ) const;
+
+   virtual TiXmlNode* Clone() const
+   {
+	   TiXmlDocument* clone = new fsTiXmlDocument();
+	   if ( !clone )
+		   return 0;
+
+	   CopyTo( clone );
+	   return clone;
+   }
+   TiXmlNode* Identify( const char* p, TiXmlEncoding encoding );
+};
+
+class fsTiXmlAttribute : public TiXmlAttribute, public fsTiXmlNode
+{
+public:
+   virtual void Print( FileStream& stream, int depth, TIXML_STRING* str ) const;
+   virtual void Print( FileStream& stream, int depth) const
+   {
+      Print(stream, depth, 0);
+   }
+};
+
+class fsTiXmlDeclaration : public TiXmlDeclaration, public fsTiXmlNode
+{
+public:
+   fsTiXmlDeclaration(){};
+	fsTiXmlDeclaration(	const char* _version,
+						const char* _encoding,
+                  const char* _standalone ) : TiXmlDeclaration(_version, _encoding, _standalone) { }
+
+   virtual void Print( FileStream& stream, int depth, TIXML_STRING* str ) const;
+   virtual void Print( FileStream& stream, int depth) const
+   {
+      Print(stream, depth, 0);
+   }
+
+   virtual TiXmlNode* Clone() const
+   {
+	   fsTiXmlDeclaration* clone = new fsTiXmlDeclaration();
+
+	   if ( !clone )
+		   return 0;
+
+	   CopyTo( clone );
+	   return clone;
+   }
+};
+
+class fsTiXmlElement : public TiXmlElement, public fsTiXmlNode
+{
+public:
+   fsTiXmlElement(const char* in_value) : TiXmlElement(in_value) { }
+
+   virtual void Print( FileStream& stream, int depth ) const;
+
+   virtual TiXmlNode* Clone() const
+   {
+	   TiXmlElement* clone = new fsTiXmlElement( Value() );
+	   if ( !clone )
+		   return 0;
+
+	   CopyTo( clone );
+	   return clone;
+   }
+
+   void SetAttribute( const char* name, const char * _value )
+   {
+      TiXmlAttribute* attrib = attributeSet.Find( name );
+      if(!attrib)
+      {
+         attrib = new fsTiXmlAttribute();
+		   attributeSet.Add( attrib );
+		   attrib->SetName( name );
+      }
+	   if ( attrib ) {
+		   attrib->SetValue( _value );
+	   }
+   }
+   void SetAttribute( const char * name, int value )
+   {
+	   TiXmlAttribute* attrib = attributeSet.Find( name );
+      if(!attrib)
+      {
+         attrib = new fsTiXmlAttribute();
+		   attributeSet.Add( attrib );
+		   attrib->SetName( name );
+      }
+	   if ( attrib ) {
+		   attrib->SetIntValue( value );
+	   }
+   }
+   TiXmlNode* Identify( const char* p, TiXmlEncoding encoding );
+   virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding );
+};
+
+class fsTiXmlComment : public TiXmlComment, public fsTiXmlNode
+{
+public:
+   virtual void Print( FileStream& stream, int depth ) const;
+
+   virtual TiXmlNode* Clone() const
+   {
+	   TiXmlComment* clone = new fsTiXmlComment();
+
+	   if ( !clone )
+		   return 0;
+
+	   CopyTo( clone );
+	   return clone;
+   }
+};
+
+class fsTiXmlText : public TiXmlText, public fsTiXmlNode
+{
+public:
+   fsTiXmlText (const char * initValue ) : TiXmlText(initValue) { }
+   virtual void Print( FileStream& stream, int depth ) const;
+
+   virtual TiXmlNode* Clone() const
+   {
+	   TiXmlText* clone = 0;
+	   clone = new fsTiXmlText( "" );
+
+	   if ( !clone )
+		   return 0;
+
+	   CopyTo( clone );
+	   return clone;
+   }
+};
+
+class fsTiXmlUnknown : public TiXmlUnknown, public fsTiXmlNode
+{
+public:
+   virtual void Print( FileStream& stream, int depth ) const;
+
+   virtual TiXmlNode* Clone() const
+   {
+	   TiXmlUnknown* clone = new fsTiXmlUnknown();
+
+	   if ( !clone )
+		   return 0;
+
+	   CopyTo( clone );
+	   return clone;
+   }
+};
+
+static bool AttemptPrintTiNode(class fsTiXmlDocument* node, FileStream& stream, int depth)
+{
+   fsTiXmlDocument* fsDoc = dynamic_cast<fsTiXmlDocument*>(node);
+   if(fsDoc != NULL)
+   {
+      fsDoc->Print(stream, depth);
+      return true;
+   }
+   fsTiXmlUnknown* fsUnk = dynamic_cast<fsTiXmlUnknown*>(node);
+   if(fsUnk != NULL)
+   {
+      fsUnk->Print(stream, depth);
+      return true;
+   }
+   fsTiXmlText* fsTxt = dynamic_cast<fsTiXmlText*>(node);
+   if(fsTxt != NULL)
+   {
+      fsTxt->Print(stream, depth);
+      return true;
+   }
+   fsTiXmlComment* fsCom = dynamic_cast<fsTiXmlComment*>(node);
+   if(fsCom != NULL)
+   {
+      fsCom->Print(stream, depth);
+      return true;
+   }
+   fsTiXmlElement* fsElm = dynamic_cast<fsTiXmlElement*>(node);
+   if(fsElm != NULL)
+   {
+      fsElm->Print(stream, depth);
+      return true;
+   }
+   fsTiXmlDeclaration* fsDec = dynamic_cast<fsTiXmlDeclaration*>(node);
+   if(fsDec != NULL)
+   {
+      fsDec->Print(stream, depth);
+      return true;
+   }
+   fsTiXmlAttribute* fsAtt = dynamic_cast<fsTiXmlAttribute*>(node);
+   if(fsAtt != NULL)
+   {
+      fsAtt->Print(stream, depth);
+      return true;
+   }
+   return false;
+}
+#endif //_FSTINYXML_H_


### PR DESCRIPTION
As described in issue #643, this pull requests aims to modify the TinyXML library in a way that doesn't affect current behaviour, but makes it possible to use FileStreams for working with the xml files, which is necessary to work with T3D's virtual file system (e.g. works inside Zip folders and stuff like that)

This Pull Request has some issues (such as placement of files and not being able to automatically merge) which I'll fix if we deem it is useful to T3D.

It's split into 4 commits: 
* dd4ae89 fixes some inconsistencies between T2D and T3D in the Stream objects.
* 50c65b5 Makes the TinyXML library more inheritance friendly.
* f40d50a Adds FileStream versions of the TinyXML classes.
* ba9bccf Alters the the SimXMLDocument classes to make use of the virtual file system through the FileStream versions of the TinyXML classes.

They are dependent on each other from bottom to top.

So is this a change we want in T3D? Discuss.