### PR TITLE
requested correction

### DIFF
--- a/Engine/source/lighting/advanced/advancedLightBinManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightBinManager.cpp
@@ -243,7 +243,7 @@ void AdvancedLightBinManager::render( SceneRenderState *state )
       return;
 
    // Get the sunlight. If there's no sun, and no lights in the bins, no draw
-   LightInfo *sunLight = mLightManager->getSpecialLight( LightManager::slSunLightType );
+   LightInfo *sunLight = mLightManager->getSpecialLight( LightManager::slSunLightType, false );
    if( !sunLight && mLightBin.empty() )
       return;
 


### PR DESCRIPTION
kills off the presence of a fake light when there are no others in a given scene. apparently this was causing other issues down the pipe.
special note, the lack of a skybox or scattersky will still reveal the canvasclearcolor. the presence of a skybox does still result in that rendering as normal.
