### PR TITLE
Prevent call to dStrlen(NULL)

### DIFF
--- a/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
@@ -736,7 +736,7 @@ bool GuiGameListMenuProfile::onAdd()
    // We can't call enforceConstraints() here because incRefCount initializes
    // some of the things to enforce. Do a basic sanity check here instead.
    
-   if( !dStrlen(mBitmapName) )
+   if( !mBitmapName || !dStrlen(mBitmapName) )
    {
       Con::errorf( "GuiGameListMenuProfile: %s can't be created without a bitmap. Please add a 'Bitmap' property to the object definition.", getName() );
       return false;


### PR DESCRIPTION
Not sure why this wasn't caught before, but it was causing a crash for me during unit tests, but only with the minimal main script I introduced [here](https://github.com/eightyeight/Torque3D/commit/4fa16b2bc0f91c8d8eb3560217d7769651096001). Needed for #626.
