### PR TITLE
Load new DLL first so existing projects don't see odd behavior

### DIFF
--- a/Engine/source/main/main.cpp
+++ b/Engine/source/main/main.cpp
@@ -55,7 +55,7 @@ int PASCAL WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdL
    HMODULE hGame = NULL;
    std::wstring dllName = std::wstring();
    // The file name is the same as this executable's name, plus a suffix.
-   const std::wstring dllSuffices[] = {L"", L" DLL"};
+   const std::wstring dllSuffices[] = {L" DLL", L""};
    const unsigned int numSuffices = sizeof(dllSuffices) / sizeof(std::wstring);
 
    for (unsigned int i = 0; i < numSuffices; i++)


### PR DESCRIPTION
As introduced in #698, the engine now compiles to `ProjectName DLL.dll` instead of `ProjectName.dll`. If you have an existing project and merge these changes in, then recompile, you'll end up with both files adjacent to your executable. The engine currently looks for `ProjectName.dll` first, and if it finds it, loads it. This change reverses that order, so the new-format DLL is loaded in preference to the old one - but you can still use a filename without the `DLL` suffix when deploying, if you prefer.
