### PR TITLE
followup to #522

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -3101,8 +3101,6 @@ void Player::updateMove(const Move* move)
    }
 
    // Container buoyancy & drag
-/* Commented out until the buoyancy calculation can be reworked so that a container and
-** player with the same density will result in neutral buoyancy.
    if (mBuoyancy != 0)
    {     
       // Applying buoyancy when standing still causing some jitters-
@@ -3111,7 +3109,7 @@ void Player::updateMove(const Move* move)
          // A little hackery to prevent oscillation
          // based on http://reinot.blogspot.com/2005/11/oh-yes-they-float-georgie-they-all.html
 
-         F32 buoyancyForce = mBuoyancy * mGravity * mGravityMod * TickSec;
+          F32 buoyancyForce = mBuoyancy/mDataBlock->density * mGravity * mGravityMod * TickSec;
          F32 currHeight = getPosition().z;
          const F32 C = 2.0f;
          const F32 M = 0.1f;
@@ -3122,7 +3120,6 @@ void Player::updateMove(const Move* move)
          mVelocity.z -= buoyancyForce;
       }
    }
-*/
 
    // Apply drag
    if ( mSwimming )


### PR DESCRIPTION
Contrary to http://en.wikipedia.org/wiki/Buoyancy#Archimedes.27_principle, getting players to float similar to rigidshapes and wheeledvehicles when water density matches or exceeds it, we need to get the water density derived from https://github.com/GarageGames/Torque3D/blob/69838bdc8c9bc055b9b1ae76f42b0f28d2a33909/Engine/source/T3D/shapeBase.cpp#L1607 and divide that by player density *(and again, specifically player density. the rest work fine) rather than the other way around.
