### PR TITLE
Make use of PlayerData::swimForce

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -2955,7 +2955,7 @@ void Player::updateMove(const Move* move)
 
       // Clamp acceleration.
       F32 maxAcc = (mDataBlock->swimForce / getMass()) * TickSec;
-      if ( false && swimSpeed > maxAcc )
+      if ( swimSpeed > maxAcc )
          swimAcc *= maxAcc / swimSpeed;      
 
       acc += swimAcc;


### PR DESCRIPTION
I suspect this `false` was debugging code that got commited. I see now downside to actually using `swimForce` as intended. Works in my build.
