### PR TITLE
Fix ALDeviceList::GetDeviceVersion incorrect check of valid pointer.

### DIFF
--- a/Engine/source/sfx/openal/aldlist.cpp
+++ b/Engine/source/sfx/openal/aldlist.cpp
@@ -161,9 +161,9 @@ const char *ALDeviceList::GetDeviceName(int index)
 void ALDeviceList::GetDeviceVersion(int index, int *major, int *minor)
 {
 	if (index < GetNumDevices()) {
-		if (*major)
+		if (major)
 			*major = vDeviceInfo[index].iMajorVersion;
-		if (*minor)
+		if (minor)
 			*minor = vDeviceInfo[index].iMinorVersion;
 	}
 	return;


### PR DESCRIPTION
```
 void ALDeviceList::GetDeviceVersion(int index, int *major, int *minor)
 {
    if (index < GetNumDevices()) {
        if (*major) // not check if it's pointer is valid, and can deferrencing a NULL pointer.
                   *major = vDeviceInfo[index].iMajorVersion;
       ...
}
```
