### PR TITLE
Fixed Vehicle crash on changing datablock shape in editor for #189

### DIFF
--- a/Engine/source/T3D/player.h
+++ b/Engine/source/T3D/player.h
@@ -344,6 +344,7 @@ struct PlayerData: public ShapeBaseData {
    DECLARE_CONOBJECT(PlayerData);
    PlayerData();
    bool preload(bool server, String &errorStr);
+   bool _loadShape(bool server, String &errorStr);
    void getGroundInfo(TSShapeInstance*,TSThread*,ActionAnimation*);
    bool isTableSequence(S32 seq);
    bool isJumpAction(U32 action);

--- a/Engine/source/T3D/proximityMine.cpp
+++ b/Engine/source/T3D/proximityMine.cpp
@@ -143,6 +143,15 @@ bool ProximityMineData::preload( bool server, String& errorStr )
          Con::errorf( ConsoleLogEntry::General, "ProximityMineData::preload: Invalid packet: %s", sfxErrorStr.c_str() );
    }
 
+   return true;
+}
+
+
+bool ProximityMineData::_loadShape( bool server, String& errorStr )
+{
+   if ( Parent::_loadShape( server, errorStr ) == false )
+      return false;
+
    if ( mShape )
    {
       // Lookup animation sequences
@@ -152,6 +161,7 @@ bool ProximityMineData::preload( bool server, String& errorStr )
 
    return true;
 }
+
 
 void ProximityMineData::packData( BitStream* stream )
 {

--- a/Engine/source/T3D/proximityMine.h
+++ b/Engine/source/T3D/proximityMine.h
@@ -59,6 +59,7 @@ public:
    DECLARE_CONOBJECT( ProximityMineData );
    static void initPersistFields();
    bool preload( bool server, String& errorStr );
+   bool _loadShape( bool server, String& errorStr );
    virtual void packData( BitStream* stream );
    virtual void unpackData( BitStream* stream );
 };

--- a/Engine/source/T3D/rigidShape.cpp
+++ b/Engine/source/T3D/rigidShape.cpp
@@ -298,14 +298,6 @@ bool RigidShapeData::preload(bool server, String &errorStr)
    if (!Parent::preload(server, errorStr))
       return false;
 
-   // RigidShape objects must define a collision detail
-   if (!collisionDetails.size() || collisionDetails[0] == -1)
-   {
-      Con::errorf("RigidShapeData::preload failed: Rigid shapes must define a collision-1 detail");
-      errorStr = String::ToString("RigidShapeData: Couldn't load shape \"%s\"",shapeName);
-      return false;
-   }
-
    // Resolve objects transmitted from server
    if (!server) {
       for (S32 i = 0; i < Body::MaxSounds; i++)
@@ -354,6 +346,23 @@ bool RigidShapeData::preload(bool server, String &errorStr)
 
    return true;
 }   
+
+
+bool RigidShapeData::_loadShape(bool server, String &errorStr)
+{
+   if (!Parent::_loadShape(server, errorStr))
+      return false;
+
+   // RigidShape objects must define a collision detail
+   if (!collisionDetails.size() || collisionDetails[0] == -1)
+   {
+      Con::errorf("RigidShapeData::_loadShape failed: Rigid shapes must define a collision-1 detail");
+      errorStr = String::ToString("RigidShapeData: Couldn't load shape \"%s\"",shapeName);
+      return false;
+   }
+
+   return true;
+}
 
 
 //----------------------------------------------------------------------------

--- a/Engine/source/T3D/rigidShape.h
+++ b/Engine/source/T3D/rigidShape.h
@@ -129,6 +129,7 @@ class RigidShapeData : public ShapeBaseData
    void packData(BitStream*);
    void unpackData(BitStream*);
    bool preload(bool server, String &errorStr);
+   bool _loadShape(bool server, String &errorStr);
 
    DECLARE_CONOBJECT(RigidShapeData);
 

--- a/Engine/source/T3D/shapeBase.h
+++ b/Engine/source/T3D/shapeBase.h
@@ -628,6 +628,12 @@ public:
    void computeAccelerator(U32 i);
    S32  findMountPoint(U32 n);
 
+   /// Initialise data related to our shapefile, such as finding named nodes
+   /// and collision meshes.
+   virtual bool _loadShape(bool server, String &errorStr);
+   /// Called when the shapeName field is changed from scripts.
+   static bool _setShapeName(void*, const char*, const char*);
+
    /// @name Infrastructure
    /// The derived class should provide the following:
    /// @{

--- a/Engine/source/T3D/turret/aiTurretShape.cpp
+++ b/Engine/source/T3D/turret/aiTurretShape.cpp
@@ -241,9 +241,9 @@ bool AITurretShapeData::onAdd()
    return true;
 }
 
-bool AITurretShapeData::preload(bool server, String &errorStr)
+bool AITurretShapeData::_loadShape(bool server, String &errorStr)
 {
-   if (!Parent::preload(server, errorStr))
+   if (!Parent::_loadShape(server, errorStr))
       return false;
 
    // We have mShape at this point.  Resolve nodes.

--- a/Engine/source/T3D/turret/aiTurretShape.h
+++ b/Engine/source/T3D/turret/aiTurretShape.h
@@ -141,7 +141,7 @@ public:
    static void initPersistFields();
 
    virtual bool onAdd();
-   virtual bool preload(bool server, String &errorStr);
+   virtual bool _loadShape(bool server, String &errorStr);
 
    virtual void packData(BitStream* stream);
    virtual void unpackData(BitStream* stream);

--- a/Engine/source/T3D/turret/turretShape.cpp
+++ b/Engine/source/T3D/turret/turretShape.cpp
@@ -212,9 +212,9 @@ void TurretShapeData::unpackData(BitStream* stream)
    stream->read(&pitchRate);
 }
 
-bool TurretShapeData::preload(bool server, String &errorStr)
+bool TurretShapeData::_loadShape(bool server, String &errorStr)
 {
-   if (!Parent::preload(server, errorStr))
+   if (!Parent::_loadShape(server, errorStr))
       return false;
 
    // We have mShape at this point.  Resolve nodes.
@@ -250,7 +250,6 @@ bool TurretShapeData::preload(bool server, String &errorStr)
 
    return true;
 }
-
 
 //----------------------------------------------------------------------------
 

--- a/Engine/source/T3D/turret/turretShape.h
+++ b/Engine/source/T3D/turret/turretShape.h
@@ -91,7 +91,7 @@ public:
    virtual void packData(BitStream* stream);
    virtual void unpackData(BitStream* stream);
 
-   virtual bool preload(bool server, String &errorStr);
+   virtual bool _loadShape(bool server, String &errorStr);
 
    DECLARE_CALLBACK( void, onMountObject, ( TurretShape* turret, SceneObject* obj, S32 node ) );
    DECLARE_CALLBACK( void, onUnmountObject, ( TurretShape* turret, SceneObject* obj ) );

--- a/Engine/source/T3D/vehicles/flyingVehicle.cpp
+++ b/Engine/source/T3D/vehicles/flyingVehicle.cpp
@@ -128,8 +128,6 @@ bool FlyingVehicleData::preload(bool server, String &errorStr)
    if (!Parent::preload(server, errorStr))
       return false;
 
-   TSShapeInstance* si = new TSShapeInstance(mShape, false);
-
    // Resolve objects transmitted from server
    if (!server) {
       for (S32 i = 0; i < MaxSounds; i++)
@@ -140,6 +138,19 @@ bool FlyingVehicleData::preload(bool server, String &errorStr)
          if (jetEmitter[j])
             Sim::findObject(SimObjectId(jetEmitter[j]),jetEmitter[j]);
    }
+
+   //
+   maxSpeed = maneuveringForce / minDrag;
+
+   return true;
+}
+
+bool FlyingVehicleData::_loadShape(bool server, String &errorStr)
+{
+   if (!Parent::_loadShape(server, errorStr))
+      return false;
+
+   TSShapeInstance* si = new TSShapeInstance(mShape, false);
 
    // Extract collision planes from shape collision detail level
    if (collisionDetails[0] != -1)
@@ -152,14 +163,12 @@ bool FlyingVehicleData::preload(bool server, String &errorStr)
       si->buildPolyList(&polyList,collisionDetails[0]);
    }
 
+   delete si;
+
    // Resolve jet nodes
    for (S32 j = 0; j < MaxJetNodes; j++)
       jetNode[j] = mShape->findNode(sJetNode[j]);
 
-   //
-   maxSpeed = maneuveringForce / minDrag;
-
-   delete si;
    return true;
 }
 

--- a/Engine/source/T3D/vehicles/flyingVehicle.h
+++ b/Engine/source/T3D/vehicles/flyingVehicle.h
@@ -108,6 +108,7 @@ struct FlyingVehicleData: public VehicleData {
    DECLARE_CONOBJECT(FlyingVehicleData);
    static void initPersistFields();
    bool preload(bool server, String &errorStr);
+   bool _loadShape(bool server, String &errorStr);
    void packData(BitStream* stream);
    void unpackData(BitStream* stream);
 };

--- a/Engine/source/T3D/vehicles/hoverVehicle.cpp
+++ b/Engine/source/T3D/vehicles/hoverVehicle.cpp
@@ -328,6 +328,16 @@ bool HoverVehicleData::preload(bool server, String &errorStr)
          Con::errorf( ConsoleLogEntry::General, "HoverVehicleData::preload Invalid packet, bad datablockId(dustTrailEmitter): 0x%x", dustTrailID );
       }
    }
+
+   return true;
+}
+
+
+bool HoverVehicleData::_loadShape(bool server, String &errorStr)
+{
+   if (Parent::_loadShape(server, errorStr) == false)
+      return false;
+
    // Resolve jet nodes
    for (S32 j = 0; j < MaxJetNodes; j++)
       jetNode[j] = mShape->findNode(sJetNode[j]);

--- a/Engine/source/T3D/vehicles/hoverVehicle.h
+++ b/Engine/source/T3D/vehicles/hoverVehicle.h
@@ -118,6 +118,7 @@ class HoverVehicleData : public VehicleData
    void packData(BitStream*);
    void unpackData(BitStream*);
    bool preload(bool server, String &errorStr);
+   bool _loadShape(bool server, String &errorStr);
 
    DECLARE_CONOBJECT(HoverVehicleData);
    static void initPersistFields();

--- a/Engine/source/T3D/vehicles/vehicle.h
+++ b/Engine/source/T3D/vehicles/vehicle.h
@@ -130,6 +130,7 @@ struct VehicleData: public ShapeBaseData
    //
    VehicleData();
    bool preload(bool server, String &errorStr);
+   bool _loadShape(bool server, String &errorStr);
    static void initPersistFields();
    virtual void packData(BitStream* stream);
    virtual void unpackData(BitStream* stream);
@@ -237,6 +238,7 @@ class Vehicle: public ShapeBase
 
    void updateWorkingCollisionSet(const U32 mask);
    virtual U32 getCollisionMask();
+   void _updateConvexCollision();
 
    void updateFroth( F32 dt );
    bool collidingWithWater( Point3F &waterHeight );

--- a/Engine/source/T3D/vehicles/wheeledVehicle.cpp
+++ b/Engine/source/T3D/vehicles/wheeledVehicle.cpp
@@ -311,6 +311,24 @@ WheeledVehicleData::WheeledVehicleData()
 
 
 //----------------------------------------------------------------------------
+bool WheeledVehicleData::preload(bool server, String &errorStr)
+{
+   if (!Parent::preload(server, errorStr))
+      return false;
+
+   // Resolve objects transmitted from server
+   if (!server) {
+      for (S32 i = 0; i < MaxSounds; i++)
+         if( !sfxResolve( &sound[ i ], errorStr ) )
+            return false;
+
+      if (tireEmitter)
+         Sim::findObject(SimObjectId(tireEmitter),tireEmitter);
+   }
+
+   return true;
+}
+
 /** Load the vehicle shape
    Loads and extracts information from the vehicle shape.
 
@@ -327,24 +345,14 @@ WheeledVehicleData::WheeledVehicleData()
 
    The steering and animation sequences are optional.
 */
-bool WheeledVehicleData::preload(bool server, String &errorStr)
+bool WheeledVehicleData::_loadShape(bool server, String &errorStr)
 {
-   if (!Parent::preload(server, errorStr))
+   if (!Parent::_loadShape(server, errorStr))
       return false;
 
    // A temporary shape instance is created so that we can
    // animate the shape and extract wheel information.
    TSShapeInstance* si = new TSShapeInstance(mShape, false);
-
-   // Resolve objects transmitted from server
-   if (!server) {
-      for (S32 i = 0; i < MaxSounds; i++)
-         if( !sfxResolve( &sound[ i ], errorStr ) )
-            return false;
-
-      if (tireEmitter)
-         Sim::findObject(SimObjectId(tireEmitter),tireEmitter);
-   }
 
    // Extract wheel information from the shape
    TSThread* thread = si->addThread();
@@ -408,9 +416,9 @@ bool WheeledVehicleData::preload(bool server, String &errorStr)
    }
 
    delete si;
+
    return true;
 }
-
 
 //----------------------------------------------------------------------------
 /** Find a matching lateral wheel

--- a/Engine/source/T3D/vehicles/wheeledVehicle.h
+++ b/Engine/source/T3D/vehicles/wheeledVehicle.h
@@ -143,6 +143,7 @@ struct WheeledVehicleData: public VehicleData
    DECLARE_CONOBJECT(WheeledVehicleData);
    static void initPersistFields();
    bool preload(bool, String &errorStr);
+   bool _loadShape(bool, String &errorStr);
    bool mirrorWheel(Wheel* we);
    virtual void packData(BitStream* stream);
    virtual void unpackData(BitStream* stream);


### PR DESCRIPTION
To fix #189 I separated out parts of `ShapeBaseData::preload` (and `preload` in descendant classes) that referred to `mShape` into `_loadShape` and called `_loadShape` when `shapeName` is changed from scripts by using `addProtectedField`. Now, Vehicle will `AssertFatal` when you give it a shape with no collision mesh, instead of crashing nastily later. See #739 also.

Note that crashes are still possible. For example, changing a `Vehicle` to a shape that has no animations will go badly.
