### PR TITLE
- Added check in tsMesh::createTangents to check size of incoming normal...

### DIFF
--- a/Engine/source/ts/tsMesh.cpp
+++ b/Engine/source/ts/tsMesh.cpp
@@ -2949,7 +2949,11 @@ inline void TSMesh::findTangent( U32 index1,
 void TSMesh::createTangents(const Vector<Point3F> &_verts, const Vector<Point3F> &_norms)
 {
    U32 numVerts = _verts.size();
-   if ( numVerts == 0 )
+   U32 numNorms = _norms.size();
+   if ( numVerts <= 0 || numNorms <= 0 )
+      return;
+
+   if( numVerts != numNorms)
       return;
 
    Vector<Point3F> tan0;


### PR DESCRIPTION
Added a check to make sure the _norms and _verts are the same size. later on in this function it loops over the vertex size and indexes the _norms, this could cause problems if the size doesn't match.

Also Vector.size() returns a signed integer so added a check for negative numbers too. 
