### PR TITLE
Use fixed buffer size variable for allocating return buffer

### DIFF
--- a/Engine/source/T3D/aiClient.cpp
+++ b/Engine/source/T3D/aiClient.cpp
@@ -457,8 +457,9 @@ ConsoleMethod( AIClient, getAimLocation, const char *, 2, 2, "ai.getAimLocation(
    AIClient *ai = static_cast<AIClient *>( object );
    Point3F aimPoint = ai->getAimLocation();
 
-   char *returnBuffer = Con::getReturnBuffer( 256 );
-   dSprintf( returnBuffer, 256, "%f %f %f", aimPoint.x, aimPoint.y, aimPoint.z );
+   static const U32 bufSize = 256;
+   char *returnBuffer = Con::getReturnBuffer( bufSize );
+   dSprintf( returnBuffer, bufSize, "%f %f %f", aimPoint.x, aimPoint.y, aimPoint.z );
 
    return returnBuffer;
 }
@@ -470,8 +471,9 @@ ConsoleMethod( AIClient, getMoveDestination, const char *, 2, 2, "ai.getMoveDest
    AIClient *ai = static_cast<AIClient *>( object );
    Point3F movePoint = ai->getMoveDestination();
 
-   char *returnBuffer = Con::getReturnBuffer( 256 );
-   dSprintf( returnBuffer, 256, "%f %f %f", movePoint.x, movePoint.y, movePoint.z );
+   static const U32 bufSize = 256;
+   char *returnBuffer = Con::getReturnBuffer( bufSize );
+   dSprintf( returnBuffer, bufSize, "%f %f %f", movePoint.x, movePoint.y, movePoint.z );
 
    return returnBuffer;
 }
@@ -522,8 +524,9 @@ ConsoleMethod( AIClient, getLocation, const char *, 2, 2, "ai.getLocation();" ) 
    AIClient *ai = static_cast<AIClient *>( object );
    Point3F locPoint = ai->getLocation();
 
-   char *returnBuffer = Con::getReturnBuffer( 256 );
-   dSprintf( returnBuffer, 256, "%f %f %f", locPoint.x, locPoint.y, locPoint.z );
+   static const U32 bufSize = 256;
+   char *returnBuffer = Con::getReturnBuffer( bufSize );
+   dSprintf( returnBuffer, bufSize, "%f %f %f", locPoint.x, locPoint.y, locPoint.z );
 
    return returnBuffer;
 }

--- a/Engine/source/T3D/gameFunctions.cpp
+++ b/Engine/source/T3D/gameFunctions.cpp
@@ -145,9 +145,10 @@ ConsoleFunction(containerFindFirst, const char*, 6, 6, "(int mask, Point3F point
 
    //return the first element
    sgServerQueryIndex = 0;
-   char *buff = Con::getReturnBuffer(100);
+   static const U32 bufSize = 100;
+   char *buff = Con::getReturnBuffer(bufSize);
    if (sgServerQueryList.mList.size())
-      dSprintf(buff, 100, "%d", sgServerQueryList.mList[sgServerQueryIndex++]->getId());
+      dSprintf(buff, bufSize, "%d", sgServerQueryList.mList[sgServerQueryIndex++]->getId());
    else
       buff[0] = '\0';
 
@@ -162,9 +163,10 @@ ConsoleFunction( containerFindNext, const char*, 1, 1, "()"
 	"@ingroup Game")
 {
    //return the next element
-   char *buff = Con::getReturnBuffer(100);
+   static const U32 bufSize = 100;
+   char *buff = Con::getReturnBuffer(bufSize);
    if (sgServerQueryIndex < sgServerQueryList.mList.size())
-      dSprintf(buff, 100, "%d", sgServerQueryList.mList[sgServerQueryIndex++]->getId());
+      dSprintf(buff, bufSize, "%d", sgServerQueryList.mList[sgServerQueryIndex++]->getId());
    else
       buff[0] = '\0';
 

--- a/Engine/source/T3D/item.cpp
+++ b/Engine/source/T3D/item.cpp
@@ -1241,9 +1241,10 @@ DefineEngineMethod( Item, getLastStickyPos, const char*, (),,
    "@note Server side only.\n"
    )
 {
-   char* ret = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char* ret = Con::getReturnBuffer(bufSize);
    if (object->isServerObject())
-      dSprintf(ret, 255, "%g %g %g",
+      dSprintf(ret, bufSize, "%g %g %g",
                object->mStickyCollisionPos.x,
                object->mStickyCollisionPos.y,
                object->mStickyCollisionPos.z);
@@ -1263,9 +1264,10 @@ DefineEngineMethod( Item, getLastStickyNormal, const char *, (),,
    "@note Server side only.\n"
    )
 {
-   char* ret = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char* ret = Con::getReturnBuffer(bufSize);
    if (object->isServerObject())
-      dSprintf(ret, 255, "%g %g %g",
+      dSprintf(ret, bufSize, "%g %g %g",
                object->mStickyCollisionNormal.x,
                object->mStickyCollisionNormal.y,
                object->mStickyCollisionNormal.z);

--- a/Engine/source/T3D/missionArea.cpp
+++ b/Engine/source/T3D/missionArea.cpp
@@ -176,10 +176,11 @@ DefineEngineFunction(getMissionAreaServerObject, MissionArea*, (),,
 DefineEngineMethod( MissionArea, getArea, const char *, (),,
               "Returns 4 fields: starting x, starting y, extents x, extents y.\n")
 {
-   char* returnBuffer = Con::getReturnBuffer(48);
+   static const U32 bufSize = 48;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
 
    RectI area = object->getArea();
-   dSprintf(returnBuffer, 48, "%d %d %d %d", area.point.x, area.point.y, area.extent.x, area.extent.y);
+   dSprintf(returnBuffer, bufSize, "%d %d %d %d", area.point.x, area.point.y, area.extent.x, area.extent.y);
    return(returnBuffer);
 }
 

--- a/Engine/source/T3D/missionMarker.cpp
+++ b/Engine/source/T3D/missionMarker.cpp
@@ -304,8 +304,9 @@ ConsoleType( WayPointTeam, TypeWayPointTeam, WayPointTeam )
 
 ConsoleGetType( TypeWayPointTeam )
 {
-   char * buf = Con::getReturnBuffer(32);
-   dSprintf(buf, 32, "%d", ((WayPointTeam*)dptr)->mTeamId);
+   static const U32 bufSize = 32;
+   char * buf = Con::getReturnBuffer(bufSize);
+   dSprintf(buf, bufSize, "%d", ((WayPointTeam*)dptr)->mTeamId);
    return(buf);
 }
 

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -6510,8 +6510,9 @@ DefineEngineMethod( Player, getDamageLocation, const char*, ( Point3F pos ),,
 
    object->getDamageLocation(pos, buffer1, buffer2);
 
-   char *buff = Con::getReturnBuffer(128);
-   dSprintf(buff, 128, "%s %s", buffer1, buffer2);
+   static const U32 bufSize = 128;
+   char *buff = Con::getReturnBuffer(bufSize);
+   dSprintf(buff, bufSize, "%s %s", buffer1, buffer2);
    return buff;
 }
 

--- a/Engine/source/T3D/trigger.cpp
+++ b/Engine/source/T3D/trigger.cpp
@@ -259,8 +259,9 @@ ConsoleGetType( TypeTriggerPolyhedron )
    AssertFatal(currVec == 3, "Internal error: Bad trigger polyhedron");
 
    // Build output string.
-   char* retBuf = Con::getReturnBuffer(1024);
-   dSprintf(retBuf, 1023, "%7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f",
+   static const U32 bufSize = 1024;
+   char* retBuf = Con::getReturnBuffer(bufSize);
+   dSprintf(retBuf, bufSize, "%7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f %7.7f",
             origin.x, origin.y, origin.z,
             vecs[0].x, vecs[0].y, vecs[0].z,
             vecs[2].x, vecs[2].y, vecs[2].z,

--- a/Engine/source/app/net/net.cpp
+++ b/Engine/source/app/net/net.cpp
@@ -382,10 +382,11 @@ ConsoleFunction( buildTaggedString, const char*, 2, 11, "(string format, ...)"
    if (*indexPtr == StringTagPrefixByte)
       indexPtr++;
    const char *fmtString = gNetStringTable->lookupString(dAtoi(indexPtr));
-   char *strBuffer = Con::getReturnBuffer(512);
+   static const U32 bufSize = 512;
+   char *strBuffer = Con::getReturnBuffer(bufSize);
    const char *fmtStrPtr = fmtString;
    char *strBufPtr = strBuffer;
-   S32 strMaxLength = 511;
+   S32 strMaxLength = bufSize - 1;
    if (!fmtString)
       goto done;
 

--- a/Engine/source/cinterface/cinterface.cpp
+++ b/Engine/source/cinterface/cinterface.cpp
@@ -468,9 +468,10 @@ ConsoleFunction(testJavaScriptBridge, const char *, 4, 4, "testBridge(arg1, arg2
 	if (dStrcmp(jret,"42"))
 		failed = 3;
 
-	char *ret = Con::getReturnBuffer(256);
+	static const U32 bufSize = 256;
+	char *ret = Con::getReturnBuffer(bufSize);
 
-	dSprintf(ret, 256, "%i", failed);
+	dSprintf(ret, bufSize, "%i", failed);
 
 	return ret;
 }

--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -1313,8 +1313,9 @@ const char *getFormattedData(S32 type, const char *data, const EnumTable *tbl, B
       Con::setData(type, variable, 0, 1, &data, tbl, flag);
       const char* formattedVal = Con::getData(type, variable, 0, tbl, flag);
 
-      char* returnBuffer = Con::getReturnBuffer(2048);
-      dSprintf(returnBuffer, 2048, "%s\0", formattedVal );
+      static const U32 bufSize = 2048;
+      char* returnBuffer = Con::getReturnBuffer(bufSize);
+      dSprintf(returnBuffer, bufSize, "%s\0", formattedVal );
 
       cbt->deleteNativeVariable(variable);
 

--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -75,7 +75,8 @@ DefineConsoleFunction( strformat, const char*, ( const char* format, const char*
    "@ingroup Strings\n"
    "@see http://en.wikipedia.org/wiki/Printf" )
 {
-   char* pBuffer = Con::getReturnBuffer(64);
+   static const U32 bufSize = 64;
+   char* pBuffer = Con::getReturnBuffer(bufSize);
    const char *pch = format;
 
    pBuffer[0] = '\0';
@@ -99,7 +100,7 @@ DefineConsoleFunction( strformat, const char*, ( const char* format, const char*
       case 'u':
       case 'x':
       case 'X':
-         dSprintf( pBuffer, 64, format, dAtoi( value ) );
+         dSprintf( pBuffer, bufSize, format, dAtoi( value ) );
          break;
 
       case 'e':
@@ -107,7 +108,7 @@ DefineConsoleFunction( strformat, const char*, ( const char* format, const char*
       case 'f':
       case 'g':
       case 'G':
-         dSprintf( pBuffer, 64, format, dAtof( value ) );
+         dSprintf( pBuffer, bufSize, format, dAtof( value ) );
          break;
 
       default:

--- a/Engine/source/console/consoleTypes.cpp
+++ b/Engine/source/console/consoleTypes.cpp
@@ -289,8 +289,9 @@ ImplementConsoleTypeCasters( TypeS8, S8 )
 
 ConsoleGetType( TypeS8 )
 {
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%d", *((U8 *) dptr) );
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d", *((U8 *) dptr) );
    return returnBuffer;
 }
 
@@ -310,8 +311,9 @@ ImplementConsoleTypeCasters(TypeS32, S32)
 
 ConsoleGetType( TypeS32 )
 {
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%d", *((S32 *) dptr) );
+   static const U32 bufSize = 512;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d", *((S32 *) dptr) );
    return returnBuffer;
 }
 
@@ -389,8 +391,9 @@ ImplementConsoleTypeCasters(TypeF32, F32)
 
 ConsoleGetType( TypeF32 )
 {
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%g", *((F32 *) dptr) );
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%g", *((F32 *) dptr) );
    return returnBuffer;
 }
 ConsoleSetType( TypeF32 )
@@ -487,8 +490,9 @@ ImplementConsoleTypeCasters( TypeBoolVector, Vector< bool > )
 ConsoleGetType( TypeBoolVector )
 {
    Vector<bool> *vec = (Vector<bool>*)dptr;
-   char* returnBuffer = Con::getReturnBuffer(1024);
-   S32 maxReturn = 1024;
+   static const U32 bufSize = 1024;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   S32 maxReturn = bufSize;
    returnBuffer[0] = '\0';
    S32 returnLeng = 0;
    for (Vector<bool>::iterator itr = vec->begin(); itr < vec->end(); itr++)
@@ -579,8 +583,9 @@ ConsoleGetType( TypeColorF )
       return colorName;
 
    // Format as color components.
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%g %g %g %g", color->red, color->green, color->blue, color->alpha);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%g %g %g %g", color->red, color->green, color->blue, color->alpha);
    return(returnBuffer);
 }
 
@@ -651,8 +656,9 @@ ConsoleGetType( TypeColorI )
       return colorName;
 
    // Format as color components.
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%d %d %d %d", color->red, color->green, color->blue, color->alpha);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d %d %d %d", color->red, color->green, color->blue, color->alpha);
    return returnBuffer;
 }
 
@@ -723,8 +729,9 @@ ConsoleSetType( TypeSimObjectName )
 ConsoleGetType( TypeSimObjectName )
 {
    SimObject **obj = (SimObject**)dptr;
-   char* returnBuffer = Con::getReturnBuffer(128);
-   dSprintf(returnBuffer, 128, "%s", *obj && (*obj)->getName() ? (*obj)->getName() : "");
+   static const U32 bufSize = 128;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%s", *obj && (*obj)->getName() ? (*obj)->getName() : "");
    return returnBuffer;
 }
 
@@ -791,8 +798,9 @@ ConsoleType( int, TypeTerrainMaterialIndex, S32 )
 
 ConsoleGetType( TypeTerrainMaterialIndex )
 {
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%d", *((S32 *) dptr) );
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d", *((S32 *) dptr) );
    return returnBuffer;
 }
 
@@ -853,8 +861,9 @@ ConsoleType( RectF, TypeRectUV, RectF )
 ConsoleGetType( TypeRectUV )
 {
    RectF *rect = (RectF *) dptr;
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%g %g %g %g", rect->point.x, rect->point.y,
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%g %g %g %g", rect->point.x, rect->point.y,
             rect->extent.x, rect->extent.y);
    return returnBuffer;
 }

--- a/Engine/source/console/dynamicTypes.h
+++ b/Engine/source/console/dynamicTypes.h
@@ -211,8 +211,9 @@ class BitfieldConsoleBaseType : public ConsoleBaseType
 
       virtual const char* getData( void* dptr, const EnumTable*, BitSet32 )
       {
-         char* returnBuffer = Con::getReturnBuffer(256);
-         dSprintf(returnBuffer, 256, "0x%08x", *((S32 *) dptr) );
+         static const U32 bufSize = 256;
+         char* returnBuffer = Con::getReturnBuffer(bufSize);
+         dSprintf(returnBuffer, bufSize, "0x%08x", *((S32 *) dptr) );
          return returnBuffer;
       }
       virtual void setData( void* dptr, S32 argc, const char** argv, const EnumTable*, BitSet32 )

--- a/Engine/source/console/fileSystemFunctions.cpp
+++ b/Engine/source/console/fileSystemFunctions.cpp
@@ -695,8 +695,9 @@ DefineEngineFunction(makeFullPath, String, ( const char* path, const char* cwd )
 	"@return String containing non-relative directory of path\n"
 	"@ingroup FileSystem")
 {
-   char *buf = Con::getReturnBuffer(512);
-   Platform::makeFullPathName(path, buf, 512, dStrlen(cwd) > 1 ? cwd : NULL);
+   static const U32 bufSize = 512;
+   char *buf = Con::getReturnBuffer(buf);
+   Platform::makeFullPathName(path, buf, bufSize, dStrlen(cwd) > 1 ? cwd : NULL);
    return buf;
 }
 
@@ -721,8 +722,9 @@ DefineEngineFunction(pathConcat, String, ( const char* path, const char* file),,
 	"@return String containing concatenated file name and path\n"
 	"@ingroup FileSystem")
 {
-   char *buf = Con::getReturnBuffer(1024);
-   Platform::makeFullPathName(file, buf, 1024, path);
+   static const U32 bufSize = 1024;
+   char *buf = Con::getReturnBuffer(buf);
+   Platform::makeFullPathName(file, buf, bufSize, path);
    return buf;
 }
 

--- a/Engine/source/console/scriptFilename.cpp
+++ b/Engine/source/console/scriptFilename.cpp
@@ -344,8 +344,9 @@ ConsoleFunction(expandFilename, const char*, 2, 2, "(string filename)"
 				"@ingroup FileSystem")
 {
    TORQUE_UNUSED(argc);
-   char* ret = Con::getReturnBuffer( 1024 );
-   Con::expandScriptFilename(ret, 1024, argv[1]);
+   static const U32 bufSize = 1024;
+   char* ret = Con::getReturnBuffer( bufSize );
+   Con::expandScriptFilename(ret, bufSize, argv[1]);
    return ret;
 }
 
@@ -355,8 +356,9 @@ ConsoleFunction(expandOldFilename, const char*, 2, 2, "(string filename)"
 				"@ingroup FileSystem")
 {
    TORQUE_UNUSED(argc);
-   char* ret = Con::getReturnBuffer( 1024 );
-   Con::expandOldScriptFilename(ret, 1024, argv[1]);
+   static const U32 bufSize = 1024;
+   char* ret = Con::getReturnBuffer( bufSize );
+   Con::expandOldScriptFilename(ret, bufSize, argv[1]);
    return ret;
 }
 
@@ -368,8 +370,9 @@ ConsoleToolFunction(collapseFilename, const char*, 2, 2, "(string filename)"
 					"@internal Editor use only")
 {
    TORQUE_UNUSED(argc);
-   char* ret = Con::getReturnBuffer( 1024 );
-   Con::collapseScriptFilename(ret, 1024, argv[1]);
+   static const U32 bufSize = 1024;
+   char* ret = Con::getReturnBuffer( bufSize );
+   Con::collapseScriptFilename(ret, bufSize, argv[1]);
    return ret;
 }
 

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -2680,11 +2680,12 @@ DefineConsoleMethod( SimObject, getDynamicField, const char*, ( S32 index ),,
       ++itr;
    }
 
-   char* buffer = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char* buffer = Con::getReturnBuffer(bufSize);
    if (*itr)
    {
       SimFieldDictionary::Entry* entry = *itr;
-      dSprintf(buffer, 256, "%s\t%s", entry->slotName, entry->value);
+      dSprintf(buffer, bufSize, "%s\t%s", entry->slotName, entry->value);
       return buffer;
    }
 

--- a/Engine/source/core/fileObject.cpp
+++ b/Engine/source/core/fileObject.cpp
@@ -343,8 +343,9 @@ DefineEngineMethod( FileObject, peekLine, const char*, (),,
 
    "@return String containing the line of data that was just peeked\n")
 {
-	char *line = Con::getReturnBuffer( 512 );
-	object->peekLine( (U8*)line, 512 );
+	static const U32 bufSize = 512;
+	char *line = Con::getReturnBuffer( bufSize );
+	object->peekLine( (U8*)line, bufSize );
 	return line;
 }
 

--- a/Engine/source/core/stream/streamObject.cpp
+++ b/Engine/source/core/stream/streamObject.cpp
@@ -113,8 +113,9 @@ const char * StreamObject::readLine()
    if(mStream == NULL)
       return NULL;
 
-   char *buffer = Con::getReturnBuffer(256);
-   mStream->readLine((U8 *)buffer, 256);
+   static const U32 bufSize = 256;
+   char *buffer = Con::getReturnBuffer(bufSize);
+   mStream->readLine((U8 *)buffer, bufSize);
    return buffer;
 }
 

--- a/Engine/source/environment/editors/guiMeshRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiMeshRoadEditorCtrl.cpp
@@ -1223,9 +1223,10 @@ ConsoleMethod( GuiMeshRoadEditorCtrl, setNodeDepth, void, 3, 3, "" )
 
 ConsoleMethod( GuiMeshRoadEditorCtrl, getNodePosition, const char*, 2, 2, "" )
 {
-	char* returnBuffer = Con::getReturnBuffer(256);
+	static const U32 bufSize = 256;
+	char* returnBuffer = Con::getReturnBuffer(bufSize);
 
-	dSprintf(returnBuffer, 256, "%f %f %f",
+	dSprintf(returnBuffer, bufSize, "%f %f %f",
       object->getNodePosition().x, object->getNodePosition().y, object->getNodePosition().z);
 
 	return returnBuffer;
@@ -1249,9 +1250,10 @@ ConsoleMethod( GuiMeshRoadEditorCtrl, setNodePosition, void, 3, 3, "" )
 
 ConsoleMethod( GuiMeshRoadEditorCtrl, getNodeNormal, const char*, 2, 2, "" )
 {
-   char* returnBuffer = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
 
-	dSprintf(returnBuffer, 256, "%f %f %f",
+	dSprintf(returnBuffer, bufSize, "%f %f %f",
       object->getNodeNormal().x, object->getNodeNormal().y, object->getNodeNormal().z);
 
 	return returnBuffer;

--- a/Engine/source/environment/editors/guiRiverEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRiverEditorCtrl.cpp
@@ -1430,9 +1430,10 @@ ConsoleMethod( GuiRiverEditorCtrl, setNodeDepth, void, 3, 3, "" )
 
 ConsoleMethod( GuiRiverEditorCtrl, getNodePosition, const char*, 2, 2, "" )
 {
-	char* returnBuffer = Con::getReturnBuffer(256);
+	static const U32 bufSize = 256;
+	char* returnBuffer = Con::getReturnBuffer(bufSize);
 
-	dSprintf(returnBuffer, 256, "%f %f %f",
+	dSprintf(returnBuffer, bufSize, "%f %f %f",
       object->getNodePosition().x, object->getNodePosition().y, object->getNodePosition().z);
 
 	return returnBuffer;
@@ -1456,9 +1457,10 @@ ConsoleMethod( GuiRiverEditorCtrl, setNodePosition, void, 3, 3, "" )
 
 ConsoleMethod( GuiRiverEditorCtrl, getNodeNormal, const char*, 2, 2, "" )
 {
-   char* returnBuffer = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
 
-	dSprintf(returnBuffer, 256, "%f %f %f",
+	dSprintf(returnBuffer, bufSize, "%f %f %f",
       object->getNodeNormal().x, object->getNodeNormal().y, object->getNodeNormal().z);
 
 	return returnBuffer;

--- a/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
@@ -1064,9 +1064,10 @@ ConsoleMethod( GuiRoadEditorCtrl, setNodeWidth, void, 3, 3, "" )
 
 ConsoleMethod( GuiRoadEditorCtrl, getNodePosition, const char*, 2, 2, "" )
 {
-	char* returnBuffer = Con::getReturnBuffer(256);
+	static const U32 bufSize = 256;
+	char* returnBuffer = Con::getReturnBuffer(bufSize);
 
-	dSprintf(returnBuffer, 256, "%f %f %f",
+	dSprintf(returnBuffer, bufSize, "%f %f %f",
       object->getNodePosition().x, object->getNodePosition().y, object->getNodePosition().z);
 
 	return returnBuffer;

--- a/Engine/source/forest/forestCollision.cpp
+++ b/Engine/source/forest/forestCollision.cpp
@@ -64,13 +64,14 @@ ScriptMethod( Forest, forestRayCast, const char*, 4, 4, "( Point3F start, Point3
    dSscanf(argv[2], "%g %g %g", &start.x, &start.y, &start.z);
    dSscanf(argv[3], "%g %g %g", &end.x,   &end.y,   &end.z);   
 
-   char *returnBuffer = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char *returnBuffer = Con::getReturnBuffer(bufSize);
    returnBuffer[0] = '0';
    returnBuffer[1] = '\0';
 
    ForestRayInfo rinfo;
    if ( object->castRayI( start, end, &rinfo ) )
-      dSprintf( returnBuffer, 256, "%d %d %g", rinfo.item->getData()->getId(), rinfo.key, rinfo.t );
+      dSprintf( returnBuffer, bufSize, "%d %d %g", rinfo.item->getData()->getId(), rinfo.key, rinfo.t );
 
    return returnBuffer;
 }

--- a/Engine/source/gui/controls/guiColorPicker.cpp
+++ b/Engine/source/gui/controls/guiColorPicker.cpp
@@ -528,10 +528,11 @@ void GuiColorPickerCtrl::setScriptValue(const char *value)
 
 ConsoleMethod(GuiColorPickerCtrl, getSelectorPos, const char*, 2, 2, "Gets the current position of the selector")
 {
-   char *temp = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char *temp = Con::getReturnBuffer(bufSize);
    Point2I pos;
    pos = object->getSelectorPos();
-   dSprintf(temp,256,"%d %d",pos.x, pos.y); 
+   dSprintf(temp,bufSize,"%d %d",pos.x, pos.y); 
    return temp;
 }
 

--- a/Engine/source/gui/controls/guiDirectoryFileListCtrl.cpp
+++ b/Engine/source/gui/controls/guiDirectoryFileListCtrl.cpp
@@ -169,17 +169,18 @@ DefineEngineMethod( GuiDirectoryFileListCtrl, getSelectedFiles, const char*, (),
       return StringTable->insert( "" );
 
    // Get an adequate buffer
-   char itemBuffer[256];
-   dMemset( itemBuffer, 0, 256 );
+   static const U32 itemBufSize = 256;
+   char itemBuffer[itemBufSize];
 
-   char* returnBuffer = Con::getReturnBuffer( ItemVector.size() * 64 );
-   dMemset( returnBuffer, 0, ItemVector.size() * 64 );
+   static const U32 bufSize = ItemVector.size() * 64;
+   char* returnBuffer = Con::getReturnBuffer( bufSize );
+   dMemset( returnBuffer, 0, bufSize );
 
    // Fetch the first entry
    StringTableEntry itemText = object->getItemText( ItemVector[0] );
    if( !itemText )
       return StringTable->lookup("");
-   dSprintf( returnBuffer, ItemVector.size() * 64, "%s", itemText );
+   dSprintf( returnBuffer, bufSize, "%s", itemText );
 
    // If only one entry, return it.
    if( ItemVector.size() == 1 )
@@ -192,8 +193,8 @@ DefineEngineMethod( GuiDirectoryFileListCtrl, getSelectedFiles, const char*, (),
       if( !itemText )
          continue;
 
-      dMemset( itemBuffer, 0, 256 );
-      dSprintf( itemBuffer, 256, " %s", itemText );
+      dMemset( itemBuffer, 0, itemBufSize );
+      dSprintf( itemBuffer, itemBufSize, " %s", itemText );
       dStrcat( returnBuffer, itemBuffer );
    }
 

--- a/Engine/source/gui/controls/guiGradientCtrl.cpp
+++ b/Engine/source/gui/controls/guiGradientCtrl.cpp
@@ -89,8 +89,9 @@ bool GuiGradientSwatchCtrl::onWake()
 	if ( !Parent::onWake() )
       return false;
 	
-	char* altCommand = Con::getReturnBuffer(512);
-	dSprintf( altCommand, 512, "%s(%i.color, \"%i.setColor\");", mColorFunction, getId(), getId() );
+	static const U32 bufSize = 512;
+	char* altCommand = Con::getReturnBuffer(bufSize);
+	dSprintf( altCommand, bufSize, "%s(%i.color, \"%i.setColor\");", mColorFunction, getId(), getId() );
 	setField( "altCommand", altCommand );
 
 	return true;
@@ -616,10 +617,11 @@ ConsoleMethod(GuiGradientCtrl, getColor, const char*, 3, 3, "Get color value")
 	{
 		if ( idx >= 0 && idx < object->mColorRange.size() )
 		{
-			char* rColor = Con::getReturnBuffer(256);
+			static const U32 bufSize = 256;
+			char* rColor = Con::getReturnBuffer(bufSize);
 			rColor[0] = 0;
 
-			dSprintf(rColor, 256, "%f %f %f %f",
+			dSprintf(rColor, bufSize, "%f %f %f %f",
 				object->mColorRange[idx].swatch->getColor().red,
 				object->mColorRange[idx].swatch->getColor().green,
 				object->mColorRange[idx].swatch->getColor().blue,
@@ -632,10 +634,11 @@ ConsoleMethod(GuiGradientCtrl, getColor, const char*, 3, 3, "Get color value")
 	{
 		if ( idx >= 0 && idx < object->mAlphaRange.size() )
 		{
-			char* rColor = Con::getReturnBuffer(256);
+			static const U32 bufSize = 256;
+			char* rColor = Con::getReturnBuffer(bufSize);
 			rColor[0] = 0;
 
-			dSprintf(rColor, 256, "%f %f %f %f",
+			dSprintf(rColor, bufSize, "%f %f %f %f",
 				object->mAlphaRange[idx].swatch->getColor().red,
 				object->mAlphaRange[idx].swatch->getColor().green,
 				object->mAlphaRange[idx].swatch->getColor().blue,

--- a/Engine/source/gui/controls/guiListBoxCtrl.cpp
+++ b/Engine/source/gui/controls/guiListBoxCtrl.cpp
@@ -450,8 +450,9 @@ DefineEngineMethod( GuiListBoxCtrl, getSelectedItems, const char*, (),,
    if( selItems.empty() )
       return StringTable->lookup("-1");
 
-   UTF8 *retBuffer = Con::getReturnBuffer( selItems.size() * 4 );
-   dMemset( retBuffer, 0, selItems.size() * 4 );
+   static const U32 bufSize = selItems.size() * 4;
+   UTF8 *retBuffer = Con::getReturnBuffer( bufSize );
+   dMemset( retBuffer, 0, bufSize );
    Vector<S32>::iterator i = selItems.begin();
    for( ; i != selItems.end(); i++ )
    {

--- a/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
@@ -579,8 +579,9 @@ ConsoleMethod( GuiPopUpMenuCtrlEx, getColorById, const char*, 3, 3,
    ColorI color;
    object->getColoredBox(color, dAtoi(argv[2]));
 
-   char *strBuffer = Con::getReturnBuffer(512);
-   dSprintf(strBuffer, 512, "%d %d %d %d", color.red, color.green, color.blue, color.alpha);
+   static const U32 bufSize = 512;
+   char *strBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(strBuffer, bufSize, "%d %d %d %d", color.red, color.green, color.blue, color.alpha);
    return strBuffer;
 }
 

--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -5061,8 +5061,9 @@ ConsoleMethod(GuiTreeViewCtrl, getSelectedObject, S32, 2, 3, "( int index=0 ) - 
 ConsoleMethod(GuiTreeViewCtrl, getSelectedObjectList, const char*, 2, 2, 
               "Returns a space sperated list of all selected object ids.")
 {
-   char* buff = Con::getReturnBuffer(1024);
-   dSprintf(buff,1024,"");
+   static const U32 bufSize = 1024;
+   char* buff = Con::getReturnBuffer(bufSize);
+   dSprintf(buff,bufSize,"");
 
    const Vector< GuiTreeViewCtrl::Item* > selectedItems = object->getSelectedItems();
    for(S32 i = 0; i < selectedItems.size(); i++)
@@ -5077,7 +5078,7 @@ ConsoleMethod(GuiTreeViewCtrl, getSelectedObjectList, const char*, 2, 2,
          //the start of the buffer where we want to write
          char* buffPart = buff+len;
          //the size of the remaining buffer (-1 cause dStrlen doesn't count the \0)
-         S32 size	=	1024-len-1;
+         S32 size = bufSize-len-1;
          //write it:
          if(size < 1)
          {
@@ -5126,8 +5127,9 @@ ConsoleMethod(GuiTreeViewCtrl, getTextToRoot, const char*,4,4,"(TreeItemId item,
 
 ConsoleMethod(GuiTreeViewCtrl, getSelectedItemList,const char*, 2,2,"returns a space seperated list of mulitple item ids")
 {
-	char* buff = Con::getReturnBuffer(1024);
-	dSprintf(buff,1024,"");
+	static const U32 bufSize = 1024;
+	char* buff = Con::getReturnBuffer(bufSize);
+	dSprintf(buff,bufSize,"");
 
    const Vector< S32 >& selected = object->getSelected();
 	for(S32 i = 0; i < selected.size(); i++)
@@ -5138,7 +5140,7 @@ ConsoleMethod(GuiTreeViewCtrl, getSelectedItemList,const char*, 2,2,"returns a s
 		//the start of the buffer where we want to write
 		char* buffPart = buff+len;
 		//the size of the remaining buffer (-1 cause dStrlen doesn't count the \0)
-		S32 size	=	1024-len-1;
+		S32 size	=	bufSize-len-1;
 		//write it:
 		if(size < 1)
 		{

--- a/Engine/source/gui/core/guiTypes.cpp
+++ b/Engine/source/gui/core/guiTypes.cpp
@@ -719,8 +719,9 @@ ImplementConsoleTypeCasters( TypeRectSpacingI, RectSpacingI )
 ConsoleGetType( TypeRectSpacingI )
 {
    RectSpacingI *rect = (RectSpacingI *) dptr;
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%d %d %d %d", rect->top, rect->bottom,
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d %d %d %d", rect->top, rect->bottom,
       rect->left, rect->right);
    return returnBuffer;
 }

--- a/Engine/source/gui/editor/guiDebugger.cpp
+++ b/Engine/source/gui/editor/guiDebugger.cpp
@@ -78,8 +78,9 @@ ConsoleMethod(DbgFileView, getCurrentLine, const char *, 2, 2, "()"
 {
 	S32 lineNum;
    const char *file = object->getCurrentLine(lineNum);
-   char* ret = Con::getReturnBuffer(256);
-	dSprintf(ret, 256, "%s\t%d", file, lineNum);
+   static const U32 bufSize = 256;
+   char* ret = Con::getReturnBuffer(bufSize);
+	dSprintf(ret, bufSize, "%s\t%d", file, lineNum);
 	return ret;
 }
 

--- a/Engine/source/gui/editor/guiParticleGraphCtrl.cpp
+++ b/Engine/source/gui/editor/guiParticleGraphCtrl.cpp
@@ -1060,12 +1060,13 @@ ConsoleMethod(GuiParticleGraphCtrl, addPlotPoint, const char*, 5, 6, "(int plotI
 {
    S32 plotID = dAtoi(argv[2]);
    S32 pointAdded = 0;
-   char *retBuffer = Con::getReturnBuffer(32);
+   static const U32 bufSize = 32;
+   char *retBuffer = Con::getReturnBuffer(bufSize);
 
    if(plotID > object->MaxPlots)
    {
 	   Con::errorf("Invalid plotID.");
-	   dSprintf(retBuffer, 32, "%d", -2);
+	   dSprintf(retBuffer, bufSize, "%d", -2);
       return retBuffer;
    }
 
@@ -1078,7 +1079,7 @@ ConsoleMethod(GuiParticleGraphCtrl, addPlotPoint, const char*, 5, 6, "(int plotI
    }
 
    
-   dSprintf(retBuffer, 32, "%d", pointAdded);
+   dSprintf(retBuffer, bufSize, "%d", pointAdded);
 
    return retBuffer;
 }
@@ -1107,19 +1108,20 @@ ConsoleMethod(GuiParticleGraphCtrl, changePlotPoint, const char*, 6, 6, "(int pl
 			  "@return No return value.")
 {
    S32 plotID = dAtoi(argv[2]);
+   static const U32 bufSize = 64;
    if(plotID > object->MaxPlots)
    {
 	   Con::errorf("Invalid plotID.");
 
-      char *retBuffer = Con::getReturnBuffer(64);
+      char *retBuffer = Con::getReturnBuffer(bufSize);
       const S32 index = -1;
-      dSprintf(retBuffer, 64, "%d", index);
+      dSprintf(retBuffer, bufSize, "%d", index);
       return retBuffer;
    }
 
-   char *retBuffer = Con::getReturnBuffer(64);
+   char *retBuffer = Con::getReturnBuffer(bufSize);
    const S32 index = object->changePlotPoint( plotID, dAtoi(argv[3]), Point2F(dAtof(argv[4]), dAtof(argv[5])));
-   dSprintf(retBuffer, 64, "%d", index);
+   dSprintf(retBuffer, bufSize, "%d", index);
    return retBuffer;
 }
 
@@ -1127,9 +1129,10 @@ ConsoleMethod(GuiParticleGraphCtrl, getSelectedPlot, const char*, 2, 2, "() "
               "Gets the selected Plot (a.k.a. graph).\n"
 			  "@return The plot's ID.")
 {
-   char *retBuffer = Con::getReturnBuffer(32);
+   static const U32 bufSize = 32;
+   char *retBuffer = Con::getReturnBuffer(bufSize);
    const S32 plot = object->getSelectedPlot();
-   dSprintf(retBuffer, 32, "%d", plot);
+   dSprintf(retBuffer, bufSize, "%d", plot);
    return retBuffer;
 }
 
@@ -1137,9 +1140,10 @@ ConsoleMethod(GuiParticleGraphCtrl, getSelectedPoint, const char*, 2, 2, "()"
               "Gets the selected Point on the Plot (a.k.a. graph)."
 			  "@return The last selected point ID")
 {
-   char *retBuffer = Con::getReturnBuffer(32);
+   static const U32 bufSize = 32;
+   char *retBuffer = Con::getReturnBuffer(bufSize);
    const S32 point = object->getSelectedPoint();
-   dSprintf(retBuffer, 32, "%d", point);
+   dSprintf(retBuffer, bufSize, "%d", point);
    return retBuffer;
 }
 
@@ -1158,9 +1162,10 @@ ConsoleMethod(GuiParticleGraphCtrl, isExistingPoint, const char*, 4, 4, "(int pl
 	   Con::errorf("Invalid sample.");
    }
 
-   char *retBuffer = Con::getReturnBuffer(32);
+   static const U32 bufSize = 32;
+   char *retBuffer = Con::getReturnBuffer(bufSize);
    const bool isPoint = object->isExistingPoint(plotID, samples);
-   dSprintf(retBuffer, 32, "%d", isPoint);
+   dSprintf(retBuffer, bufSize, "%d", isPoint);
    return retBuffer;
 }
 
@@ -1180,9 +1185,10 @@ ConsoleMethod(GuiParticleGraphCtrl, getPlotPoint, const char*, 4, 4, "(int plotI
 	   Con::errorf("Invalid sample.");
    }
 
-   char *retBuffer = Con::getReturnBuffer(64);
+   static const U32 bufSize = 64;
+   char *retBuffer = Con::getReturnBuffer(bufSize);
    const Point2F &pos = object->getPlotPoint(plotID, samples);
-   dSprintf(retBuffer, 64, "%f %f", pos.x, pos.y);
+   dSprintf(retBuffer, bufSize, "%f %f", pos.x, pos.y);
    return retBuffer;
 }
 
@@ -1201,9 +1207,10 @@ ConsoleMethod(GuiParticleGraphCtrl, getPlotIndex, const char*, 5, 5, "(int plotI
 	   Con::errorf("Invalid plotID.");
    }
 
-   char *retBuffer = Con::getReturnBuffer(32);
+   static const U32 bufSize = 32;
+   char *retBuffer = Con::getReturnBuffer(bufSize);
    const S32 &index = object->getPlotIndex(plotID, x, y);
-   dSprintf(retBuffer, 32, "%d", index);
+   dSprintf(retBuffer, bufSize, "%d", index);
    return retBuffer;
 }
 
@@ -1218,9 +1225,10 @@ ConsoleMethod(GuiParticleGraphCtrl, getGraphColor, const char*, 3, 3, "(int plot
 	   Con::errorf("Invalid plotID.");
    }
 
-   char *retBuffer = Con::getReturnBuffer(64);
+   static const U32 bufSize = 64;
+   char *retBuffer = Con::getReturnBuffer(bufSize);
    const ColorF &color = object->getGraphColor(plotID);
-   dSprintf(retBuffer, 64, "%f %f %f", color.red, color.green, color.blue);
+   dSprintf(retBuffer, bufSize, "%f %f %f", color.red, color.green, color.blue);
    return retBuffer;
 }
 
@@ -1235,9 +1243,10 @@ ConsoleMethod(GuiParticleGraphCtrl, getGraphMin, const char*, 3, 3, "(int plotID
 	   Con::errorf("Invalid plotID.");
    }
 
-   char *retBuffer = Con::getReturnBuffer(64);
+   static const U32 bufSize = 64;
+   char *retBuffer = Con::getReturnBuffer(bufSize);
    const Point2F graphMin = object->getGraphMin(plotID);
-   dSprintf(retBuffer, 64, "%f %f", graphMin.x, graphMin.y);
+   dSprintf(retBuffer, bufSize, "%f %f", graphMin.x, graphMin.y);
    return retBuffer;
 }
 
@@ -1252,9 +1261,10 @@ ConsoleMethod(GuiParticleGraphCtrl, getGraphMax, const char*, 3, 3, "(int plotID
 	   Con::errorf("Invalid plotID.");
    }
 
-   char *retBuffer = Con::getReturnBuffer(64);
+   static const U32 bufSize = 64;
+   char *retBuffer = Con::getReturnBuffer(bufSize);
    const Point2F graphMax = object->getGraphMax(plotID);
-   dSprintf(retBuffer, 64, "%f %f", graphMax.x, graphMax.y);
+   dSprintf(retBuffer, bufSize, "%f %f", graphMax.x, graphMax.y);
    return retBuffer;
 }
 
@@ -1269,9 +1279,10 @@ ConsoleMethod(GuiParticleGraphCtrl, getGraphName, const char*, 3, 3, "(int plotI
 	   Con::errorf("Invalid plotID.");
    }
 
-   char *retBuffer = Con::getReturnBuffer(64);
+   static const U32 bufSize = 64;
+   char *retBuffer = Con::getReturnBuffer(bufSize);
    const StringTableEntry graphName = object->getGraphName(plotID);
-   dSprintf(retBuffer, 64, "%s", graphName);
+   dSprintf(retBuffer, bufSize, "%s", graphName);
    return retBuffer;
 }
 

--- a/Engine/source/gui/game/guiProgressBitmapCtrl.cpp
+++ b/Engine/source/gui/game/guiProgressBitmapCtrl.cpp
@@ -158,8 +158,9 @@ void GuiProgressBitmapCtrl::setBitmap( const char* name )
 
 const char* GuiProgressBitmapCtrl::getScriptValue()
 {
-   char * ret = Con::getReturnBuffer(64);
-   dSprintf(ret, 64, "%g", mProgress);
+   static const U32 bufSize = 64;
+   char * ret = Con::getReturnBuffer(bufSize);
+   dSprintf(ret, bufSize, "%g", mProgress);
    return ret;
 }
 

--- a/Engine/source/gui/game/guiProgressCtrl.cpp
+++ b/Engine/source/gui/game/guiProgressCtrl.cpp
@@ -59,8 +59,9 @@ GuiProgressCtrl::GuiProgressCtrl()
 
 const char* GuiProgressCtrl::getScriptValue()
 {
-   char * ret = Con::getReturnBuffer(64);
-   dSprintf(ret, 64, "%g", mProgress);
+   static const U32 bufSize = 64;
+   char * ret = Con::getReturnBuffer(bufSize);
+   dSprintf(ret, bufSize, "%g", mProgress);
    return ret;
 }
 

--- a/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
@@ -821,12 +821,13 @@ ConsoleMethod( GuiDecalEditorCtrl, getDecalTransform, const char*, 3, 3, "getDec
 	if( decalInstance == NULL )
 		return "";
 
-	char* returnBuffer = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
    returnBuffer[0] = 0;
 
    if ( decalInstance )
    {
-	   dSprintf(returnBuffer, 256, "%f %f %f %f %f %f %f",
+	   dSprintf(returnBuffer, bufSize, "%f %f %f %f %f %f %f",
          decalInstance->mPosition.x, decalInstance->mPosition.y, decalInstance->mPosition.z, 
 		   decalInstance->mTangent.x, decalInstance->mTangent.y, decalInstance->mTangent.z,
 		   decalInstance->mSize);

--- a/Engine/source/gui/worldEditor/terrainEditor.cpp
+++ b/Engine/source/gui/worldEditor/terrainEditor.cpp
@@ -2111,8 +2111,9 @@ const char* TerrainEditor::getBrushPos()
    AssertFatal(mMouseBrush!=NULL, "TerrainEditor::getBrushPos: no mouse brush!");
 
    Point2I pos = mMouseBrush->getPosition();
-   char * ret = Con::getReturnBuffer(32);
-   dSprintf(ret, 32, "%d %d", pos.x, pos.y);
+   static const U32 bufSize = 32;
+   char * ret = Con::getReturnBuffer(bufSize);
+   dSprintf(ret, bufSize, "%d %d", pos.x, pos.y);
    return(ret);
 }
 
@@ -2521,8 +2522,9 @@ ConsoleMethod( TerrainEditor, getBrushSize, const char*, 2, 2, "()")
 {
    Point2I size = object->getBrushSize();
 
-   char * ret = Con::getReturnBuffer(32);
-   dSprintf(ret, 32, "%d %d", size.x, size.y);
+   static const U32 bufSize = 32;
+   char * ret = Con::getReturnBuffer(bufSize);
+   dSprintf(ret, bufSize, "%d %d", size.x, size.y);
    return ret;
 }
 

--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -2882,8 +2882,9 @@ const Point3F& WorldEditor::getSelectionCentroid()
 const char* WorldEditor::getSelectionCentroidText()
 {
    const Point3F & centroid = getSelectionCentroid();
-   char * ret = Con::getReturnBuffer(100);
-   dSprintf(ret, 100, "%g %g %g", centroid.x, centroid.y, centroid.z);
+   static const U32 bufSize = 100;
+   char * ret = Con::getReturnBuffer(bufSize);
+   dSprintf(ret, bufSize, "%g %g %g", centroid.x, centroid.y, centroid.z);
    return ret;	
 }
 
@@ -3263,8 +3264,9 @@ ConsoleMethod( WorldEditor, getSelectionCentroid, const char *, 2, 2, "")
 ConsoleMethod( WorldEditor, getSelectionExtent, const char *, 2, 2, "")
 {
    Point3F bounds = object->getSelectionExtent();
-   char * ret = Con::getReturnBuffer(100);
-   dSprintf(ret, 100, "%g %g %g", bounds.x, bounds.y, bounds.z);
+   static const U32 bufSize = 100;
+   char * ret = Con::getReturnBuffer(bufSize);
+   dSprintf(ret, bufSize, "%g %g %g", bounds.x, bounds.y, bounds.z);
    return ret;	
 }
 

--- a/Engine/source/gui/worldEditor/worldEditorSelection.cpp
+++ b/Engine/source/gui/worldEditor/worldEditorSelection.cpp
@@ -642,10 +642,11 @@ ConsoleMethod( WorldEditorSelection, containsGlobalBounds, bool, 2, 2, "() - Tru
 
 ConsoleMethod( WorldEditorSelection, getCentroid, const char*, 2, 2, "() - Return the median of all object positions in the selection." )
 {
-   char* buffer = Con::getReturnBuffer( 256 );
+   static const U32 bufSize = 256;
+   char* buffer = Con::getReturnBuffer( bufSize );
    const Point3F& centroid = object->getCentroid();
    
-   dSprintf( buffer, 256, "%g %g %g", centroid.x, centroid.y, centroid.z );
+   dSprintf( buffer, bufSize, "%g %g %g", centroid.x, centroid.y, centroid.z );
    return buffer;
 }
 
@@ -653,10 +654,11 @@ ConsoleMethod( WorldEditorSelection, getCentroid, const char*, 2, 2, "() - Retur
 
 ConsoleMethod( WorldEditorSelection, getBoxCentroid, const char*, 2, 2, "() - Return the center of the bounding box around the selection." )
 {
-   char* buffer = Con::getReturnBuffer( 256 );
+   static const U32 bufSize = 256;
+   char* buffer = Con::getReturnBuffer( bufSize );
    const Point3F& boxCentroid = object->getBoxCentroid();
    
-   dSprintf( buffer, 256, "%g %g %g", boxCentroid.x, boxCentroid.y, boxCentroid.z );
+   dSprintf( buffer, bufSize, "%g %g %g", boxCentroid.x, boxCentroid.y, boxCentroid.z );
    return buffer;
 }
 

--- a/Engine/source/lighting/advanced/advancedLightManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightManager.cpp
@@ -664,8 +664,9 @@ ConsoleFunction( setShadowVizLight, const char*, 2, 2, "" )
    const Point3I &size = texObject->getSize();
    F32 aspect = (F32)size.x / (F32)size.y;
 
-   char *result = Con::getReturnBuffer( 64 );
-   dSprintf( result, 64, "%d %d %g", size.x, size.y, aspect ); 
+   static const U32 bufSize = 64;
+   char *result = Con::getReturnBuffer( bufSize );
+   dSprintf( result, bufSize, "%d %d %g", size.x, size.y, aspect ); 
    return result;
 }
 

--- a/Engine/source/math/mConsoleFunctions.cpp
+++ b/Engine/source/math/mConsoleFunctions.cpp
@@ -41,8 +41,9 @@ DefineConsoleFunction( mSolveQuadratic, const char*, ( F32 a, F32 b, F32 c ),,
    F32 x[2];
    U32 sol = mSolveQuadratic( a, b, c, x );
 
-   char * retBuffer = Con::getReturnBuffer(256);
-   dSprintf(retBuffer, 256, "%d %g %g", sol, x[0], x[1]);
+   static const U32 bufSize = 256;
+   char * retBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(retBuffer, bufSize, "%d %g %g", sol, x[0], x[1]);
    return retBuffer;
 }
 
@@ -59,8 +60,9 @@ DefineConsoleFunction( mSolveCubic, const char*, ( F32 a, F32 b, F32 c, F32 d ),
    F32 x[3];
    U32 sol = mSolveCubic( a, b, c, d, x );
 
-   char * retBuffer = Con::getReturnBuffer(256);
-   dSprintf(retBuffer, 256, "%d %g %g %g", sol, x[0], x[1], x[2]);
+   static const U32 bufSize = 256;
+   char * retBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(retBuffer, bufSize, "%d %g %g %g", sol, x[0], x[1], x[2]);
    return retBuffer;
 }
 
@@ -76,9 +78,10 @@ DefineConsoleFunction( mSolveQuartic, const char*, ( F32 a, F32 b, F32 c, F32 d,
     "@ingroup Math" )
 {
    F32 x[4];
-   char * retBuffer = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char * retBuffer = Con::getReturnBuffer(bufSize);
    U32 sol = mSolveQuartic(a, b, c, d, e, x);
-   dSprintf(retBuffer, 256, "%d %g %g %g %g", sol, x[0], x[1], x[2], x[3]);
+   dSprintf(retBuffer, bufSize, "%d %g %g %g %g", sol, x[0], x[1], x[2], x[3]);
    return retBuffer;
 }
 
@@ -121,8 +124,9 @@ DefineConsoleFunction( mFloatLength, const char*, ( F32 v, U32 precision ),,
       precision = 9;
    fmtString[2] = '0' + precision;
 
-   char * outBuffer = Con::getReturnBuffer(256);
-   dSprintf(outBuffer, 255, fmtString, v);
+   static const U32 bufSize = 256;
+   char * outBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(outBuffer, bufSize, fmtString, v);
    return outBuffer;
 }
 

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -123,8 +123,9 @@ ImplementConsoleTypeCasters( TypePoint2I, Point2I )
 ConsoleGetType( TypePoint2I )
 {
    Point2I *pt = (Point2I *) dptr;
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%d %d", pt->x, pt->y);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d %d", pt->x, pt->y);
    return returnBuffer;
 }
 
@@ -147,8 +148,9 @@ ImplementConsoleTypeCasters( TypePoint2F, Point2F )
 ConsoleGetType( TypePoint2F )
 {
    Point2F *pt = (Point2F *) dptr;
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%g %g", pt->x, pt->y);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%g %g", pt->x, pt->y);
    return returnBuffer;
 }
 
@@ -171,8 +173,9 @@ ImplementConsoleTypeCasters(TypePoint3I, Point3I)
 ConsoleGetType( TypePoint3I )
 {
    Point3I *pt = (Point3I *) dptr;
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%d %d %d", pt->x, pt->y, pt->z);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d %d %d", pt->x, pt->y, pt->z);
    return returnBuffer;
 }
 
@@ -195,8 +198,9 @@ ImplementConsoleTypeCasters(TypePoint3F, Point3F)
 ConsoleGetType( TypePoint3F )
 {
    Point3F *pt = (Point3F *) dptr;
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%g %g %g", pt->x, pt->y, pt->z);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%g %g %g", pt->x, pt->y, pt->z);
    return returnBuffer;
 }
 
@@ -219,8 +223,9 @@ ImplementConsoleTypeCasters( TypePoint4F, Point4F )
 ConsoleGetType( TypePoint4F )
 {
    Point4F *pt = (Point4F *) dptr;
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%g %g %g %g", pt->x, pt->y, pt->z, pt->w);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%g %g %g %g", pt->x, pt->y, pt->z, pt->w);
    return returnBuffer;
 }
 
@@ -243,8 +248,9 @@ ImplementConsoleTypeCasters( TypeRectI, RectI )
 ConsoleGetType( TypeRectI )
 {
    RectI *rect = (RectI *) dptr;
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%d %d %d %d", rect->point.x, rect->point.y,
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d %d %d %d", rect->point.x, rect->point.y,
             rect->extent.x, rect->extent.y);
    return returnBuffer;
 }
@@ -269,8 +275,9 @@ ImplementConsoleTypeCasters( TypeRectF, RectF )
 ConsoleGetType( TypeRectF )
 {
    RectF *rect = (RectF *) dptr;
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%g %g %g %g", rect->point.x, rect->point.y,
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%g %g %g %g", rect->point.x, rect->point.y,
             rect->extent.x, rect->extent.y);
    return returnBuffer;
 }
@@ -303,8 +310,9 @@ ConsoleGetType( TypeMatrixF )
    mat->getColumn(0, &col0);
    mat->getColumn(1, &col1);
    mat->getColumn(2, &col2);
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer,256,"%g %g %g %g %g %g %g %g %g",
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer,bufSize,"%g %g %g %g %g %g %g %g %g",
             col0.x, col0.y, col0.z, col1.x, col1.y, col1.z, col2.x, col2.y, col2.z);
    return returnBuffer;
 }
@@ -336,11 +344,12 @@ ConsoleType( MatrixPosition, TypeMatrixPosition, MatrixF )
 ConsoleGetType( TypeMatrixPosition )
 {
    F32 *col = (F32 *) dptr + 3;
-   char* returnBuffer = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
    if(col[12] == 1.f)
-      dSprintf(returnBuffer, 256, "%g %g %g", col[0], col[4], col[8]);
+      dSprintf(returnBuffer, bufSize, "%g %g %g", col[0], col[4], col[8]);
    else
-      dSprintf(returnBuffer, 256, "%g %g %g %g", col[0], col[4], col[8], col[12]);
+      dSprintf(returnBuffer, bufSize, "%g %g %g %g", col[0], col[4], col[8], col[12]);
    return returnBuffer;
 }
 
@@ -371,8 +380,9 @@ ConsoleGetType( TypeMatrixRotation )
 {
    AngAxisF aa(*(MatrixF *) dptr);
    aa.axis.normalize();
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer,256,"%g %g %g %g",aa.axis.x,aa.axis.y,aa.axis.z,mRadToDeg(aa.angle));
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer,bufSize,"%g %g %g %g",aa.axis.x,aa.axis.y,aa.axis.z,mRadToDeg(aa.angle));
    return returnBuffer;
 }
 
@@ -415,8 +425,9 @@ ImplementConsoleTypeCasters( TypeAngAxisF, AngAxisF )
 ConsoleGetType( TypeAngAxisF )
 {
    AngAxisF* aa = ( AngAxisF* ) dptr;
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer,256,"%g %g %g %g",aa->axis.x,aa->axis.y,aa->axis.z,mRadToDeg(aa->angle));
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer,bufSize,"%g %g %g %g",aa->axis.x,aa->axis.y,aa->axis.z,mRadToDeg(aa->angle));
    return returnBuffer;
 }
 
@@ -453,8 +464,9 @@ ImplementConsoleTypeCasters( TypeTransformF, TransformF )
 ConsoleGetType( TypeTransformF )
 {
    TransformF* aa = ( TransformF* ) dptr;
-   char* returnBuffer = Con::getReturnBuffer( 256 );
-   dSprintf( returnBuffer, 256, "%g %g %g %g %g %g %g",
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf( returnBuffer, bufSize, "%g %g %g %g %g %g %g",
              aa->mPosition.x, aa->mPosition.y, aa->mPosition.z,
              aa->mOrientation.axis.x, aa->mOrientation.axis.y, aa->mOrientation.axis.z, aa->mOrientation.angle );
    return returnBuffer;
@@ -497,8 +509,9 @@ ConsoleGetType( TypeBox3F )
 {
    const Box3F* pBox = (const Box3F*)dptr;
 
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%g %g %g %g %g %g",
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%g %g %g %g %g %g",
             pBox->minExtents.x, pBox->minExtents.y, pBox->minExtents.z,
             pBox->maxExtents.x, pBox->maxExtents.y, pBox->maxExtents.z);
 
@@ -533,8 +546,9 @@ ConsoleGetType( TypeEaseF )
 {
    const EaseF* pEase = (const EaseF*)dptr;
 
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%d %d %g %g",
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d %d %g %g",
             pEase->dir, pEase->type, pEase->param[0], pEase->param[1]);
 
    return returnBuffer;

--- a/Engine/source/scene/sceneContainer.cpp
+++ b/Engine/source/scene/sceneContainer.cpp
@@ -1631,10 +1631,11 @@ DefineEngineFunction( containerRayCast, const char*,
       pExempt->enableCollision();
 
    // add the hit position and normal?
-   char *returnBuffer = Con::getReturnBuffer(256);
+   static const U32 bufSize = 256;
+   char *returnBuffer = Con::getReturnBuffer(bufSize);
    if(ret)
    {
-      dSprintf(returnBuffer, 256, "%d %g %g %g %g %g %g %g",
+      dSprintf(returnBuffer, bufSize, "%d %g %g %g %g %g %g %g",
                ret, rinfo.point.x, rinfo.point.y, rinfo.point.z,
                rinfo.normal.x, rinfo.normal.y, rinfo.normal.z, rinfo.distance);
    }

--- a/Engine/source/ts/tsShapeConstruct.cpp
+++ b/Engine/source/ts/tsShapeConstruct.cpp
@@ -1216,8 +1216,9 @@ DefineTSShapeConstructorMethod( getMeshName, const char*, ( const char* name, S3
 
    CHECK_INDEX_IN_RANGE( getMeshName, index, objectDetails.size(), "" );
 
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf(returnBuffer, 256, "%s %d", name, (S32)mShape->details[objectDetails[index]].size);
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%s %d", name, (S32)mShape->details[objectDetails[index]].size);
    return returnBuffer;
 }}
 
@@ -1602,8 +1603,9 @@ DefineTSShapeConstructorMethod( getImposterSettings, const char*, ( S32 index ),
    // Return information about the detail level
    const TSShape::Detail& det = mShape->details[index];
 
-   char* returnBuffer = Con::getReturnBuffer(512);
-   dSprintf(returnBuffer, 512, "%d\t%d\t%d\t%d\t%d\t%d\t%g",
+   static const U32 bufSize = 512;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d\t%d\t%d\t%d\t%d\t%d\t%g",
       (S32)( det.subShapeNum < 0 ),          // isImposter
       det.bbEquatorSteps,
       det.bbPolarSteps,
@@ -1727,8 +1729,9 @@ DefineTSShapeConstructorMethod( getSequenceSource, const char*, ( const char* na
    GET_SEQUENCE( getSequenceSource, seq, name, "" );
 
    // Return information about the source data for this sequence
-   char* returnBuffer = Con::getReturnBuffer(512);
-   dSprintf( returnBuffer, 512, "%s\t%d\t%d\t%d",
+   static const U32 bufSize = 512;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf( returnBuffer, bufSize, "%s\t%d\t%d\t%d",
       seq->sourceData.from.c_str(), seq->sourceData.start,
       seq->sourceData.end, seq->sourceData.total );
    return returnBuffer;
@@ -1802,8 +1805,9 @@ DefineTSShapeConstructorMethod( getSequenceGroundSpeed, const char*, ( const cha
       rot = mat.toEuler();
    }
 
-   char* returnBuffer = Con::getReturnBuffer(256);
-   dSprintf( returnBuffer, 256, "%g %g %g %g %g %g",
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf( returnBuffer, bufSize, "%g %g %g %g %g %g",
       trans.x, trans.y, trans.z, rot.x, rot.y, rot.z );
    return returnBuffer;
 }}
@@ -1896,8 +1900,9 @@ DefineTSShapeConstructorMethod( getSequenceBlend, const char*, ( const char* nam
    GET_SEQUENCE( getSequenceBlend, seq, name, "0" );
 
    // Return the blend information (flag reference_sequence reference_frame)
-   char* returnBuffer = Con::getReturnBuffer(512);
-   dSprintf( returnBuffer, 512, "%d\t%s\t%d", (int)seq->isBlend(),
+   static const U32 bufSize = 512;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf( returnBuffer, bufSize, "%d\t%s\t%d", (int)seq->isBlend(),
       seq->sourceData.blendSeq.c_str(), seq->sourceData.blendFrame );
    return returnBuffer;
 }}
@@ -2038,8 +2043,9 @@ DefineTSShapeConstructorMethod( getTrigger, const char*, ( const char* name, S32
    if (!(trig.state & TSShape::Trigger::StateOn))
       state = -state;
 
-   char* returnBuffer = Con::getReturnBuffer(32);
-   dSprintf(returnBuffer, 32, "%d %d", frame, state);
+   static const U32 bufSize = 32;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   dSprintf(returnBuffer, bufSize, "%d %d", frame, state);
    return returnBuffer;
 }}
 


### PR DESCRIPTION
Use fixed buffer size var when allocating return buffer from console.

This prevents issues when someone tries to use `sizeof(char* buffer)` and gives minor performance boost (comparing to usage of `dStrlen()`).
