### PR TITLE
GuiTreeView bug in buildVisibleTree

### DIFF
--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -1237,7 +1237,7 @@ void GuiTreeViewCtrl::buildVisibleTree(bool bForceFullUpdate)
       bForceFullUpdate = true;
 
    // Update the flags.
-   mFlags.set(RebuildVisible);
+   mFlags.clear(RebuildVisible);
 
    // build the root items
    Item *traverse = mRoot;
@@ -1785,6 +1785,8 @@ bool GuiTreeViewCtrl::onWake()
       // make sure it's big enough for both bitmap AND font...
       mItemHeight = getMax((S32)mFont->getHeight(), (S32)mProfile->mBitmapArrayRects[0].extent.y);
    }
+   
+   mFlags.set(RebuildVisible);
 
    return true;
 }


### PR DESCRIPTION
There was a bug in buildVisibleTree, it should be setting the RebuildVisible flag, not clearing it.

The clip rectangle did not appear to be updating when expanding items or calling scrollVisible, which expands all the items to make a particular item visible. This would cause part of the tree to be cut off.

Setting the RebuildVisible flag made the problem go away.
