### PR TITLE
Fix SignalBase constructor shenanigans

### DIFF
--- a/Engine/source/core/util/tSignal.h
+++ b/Engine/source/core/util/tSignal.h
@@ -54,7 +54,6 @@ public:
    {
       mList.next = mList.prev = &mList;
       mList.order = 0.5f;
-      mTriggerNext = NULL;
    }
 
    ~SignalBase();


### PR DESCRIPTION
Fixes #673. Assigning `NULL` to a `Vector` doesn't really make any sense.
