### PR TITLE
GuiObjectView - Fixed rotation bug

### DIFF
--- a/Engine/source/T3D/guiObjectView.cpp
+++ b/Engine/source/T3D/guiObjectView.cpp
@@ -520,7 +520,7 @@ void GuiObjectView::renderWorld( const RectI& updateRect )
    (
       gClientSceneGraph,
       SPT_Diffuse,
-      SceneCameraState( GFX->getViewport(), frust, GFX->getWorldMatrix(), GFX->getProjectionMatrix() ),
+      SceneCameraState( GFX->getViewport(), frust, MatrixF::Identity, GFX->getProjectionMatrix() ),
       renderPass,
       false
    );


### PR DESCRIPTION
There was a bug with GuiObjectView causing the view to rotate around the wrong axis instead of the center of the object that was loaded.
A fix was posted on the GarageGames forums a while back, but never seems to have made its way in to the repo.

reference: http://www.garagegames.com/community/forums/viewthread/126414/1#comment-825677
