### PR TITLE
Removed annoying warning

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -487,10 +487,6 @@ bool PlayerData::preload(bool server, String &errorStr)
          dp->death         = false;
          if (dp->sequence != -1)
             getGroundInfo(si,thread,dp);
-
-         // No real reason to spam the console about a missing jet animation
-         if (dStricmp(sp->name, "jet") != 0)
-            AssertWarn(dp->sequence != -1, avar("PlayerData::preload - Unable to find named animation sequence '%s'!", sp->name));
       }
       for (S32 b = 0; b < mShape->sequences.size(); b++)
       {


### PR DESCRIPTION
Oftentimes you _don't_ have most animations defined in the Player shape. No need to fuss, it'll be obvious if they're supposed to be there anr they're not.
