### PR TITLE
Cloned Dynamic Cubemaps bad.

### DIFF
--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -328,6 +328,7 @@ void ProcessedShaderMaterial::_determineFeatures(  U32 stageNum,
    if (  features.hasFeature( MFT_UseInstancing ) &&
          mMaxStages == 1 &&
          !mMaterial->mGlow[0] &&
+         !mMaterial->mDynamicCubemap &&
          shaderVersion >= 3.0f )
       fd.features.addFeature( MFT_UseInstancing );
 


### PR DESCRIPTION
Instancing clones the results of a previously used material to it's next instance. As such, it and Dynamic Cube Mapping are mutually exclusive features.

Working on a more extensive approach when it comes to consistency: https://github.com/Azaezel/Torque3D/tree/tsstatic_DynamicCubemaps but that may take a few additionally divergent turns, so for now just noting the raw fix to existing functionality.
