### PR TITLE
Support for large lists of shape formats.

### DIFF
--- a/Engine/source/gui/editor/guiInspectorTypes.cpp
+++ b/Engine/source/gui/editor/guiInspectorTypes.cpp
@@ -764,8 +764,7 @@ GuiControl* GuiInspectorTypeShapeFilename::constructEditControl()
 
    // Change filespec
    char szBuffer[512];
-   dSprintf( szBuffer, sizeof(szBuffer), "getLoadFilename(\"%s\", \"%d.apply\", %d.getData());",
-      "DTS Files (*.dts)|*.dts|COLLADA Files (*.dae)|*.dae|(All Files (*.*)|*.*|", getId(), getId() );
+   dSprintf( szBuffer, sizeof(szBuffer), "getLoadFormatFilename(\"%d.apply\", %d.getData());", getId(), getId() );
    mBrowseButton->setField( "Command", szBuffer );
 
    // Create "Open in ShapeEditor" button

--- a/Engine/source/ts/collada/colladaShapeLoader.cpp
+++ b/Engine/source/ts/collada/colladaShapeLoader.cpp
@@ -50,6 +50,15 @@
 #include "core/util/zip/zipVolume.h"
 #include "gfx/bitmap/gBitmap.h"
 
+MODULE_BEGIN( ColladaShapeLoader )
+   MODULE_INIT_AFTER( ShapeLoader )
+   MODULE_INIT
+   {
+      TSShapeLoader::addFormat("Collada", "dae");
+      TSShapeLoader::addFormat("Google Earth", "kmz");
+   }
+MODULE_END;
+
 // 
 static DAE sDAE;                 // Collada model database (holds the last loaded file)
 static Torque::Path sLastPath;   // Path of the last loaded Collada file

--- a/Engine/source/ts/loader/tsShapeLoader.cpp
+++ b/Engine/source/ts/loader/tsShapeLoader.cpp
@@ -21,6 +21,7 @@
 //-----------------------------------------------------------------------------
 
 #include "platform/platform.h"
+#include "console/engineAPI.h"
 #include "ts/loader/tsShapeLoader.h"
 
 #include "core/volume.h"
@@ -30,12 +31,22 @@
 #include "ts/tsShapeInstance.h"
 #include "ts/tsMaterialList.h"
 
+MODULE_BEGIN( ShapeLoader )
+   MODULE_INIT_AFTER( GFX )
+   MODULE_INIT
+   {
+      TSShapeLoader::addFormat("Torque DTS", "dts");
+      TSShapeLoader::addFormat("Torque DSQ", "dsq");
+   }
+MODULE_END;
 
 const F32 TSShapeLoader::DefaultTime = -1.0f;
 const double TSShapeLoader::MinFrameRate = 15.0f;
 const double TSShapeLoader::MaxFrameRate = 60.0f;
 const double TSShapeLoader::AppGroundFrameRate = 10.0f;
 Torque::Path TSShapeLoader::shapePath;
+
+Vector<TSShapeLoader::ShapeFormat> TSShapeLoader::smFormats;
 
 //------------------------------------------------------------------------------
 // Utility functions
@@ -1269,4 +1280,54 @@ TSShapeLoader::~TSShapeLoader()
    for (int iSeq = 0; iSeq < appSequences.size(); iSeq++)
       delete appSequences[iSeq];
    appSequences.clear();   
+}
+
+// Static functions to handle supported formats for shape loader.
+void TSShapeLoader::addFormat(String name, String extension)
+{
+   ShapeFormat newFormat;
+   newFormat.mName = name;
+   newFormat.mExtension = extension;
+   smFormats.push_back(newFormat);
+}
+
+String TSShapeLoader::getFormatExtensions()
+{
+   // "*.dsq TAB *.dae TAB
+   StringBuilder output;
+   for(U32 n = 0; n < smFormats.size(); ++n)
+   {
+      output.append("*.");
+      output.append(smFormats[n].mExtension);
+      output.append("\t");
+   }
+   return output.end();
+}
+
+String TSShapeLoader::getFormatFilters()
+{
+   // "DSQ Files|*.dsq|COLLADA Files|*.dae|"
+   StringBuilder output;
+   for(U32 n = 0; n < smFormats.size(); ++n)
+   {
+      output.append(smFormats[n].mName);
+      output.append("|*.");
+      output.append(smFormats[n].mExtension);
+      output.append("|");
+   }
+   return output.end();
+}
+
+DefineConsoleFunction( getFormatExtensions, const char*, ( ),, 
+  "Returns a list of supported shape format extensions separated by tabs."
+  "Example output: *.dsq TAB *.dae TAB")
+{
+   return Con::getReturnBuffer(TSShapeLoader::getFormatExtensions());
+}
+
+DefineConsoleFunction( getFormatFilters, const char*, ( ),, 
+  "Returns a list of supported shape formats in filter form.\n"
+  "Example output: DSQ Files|*.dsq|COLLADA Files|*.dae|")
+{
+   return Con::getReturnBuffer(TSShapeLoader::getFormatFilters());
 }

--- a/Engine/source/ts/loader/tsShapeLoader.h
+++ b/Engine/source/ts/loader/tsShapeLoader.h
@@ -45,6 +45,19 @@
 class TSShapeLoader
 {
 
+// Supported Format List
+protected:
+   struct ShapeFormat
+   {
+      String mName;
+      String mExtension;
+   };
+   static Vector<ShapeFormat> smFormats;
+public:
+   static void addFormat(String name, String extension);
+   static String getFormatExtensions();
+   static String getFormatFilters();
+
 public:
    enum eLoadPhases
    {

--- a/Templates/Empty/game/tools/gui/openFileDialog.ed.cs
+++ b/Templates/Empty/game/tools/gui/openFileDialog.ed.cs
@@ -42,3 +42,29 @@ function getLoadFilename(%filespec, %callback, %currentFile)
    
    %dlg.delete();
 }
+
+// Opens a choose file dialog with format filters already loaded
+// in. This avoids the issue of passing a massive list of format 
+// filters into a function as an arguement.
+function getLoadFormatFilename(%callback, %currentFile)
+{   
+   %dlg = new OpenFileDialog()
+   {
+      Filters = getFormatFilters() @ "(All Files (*.*)|*.*|";
+      DefaultFile = %currentFile;
+      ChangePath = false;
+      MustExist = true;
+      MultipleFiles = false;
+   };
+   
+   if ( filePath( %currentFile ) !$= "" )
+      %dlg.DefaultPath = filePath(%currentFile);  
+      
+   if ( %dlg.Execute() )
+   {
+      eval(%callback @ "(\"" @ %dlg.FileName @ "\");");
+      $Tools::FileDialogs::LastFilePath = filePath( %dlg.FileName );
+   }
+   
+   %dlg.delete();
+}

--- a/Templates/Empty/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
+++ b/Templates/Empty/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
@@ -366,7 +366,7 @@ function ShapeEdSelectWindow::navigate( %this, %address )
    %this-->shapeLibrary.clear();
    ShapeEdSelectMenu.clear();
 
-   %filePatterns = "*.dts" TAB "*.dae" TAB "*.kmz";
+   %filePatterns = getFormatExtensions();
    %fullPath = findFirstFileMultiExpr( %filePatterns );
 
    while ( %fullPath !$= "" )
@@ -1632,7 +1632,7 @@ function ShapeEdSequences::onAddSequence( %this, %name )
    if ( %from $= "" )
    {
       // No sequence selected => open dialog to browse for one
-      getLoadFilename( "DSQ Files|*.dsq|COLLADA Files|*.dae|Google Earth Files|*.kmz", %this @ ".onAddSequenceFromBrowse", ShapeEdFromMenu.lastPath );
+      getLoadFormatFilename( %this @ ".onAddSequenceFromBrowse", ShapeEdFromMenu.lastPath );
       return;
    }
    else
@@ -1740,7 +1740,7 @@ function ShapeEdSeqFromMenu::onSelect( %this, %id, %text )
       %this.setText( %seqFrom );
 
       // Allow the user to browse for an external source of animation data
-      getLoadFilename( "DSQ Files|*.dsq|COLLADA Files|*.dae|Google Earth Files|*.kmz", %this @ ".onBrowseSelect", %this.lastPath );
+      getLoadFormatFilename( %this @ ".onBrowseSelect", %this.lastPath );
    }
    else
    {
@@ -2862,7 +2862,7 @@ function ShapeEdDetails::onAddMeshFromFile( %this, %path )
 {
    if ( %path $= "" )
    {
-      getLoadFilename( "DTS Files|*.dts|COLLADA Files|*.dae|Google Earth Files|*.kmz", %this @ ".onAddMeshFromFile", %this.lastPath );
+      getLoadFormatFilename( %this @ ".onAddMeshFromFile", %this.lastPath );
       return;
    }
 
@@ -3291,7 +3291,7 @@ function ShapeEdMountShapeMenu::onSelect( %this, %id, %text )
    if ( %text $= "Browse..." )
    {
       // Allow the user to browse for an external model file
-      getLoadFilename( "DTS Files|*.dts|COLLADA Files|*.dae|Google Earth Files|*.kmz", %this @ ".onBrowseSelect", %this.lastPath );
+      getLoadFormatFilename( %this @ ".onBrowseSelect", %this.lastPath );
    }
    else
    {

--- a/Templates/Empty/game/tools/worldEditor/scripts/editors/creator.ed.cs
+++ b/Templates/Empty/game/tools/worldEditor/scripts/editors/creator.ed.cs
@@ -324,13 +324,13 @@ function EWCreatorWindow::navigate( %this, %address )
    
    if ( %this.tab $= "Meshes" )
    {      
-      %fullPath = findFirstFileMultiExpr( "*.dts" TAB "*.dae" TAB "*.kmz" TAB "*.dif" );
+      %fullPath = findFirstFileMultiExpr( getFormatExtensions() );
       
       while ( %fullPath !$= "" )
       {
          if (strstr(%fullPath, "cached.dts") != -1)
          {
-            %fullPath = findNextFileMultiExpr( "*.dts" TAB "*.dae" TAB "*.kmz"  TAB "*.dif" );
+            %fullPath = findNextFileMultiExpr( getFormatExtensions() );
             continue;
          }
 
@@ -338,7 +338,7 @@ function EWCreatorWindow::navigate( %this, %address )
          %splitPath = strreplace( %fullPath, "/", " " );     
          if( getWord(%splitPath, 0) $= "tools" )
          {
-            %fullPath = findNextFileMultiExpr( "*.dts" TAB "*.dae" TAB "*.kmz"  TAB "*.dif" );
+            %fullPath = findNextFileMultiExpr( getFormatExtensions() );
             continue;
          }
                       
@@ -396,7 +396,7 @@ function EWCreatorWindow::navigate( %this, %address )
             }
          }         
 
-         %fullPath = findNextFileMultiExpr( "*.dts" TAB "*.dae" TAB "*.kmz" TAB "*.dif" );
+         %fullPath = findNextFileMultiExpr( getFormatExtensions() );
       }
    }
    

--- a/Templates/Full/game/tools/gui/openFileDialog.ed.cs
+++ b/Templates/Full/game/tools/gui/openFileDialog.ed.cs
@@ -42,3 +42,29 @@ function getLoadFilename(%filespec, %callback, %currentFile)
    
    %dlg.delete();
 }
+
+// Opens a choose file dialog with format filters already loaded
+// in. This avoids the issue of passing a massive list of format 
+// filters into a function as an arguement.
+function getLoadFormatFilename(%callback, %currentFile)
+{   
+   %dlg = new OpenFileDialog()
+   {
+      Filters = getFormatFilters() @ "(All Files (*.*)|*.*|";
+      DefaultFile = %currentFile;
+      ChangePath = false;
+      MustExist = true;
+      MultipleFiles = false;
+   };
+   
+   if ( filePath( %currentFile ) !$= "" )
+      %dlg.DefaultPath = filePath(%currentFile);  
+      
+   if ( %dlg.Execute() )
+   {
+      eval(%callback @ "(\"" @ %dlg.FileName @ "\");");
+      $Tools::FileDialogs::LastFilePath = filePath( %dlg.FileName );
+   }
+   
+   %dlg.delete();
+}

--- a/Templates/Full/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
+++ b/Templates/Full/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
@@ -366,7 +366,7 @@ function ShapeEdSelectWindow::navigate( %this, %address )
    %this-->shapeLibrary.clear();
    ShapeEdSelectMenu.clear();
 
-   %filePatterns = "*.dts" TAB "*.dae" TAB "*.kmz";
+   %filePatterns = getFormatExtensions();
    %fullPath = findFirstFileMultiExpr( %filePatterns );
 
    while ( %fullPath !$= "" )
@@ -1632,7 +1632,7 @@ function ShapeEdSequences::onAddSequence( %this, %name )
    if ( %from $= "" )
    {
       // No sequence selected => open dialog to browse for one
-      getLoadFilename( "DSQ Files|*.dsq|COLLADA Files|*.dae|Google Earth Files|*.kmz", %this @ ".onAddSequenceFromBrowse", ShapeEdFromMenu.lastPath );
+      getLoadFormatFilename( %this @ ".onAddSequenceFromBrowse", ShapeEdFromMenu.lastPath );
       return;
    }
    else
@@ -1740,7 +1740,7 @@ function ShapeEdSeqFromMenu::onSelect( %this, %id, %text )
       %this.setText( %seqFrom );
 
       // Allow the user to browse for an external source of animation data
-      getLoadFilename( "DSQ Files|*.dsq|COLLADA Files|*.dae|Google Earth Files|*.kmz", %this @ ".onBrowseSelect", %this.lastPath );
+      getLoadFormatFilename( %this @ ".onBrowseSelect", %this.lastPath );
    }
    else
    {
@@ -2862,7 +2862,7 @@ function ShapeEdDetails::onAddMeshFromFile( %this, %path )
 {
    if ( %path $= "" )
    {
-      getLoadFilename( "DTS Files|*.dts|COLLADA Files|*.dae|Google Earth Files|*.kmz", %this @ ".onAddMeshFromFile", %this.lastPath );
+      getLoadFormatFilename( %this @ ".onAddMeshFromFile", %this.lastPath );
       return;
    }
 
@@ -3291,7 +3291,7 @@ function ShapeEdMountShapeMenu::onSelect( %this, %id, %text )
    if ( %text $= "Browse..." )
    {
       // Allow the user to browse for an external model file
-      getLoadFilename( "DTS Files|*.dts|COLLADA Files|*.dae|Google Earth Files|*.kmz", %this @ ".onBrowseSelect", %this.lastPath );
+      getLoadFormatFilename( %this @ ".onBrowseSelect", %this.lastPath );
    }
    else
    {

--- a/Templates/Full/game/tools/worldEditor/scripts/editors/creator.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editors/creator.ed.cs
@@ -324,13 +324,13 @@ function EWCreatorWindow::navigate( %this, %address )
    
    if ( %this.tab $= "Meshes" )
    {      
-      %fullPath = findFirstFileMultiExpr( "*.dts" TAB "*.dae" TAB "*.kmz" TAB "*.dif" );
+      %fullPath = findFirstFileMultiExpr( getFormatExtensions() );
       
       while ( %fullPath !$= "" )
       {
          if (strstr(%fullPath, "cached.dts") != -1)
          {
-            %fullPath = findNextFileMultiExpr( "*.dts" TAB "*.dae" TAB "*.kmz"  TAB "*.dif" );
+            %fullPath = findNextFileMultiExpr( getFormatExtensions() );
             continue;
          }
 
@@ -338,7 +338,7 @@ function EWCreatorWindow::navigate( %this, %address )
          %splitPath = strreplace( %fullPath, "/", " " );     
          if( getWord(%splitPath, 0) $= "tools" )
          {
-            %fullPath = findNextFileMultiExpr( "*.dts" TAB "*.dae" TAB "*.kmz"  TAB "*.dif" );
+            %fullPath = findNextFileMultiExpr( getFormatExtensions() );
             continue;
          }
                       
@@ -396,7 +396,7 @@ function EWCreatorWindow::navigate( %this, %address )
             }
          }         
 
-         %fullPath = findNextFileMultiExpr( "*.dts" TAB "*.dae" TAB "*.kmz" TAB "*.dif" );
+         %fullPath = findNextFileMultiExpr( getFormatExtensions() );
       }
    }
    


### PR DESCRIPTION
This is necessary before assimp can be moved in. With this system in place supported shape formats are added during engine load so if assimp (or collada for that matter) is excluded from compilation their formats won't show up in any shape import dialogs.
