### PR TITLE
Append ' DLL' to DLL name to fix linker times

### DIFF
--- a/Tools/projectGenerator/templates/vc2010_dll_proj.tpl
+++ b/Tools/projectGenerator/templates/vc2010_dll_proj.tpl
@@ -50,15 +50,15 @@
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">{$projectOffset}../../{$gameFolder}/</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">{$projectOffset}../Link/VC2010.$(Configuration).$(PlatformName)/$(ProjectName)/</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">{$projOutName}_DEBUG</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">{$projOutName}_DEBUG DLL</TargetName>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Optimized Debug|Win32'">{$projectOffset}../../{$gameFolder}/</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Optimized Debug|Win32'">{$projectOffset}../Link/VC2010.$(Configuration).$(PlatformName)/$(ProjectName)/</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Optimized Debug|Win32'">false</LinkIncremental>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Optimized Debug|Win32'">{$projOutName}_OPTIMIZEDDEBUG</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Optimized Debug|Win32'">{$projOutName}_OPTIMIZEDDEBUG DLL</TargetName>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">{$projectOffset}../../{$gameFolder}/</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">{$projectOffset}../Link/VC2010.$(Configuration).$(PlatformName)/$(ProjectName)/</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">{$projOutName}</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">{$projOutName} DLL</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Midl>
@@ -96,7 +96,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>{foreach item=def from=$projLibsDebug}{$def};{/foreach}%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir){$projOutName}_DEBUG.dll</OutputFile>
+      <OutputFile>$(OutDir)$(TargetName).dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>{foreach item=def from=$projLibDirs}{$def};{/foreach}{$projectOffset}../Link/VC2010.$(Configuration).$(PlatformName);$(DXSDK_DIR)/Lib/x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;{foreach item=def from=$projLibsIgnore}{$def};{/foreach}%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -148,7 +148,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>{foreach item=def from=$projLibsDebug}{$def};{/foreach}%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir){$projOutName}_OPTIMIZEDDEBUG.dll</OutputFile>
+      <OutputFile>$(OutDir)$(TargetName).dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>{foreach item=def from=$projLibDirs}{$def};{/foreach}{$projectOffset}../Link/VC2010.$(Configuration).$(PlatformName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;{foreach item=def from=$projLibsIgnore}{$def};{/foreach}%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -200,7 +200,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>{foreach item=def from=$projLibs}{$def};{/foreach}%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir){$projOutName}.dll</OutputFile>
+      <OutputFile>$(OutDir)$(TargetName).dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>{foreach item=def from=$projLibDirs}{$def};{/foreach}{$projectOffset}../Link/VC2010.$(Configuration).$(PlatformName);$(DXSDK_DIR)/Lib/x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;{foreach item=def from=$projLibsIgnore}{$def};{/foreach}%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>

--- a/Tools/projectGenerator/templates/vc2k8_dll_proj.tpl
+++ b/Tools/projectGenerator/templates/vc2k8_dll_proj.tpl
@@ -81,9 +81,9 @@
 				AdditionalDependencies="{foreach item=def from=$projLibsDebug}{$def} {/foreach}"
             
             {if $uniformOutputFile eq 1}
-				   OutputFile="{$projectOffset}../../{$gameFolder}/{$projOutName}.dll"
+				   OutputFile="{$projectOffset}../../{$gameFolder}/{$projOutName} DLL.dll"
             {else}
-               OutputFile="{$projectOffset}../../{$gameFolder}/{$projOutName}_DEBUG.dll"
+               OutputFile="{$projectOffset}../../{$gameFolder}/{$projOutName}_DEBUG DLL.dll"
             {/if}
             
 				LinkIncremental="2"
@@ -191,9 +191,9 @@
 				AdditionalDependencies="{foreach item=def from=$projLibsDebug}{$def} {/foreach}"
             
             {if $uniformOutputFile eq 1}
-				   OutputFile="{$projectOffset}../../{$gameFolder}/{$projOutName}.dll"
+				   OutputFile="{$projectOffset}../../{$gameFolder}/{$projOutName} DLL.dll"
             {else}
-               OutputFile="{$projectOffset}../../{$gameFolder}/{$projOutName}_OPTIMIZEDDEBUG.dll"
+               OutputFile="{$projectOffset}../../{$gameFolder}/{$projOutName}_OPTIMIZEDDEBUG DLL.dll"
             {/if}
 
               LinkIncremental="1"
@@ -299,7 +299,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalDependencies="{foreach item=def from=$projLibs}{$def} {/foreach}"
-				OutputFile="{$projectOffset}../../{$gameFolder}/{$projOutName}.dll"
+				OutputFile="{$projectOffset}../../{$gameFolder}/{$projOutName} DLL.dll"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
 				AdditionalLibraryDirectories="{foreach item=def from=$projLibDirs}{$def};{/foreach}{$projectOffset}../Link/VC2k8.$(ConfigurationName).$(PlatformName);"


### PR DESCRIPTION
As reported in #72, the DLL having the same name as the EXE was causing long link times in Visual Studio. This commit renames the DLL to have an _ after the project name, fixing the link times. I should mention, @LuisAntonRebollo is responsible for this. I'm just requesting it officially...

Possibility: on load, the engine should look for DLLs with and without the underscore, so if you find it really obnoxious you can rename your DLL before shipping.
