### PR TITLE
Fix assertfatal/TORQUE_UNUSED release performance

### DIFF
--- a/Engine/source/platform/types.h
+++ b/Engine/source/platform/types.h
@@ -40,7 +40,7 @@ typedef double             F64;     ///< Compiler independent 64-bit float
 
 struct EmptyType {};             ///< "Null" type used by templates
 
-#define TORQUE_UNUSED(var) (void)(var)
+#define TORQUE_UNUSED(var) (void)sizeof(var)
 
 //------------------------------------------------------------------------------
 //------------------------------------- String Types


### PR DESCRIPTION
 Fix AssertFatal/TORQUE_UNUSED are not optimized on release build causing performance problems.

http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/

> "Both gcc and MSVC are smart enough to optimize out the evaluation of x, but only if they can determine if  there are no side effects associated with the evaluation.  Unfortunately, this can only be done if the body of x is known entirely to the compiler.  If x is a function call to another module MSVC can still make it go away with Link-Time Code Generation (via cross-module inlining), but poor gcc is dead in the water and emits the call.  Either way, we’re relying on compiler and linker optimizations to make this code go away."
