### PR TITLE
Implemented physics collision for MeshRoad

### DIFF
--- a/Engine/source/environment/meshRoad.cpp
+++ b/Engine/source/environment/meshRoad.cpp
@@ -49,6 +49,7 @@
 #include "collision/concretePolyList.h"
 #include "T3D/physics/physicsPlugin.h"
 #include "T3D/physics/physicsBody.h"
+#include "T3D/physics/physicsCollision.h"
 #include "environment/nodeListManager.h"
 
 #define MIN_METERS_PER_SEGMENT 1.0f
@@ -1722,6 +1723,8 @@ void MeshRoad::_generateSlices()
 
 void MeshRoad::_generateSegments()
 {
+   SAFE_DELETE( mPhysicsRep );
+
    mSegments.clear();
 
    for ( U32 i = 0; i < mSlices.size() - 1; i++ )
@@ -1736,8 +1739,22 @@ void MeshRoad::_generateSegments()
 
    if ( PHYSICSMGR )
    {
-      SAFE_DELETE( mPhysicsRep );
-      //mPhysicsRep = PHYSICSMGR->createBody();
+      ConcretePolyList polylist;
+      if ( buildPolyList( PLC_Collision, &polylist, getWorldBox(), getWorldSphere() ) )
+      {
+         polylist.triangulate();
+
+         PhysicsCollision *colShape = PHYSICSMGR->createCollision();
+         colShape->addTriangleMesh( polylist.mVertexList.address(),
+            polylist.mVertexList.size(),
+            polylist.mIndexList.address(),
+            polylist.mIndexList.size() / 3,
+            MatrixF::Identity );
+
+         PhysicsWorld *world = PHYSICSMGR->getWorld( isServerObject() ? "server" : "client" );
+         mPhysicsRep = PHYSICSMGR->createBody();
+         mPhysicsRep->init( colShape, 0, 0, this, world );
+      }
    }
 }
 


### PR DESCRIPTION
According to [deepscratch's post](http://www.garagegames.com/community/forums/viewthread/130181/1#comment-826897) in the forum. It seems like his fix had been half-implemented, adding `mPhysicsRep` to `MeshRoad`, but it was still unused. This adds the remainder of his code, as well as an extra line that deletes the existing `mPhysicsRep` before creating a new one.
