### PR TITLE
Fix scopeScene's use of Box3F constructor

### DIFF
--- a/Engine/source/scene/sceneManager.cpp
+++ b/Engine/source/scene/sceneManager.cpp
@@ -566,7 +566,7 @@ void SceneManager::scopeScene( CameraScopeQuery* query, NetConnection* netConnec
 
    // Scope all objects in the query area.
 
-   Box3F area( query->visibleDistance );
+   Box3F area( 2 * query->visibleDistance );
    area.setCenter( query->pos );
 
    getContainer()->findObjects( area, 0xFFFFFFFF, _scopeCallback, &info );


### PR DESCRIPTION
The `Box3F` constructor accepting a single float [treats it as a diameter, not a radius](https://github.com/GarageGames/Torque3D/blob/d08e594316e69651b6b6c8a07063d9111b2af688/Engine/source/math/mBox.h#L249). Therefore we need to double `visibleDistance` before we pass it in.
