### PR TITLE
Allow drawing 2D squares with 0 rotation angle

### DIFF
--- a/Engine/source/gfx/gfxDrawUtil.cpp
+++ b/Engine/source/gfx/gfxDrawUtil.cpp
@@ -558,7 +558,12 @@ void GFXDrawUtil::draw2DSquare( const Point2F &screenPoint, F32 width, F32 spinA
 
    verts[0].color = verts[1].color = verts[2].color = verts[3].color = mBitmapModulation;
 
-   if(spinAngle != 0.f)
+   if (spinAngle == 0.0f)
+   {
+      for( S32 i = 0; i < 4; i++ )
+         verts[i].point += offset;
+   }
+   else
    {
       MatrixF rotMatrix( EulerF( 0.0, 0.0, spinAngle ) );
 

--- a/Engine/source/gfx/gfxDrawUtil.h
+++ b/Engine/source/gfx/gfxDrawUtil.h
@@ -58,7 +58,7 @@ public:
    void drawRectFill( const Point2I &upperLeft, const Point2I &lowerRight, const ColorI &color );
    void drawRectFill( const RectI &rect, const ColorI &color );
 
-   void draw2DSquare( const Point2F &screenPoint, F32 width, F32 spinAngle );
+   void draw2DSquare( const Point2F &screenPoint, F32 width, F32 spinAngle = 0.0f );
 
    //-----------------------------------------------------------------------------
    // Draw Lines


### PR DESCRIPTION
As reported in #277. Spin angle now defaults to 0 as recommended.
