### PR TITLE
Make NavPath::alwaysRender work the same as NavMesh::alwaysRender

### DIFF
--- a/Engine/source/navigation/navPath.h
+++ b/Engine/source/navigation/navPath.h
@@ -155,6 +155,8 @@ private:
    static const char *getProtectedMesh(void *obj, const char *data);
    static bool setProtectedWaypoints(void *obj, const char *index, const char *data);
 
+   static bool setProtectedAlwaysRender(void *obj, const char *index, const char *data);
+
    static bool setProtectedFrom(void *obj, const char *index, const char *data);
    static const char *getProtectedFrom(void *obj, const char *data);
 


### PR DESCRIPTION
Currently, `NavPath`'s `alwaysRender` flag only works in the editor, which is kind of annoying. This makes it work in the same way as `NavMesh`'s flag, which lets you view it outside the editor.
