### PR TITLE
Extended onend sequence

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -114,7 +114,7 @@ IMPLEMENT_CALLBACK( ShapeBaseData, onTrigger, void, ( ShapeBase* obj, S32 index,
    "@param index Index of the trigger that changed\n"
    "@param state New state of the trigger\n" );
 
-IMPLEMENT_CALLBACK(ShapeBaseData, onEndSequence, void, (ShapeBase* obj, S32 slot, const String &name), (obj, slot, name),
+IMPLEMENT_CALLBACK(ShapeBaseData, onEndSequence, void, (ShapeBase* obj, S32 slot, const char* name), (obj, slot, name),
    "@brief Called when a thread playing a non-cyclic sequence reaches the end of the "
    "sequence.\n\n"
    "@param obj The ShapeBase object\n"

--- a/Engine/source/T3D/shapeBase.h
+++ b/Engine/source/T3D/shapeBase.h
@@ -648,7 +648,7 @@ public:
    DECLARE_CALLBACK( void, onCollision, ( ShapeBase* obj, SceneObject* collObj, VectorF vec, F32 len ) );
    DECLARE_CALLBACK( void, onDamage, ( ShapeBase* obj, F32 delta ) );
    DECLARE_CALLBACK( void, onTrigger, ( ShapeBase* obj, S32 index, bool state ) );
-   DECLARE_CALLBACK( void, onEndSequence, (ShapeBase* obj, S32 slot, const String &name));
+   DECLARE_CALLBACK(void, onEndSequence, (ShapeBase* obj, S32 slot, const char* name));
    DECLARE_CALLBACK( void, onForceUncloak, ( ShapeBase* obj, const char* reason ) );
    /// @}
 };


### PR DESCRIPTION
adds the name of the sequence just completed.
example usage for simple FSMs and the like:

function shapeBaseData::onEndSequence(%this, %obj, %slot, %name)
{
   %script = "on" @ %name; //concatenate the returned name with "on" as a differentiated standard nomenclature
   if(%this.isMethod(%script)) //check to ensure the method exists for the class or child class
      %this.call(%script, %obj); //call it
}

function fooData::onBar(%this,%obj)
{
   error("fooData::onBar" SPC %this SPC %obj); //simple data verification
}
