### PR TITLE
Re-enable Mixed particle rendering

### DIFF
--- a/Templates/Empty/game/core/scripts/client/postFx/edgeAA.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/edgeAA.cs
@@ -83,7 +83,7 @@ singleton PostEffect( EdgeDetectPostEffect )
    texture[0] = "#prepass";
    target = "#edge";
    
-   isEnabled = false;
+   isEnabled = true;
 };
 
 singleton PostEffect( EdgeAAPostEffect )

--- a/Templates/Full/game/core/scripts/client/postFx/edgeAA.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/edgeAA.cs
@@ -83,7 +83,7 @@ singleton PostEffect( EdgeDetectPostEffect )
    texture[0] = "#prepass";
    target = "#edge";
    
-   isEnabled = false;
+   isEnabled = true;
 };
 
 singleton PostEffect( EdgeAAPostEffect )


### PR DESCRIPTION
There seems to have been some copy-pasta and maintenance issues that have caused Mixed rendering to be unfunctional.
This commit fixes those issues and re-enables mixed rendering, as explained [here](http://www.garagegames.com/community/blogs/view/22804).

Currently renders the low-res particles at 1/4 the resolution. To increase or decrease this, look at line 77 in RenderParticleMgr.

Performance difference with 2 emitters,  each emitting 1000 particles per second: 

| Method | MSPF | Impact |
| --- | :-: | :-: |
| Highres | 27 | 8.5 |
| MixedRes | 20 | 1.5 |
| No emitters | 18.5 |  |
