### PR TITLE
WaterObject loose reflection.

### DIFF
--- a/Engine/source/environment/waterObject.cpp
+++ b/Engine/source/environment/waterObject.cpp
@@ -732,6 +732,11 @@ void WaterObject::renderObject( ObjectRenderInst *ri, SceneRenderState *state, B
 
    bool doQuery = ( !mPlaneReflector.mQueryPending && query && mReflectorDesc.useOcclusionQuery );
 
+   // We need to call this for avoid a DX9 or Nvidia bug.
+   // At some resollutions read from render target,
+   // break current occlusion query.
+   REFLECTMGR->getRefractTex();
+
    if ( doQuery )
       query->begin();
 


### PR DESCRIPTION
See GG forum: [Reflection Rendering Bug (GF 600 Series Only?)](http://www.garagegames.com/community/forums/viewthread/134050)

I have dedicated some time to this weird bug.

After pass the O_o phase, i tracked the problem:
- It's resollution dependent.
- First frame's call to `REFLECTMGR->getRefractTex()` break current occlusion query.
- Seem [read from current render target](https://github.com/GarageGames/Torque3D/blob/8142a3e9645e881cd8e21434809289855e57a0b4/Engine/source/scene/reflectionManager.cpp#L265) when a occlusion query are active it's the problem.

For a simple fix i recomend call `REFLECTMGR->getRefractTex()` before begin the occlusion query on `WaterObject::renderObject`

``` cpp
void WaterObject::renderObject( ObjectRenderInst *ri, SceneRenderState *state, BaseMatInstance *overrideMat )
{
   if ( overrideMat )
      return; 

   GFXOcclusionQuery *query = mPlaneReflector.getOcclusionQuery();

   bool doQuery = ( !mPlaneReflector.mQueryPending && query && mReflectorDesc.useOcclusionQuery );

   REFLECTMGR->getRefractTex(); // add this line

   if ( doQuery )
      query->begin();

   // Real render call, done by derived class.
   innerRender( state );

   if ( doQuery )
      query->end();   

   if ( mUnderwater && mBasicLighting )
      drawUnderwaterFilter( state );
}
```
- Anyone can test the fix?
- Anyone can reproduce this problem on a non Nvidia card?
- A DirectX9 limitation or a driver's bug?
