### PR TITLE
Allow return status to be specified using quitWithStatus

### DIFF
--- a/Engine/source/app/mainLoop.cpp
+++ b/Engine/source/app/mainLoop.cpp
@@ -623,6 +623,11 @@ bool StandardMainLoop::doMainLoop()
    return keepRunning;
 }
 
+S32 StandardMainLoop::getReturnStatus()
+{
+   return Process::getReturnStatus();
+}
+
 void StandardMainLoop::setRestart(bool restart )
 {
    gRequiresRestart = restart;

--- a/Engine/source/app/mainLoop.h
+++ b/Engine/source/app/mainLoop.h
@@ -41,6 +41,9 @@ public:
    /// Shut down the core libraries and call registered shutdown fucntions.
    static void shutdown();
 
+   /// Gets the return status code of the current process.
+   static S32 getReturnStatus();
+
    static void setRestart( bool restart );
    static bool requiresRestart();
 

--- a/Engine/source/cinterface/cinterface.cpp
+++ b/Engine/source/cinterface/cinterface.cpp
@@ -132,6 +132,11 @@ extern "C" {
 
 	}
 
+	S32 torque_getreturnstatus()
+	{
+		return StandardMainLoop::getReturnStatus();
+	}
+
    // signal an engine shutdown (as with the quit(); console command)
 	void torque_enginesignalshutdown()
 	{

--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -1517,11 +1517,12 @@ ConsoleFunction( realQuit, void, 1, 1, "" )
 
 //-----------------------------------------------------------------------------
 
-DefineConsoleFunction( quitWithErrorMessage, void, ( const char* message ),,
+DefineConsoleFunction( quitWithErrorMessage, void, ( const char* message, S32 status ), (0),
    "Display an error message box showing the given @a message and then shut down the engine and exit its process.\n"
    "This function cleanly uninitialized the engine and then exits back to the system with a process "
    "exit status indicating an error.\n\n"
-   "@param message The message to log to the console and show in an error message box.\n\n"
+   "@param message The message to log to the console and show in an error message box.\n"
+   "@param status  The status code to return to the OS.\n\n"
    "@see quit\n\n"
    "@ingroup Platform" )
 {
@@ -1532,7 +1533,20 @@ DefineConsoleFunction( quitWithErrorMessage, void, ( const char* message ),,
    //    as the script code should not be allowed to pretty much hard-crash the engine
    //    and prevent proper shutdown.  Changed this to use postQuitMessage.
    
-   Platform::postQuitMessage( -1 );
+   Platform::postQuitMessage( status );
+}
+
+//-----------------------------------------------------------------------------
+
+DefineConsoleFunction( quitWithStatus, void, ( S32 status ), (0),
+   "Shut down the engine and exit its process.\n"
+   "This function cleanly uninitializes the engine and then exits back to the system with a given "
+   "return status code.\n\n"
+   "@param status The status code to return to the OS.\n\n"
+   "@see quitWithErrorMessage\n\n"
+   "@ingroup Platform" )
+{
+   Platform::postQuitMessage(status);
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/core/util/journal/process.cpp
+++ b/Engine/source/core/util/journal/process.cpp
@@ -43,15 +43,21 @@ static Process* _theOneProcess = NULL; ///< the one instance of the Process clas
 
 //-----------------------------------------------------------------------------
 
-void Process::requestShutdown()
+void Process::requestShutdown(S32 status)
 {
    Process::get()._RequestShutdown = true;
+   Process::get()._ReturnStatus = status;
+}
+
+S32 Process::getReturnStatus()
+{
+   return Process::get()._ReturnStatus;
 }
 
 //-----------------------------------------------------------------------------
 
 Process::Process()
-:  _RequestShutdown( false )
+:  _RequestShutdown( false ), _ReturnStatus( 0 )
 {
 }
 

--- a/Engine/source/core/util/journal/process.h
+++ b/Engine/source/core/util/journal/process.h
@@ -64,7 +64,7 @@ public:
    static bool processEvents();
 
    /// Ask the processEvents() function to shutdown.
-   static void requestShutdown();
+   static void requestShutdown(S32 status = 0);
 
 
    static void notifyInit(Delegate<bool()> del, F32 order = PROCESS_DEFAULT_ORDER) 
@@ -149,6 +149,9 @@ public:
    /// Trigger the registered shutdown functions
    static bool shutdown();
 
+   /// get the current return status code we've been asked to end with.
+   static S32 getReturnStatus();
+
 private:
    friend class StandardMainLoop;
 
@@ -167,6 +170,7 @@ private:
    Signal<bool()>                   _signalShutdown;
 
    bool _RequestShutdown;
+   S32 _ReturnStatus;
 };
 
 /// Register a command line handling function.

--- a/Engine/source/main/main.cpp
+++ b/Engine/source/main/main.cpp
@@ -321,7 +321,7 @@ S32 TorqueMain(S32 argc, const char **argv)
       Platform::restartInstance();
 
    // Return.
-   return 0;
+   return StandardMainLoop::getReturnStatus();
 }
 
 #endif //TORQUE_SHARED

--- a/Engine/source/platform/platform.h
+++ b/Engine/source/platform/platform.h
@@ -204,7 +204,7 @@ namespace Platform
    bool excludeOtherInstances(const char *string);
    bool checkOtherInstances(const char *string);
    void restartInstance();
-   void postQuitMessage(const U32 in_quitVal);
+   void postQuitMessage(const S32 in_quitVal);
    void forceShutdown(S32 returnValue);
 
    // Debug

--- a/Engine/source/platformWin32/winProcessControl.cpp
+++ b/Engine/source/platformWin32/winProcessControl.cpp
@@ -23,7 +23,7 @@
 #include "platformWin32/platformWin32.h"
 #include "core/strings/stringFunctions.h"
 
-void Platform::postQuitMessage(const U32 in_quitVal)
+void Platform::postQuitMessage(const S32 in_quitVal)
 {
    if (!Platform::getWebDeployment())
       PostQuitMessage(in_quitVal);

--- a/Engine/source/platformWin32/winWindow.cpp
+++ b/Engine/source/platformWin32/winWindow.cpp
@@ -375,6 +375,7 @@ extern "C"
 {
 	bool torque_engineinit(S32 argc, const char **argv);
 	S32  torque_enginetick();
+	S32  torque_getreturnstatus();
 	bool torque_engineshutdown();
 };
 
@@ -390,7 +391,7 @@ S32 TorqueMain(int argc, const char **argv)
 
 	torque_engineshutdown();
 
-	return 0;
+	return torque_getreturnstatus();
 
 }
 

--- a/Engine/source/platformX86UNIX/x86UNIXMain.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXMain.cpp
@@ -121,6 +121,7 @@ extern "C"
 {
    bool torque_engineinit(int argc, const char **argv);
    int  torque_enginetick();
+   S32  torque_getreturnstatus();
    bool torque_engineshutdown();
 
    int torque_unixmain(int argc, const char **argv)
@@ -135,7 +136,7 @@ extern "C"
 
      torque_engineshutdown();
 
-     return 0;
+     return torque_getreturnstatus();
 
    }
 }

--- a/Engine/source/platformX86UNIX/x86UNIXProcessControl.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXProcessControl.cpp
@@ -37,9 +37,6 @@
 //-----------------------------------------------------------------------------
 // This is a mainly a debugging function for intercepting a nonzero exit code
 // and generating a core dump for a stack trace.
-// Need an S64 here because postQuitMessage uses a U32, and 
-// forceshutdown uses an S32.  So S64 is needed to
-// accomodate them both
 static void CheckExitCode(S64 exitCode)
 {
    if (exitCode != 0)
@@ -141,7 +138,7 @@ void ProcessControlInit()
 }
 
 //-----------------------------------------------------------------------------
-void Platform::postQuitMessage(const U32 in_quitVal)
+void Platform::postQuitMessage(const S32 in_quitVal)
 {
    // if we have a window send a quit event, otherwise just force shutdown
 #if 0
@@ -171,8 +168,6 @@ void Platform::debugBreak()
 //-----------------------------------------------------------------------------
 void Platform::forceShutdown(S32 returnValue)
 {
-   CheckExitCode(returnValue);
-
 #if 0
    // if a dedicated server is running, turn it off
    if (x86UNIXState->isDedicated() && Game->isRunning())

--- a/Engine/source/windowManager/win32/winDispatch.cpp
+++ b/Engine/source/windowManager/win32/winDispatch.cpp
@@ -450,7 +450,7 @@ static bool _dispatch(HWND hWnd,UINT message,WPARAM wParam,WPARAM lParam)
 		// Quit indicates that we're not going to receive anymore Win32 messages.
 		// Therefore, it's appropriate to flag our event loop for exit as well,
 		// since we won't be getting any more messages.
-		Process::requestShutdown();
+		Process::requestShutdown((S32)wParam);
 		break;
 				  }
 


### PR DESCRIPTION
Call `quitWithStatus(1)`, for example, to exit the program with a 1 status code. This is useful for unit tests and servers. Currently not implemented for Mac platform. Note that I haven't tested the Linux build yet because of VM issues, so I may rebase this at some point so it actually works on Ubuntu dedicated.

EDIT: The reason this is a separate command is because of this:

```
GlobalActionMap.bind(keyboard, escape, quit);
```

This will call `quit(1)` when the escape key is pressed because of the way TorqueScript works (AFAICT). Therefore to prevent incorrect default arguments from being passed, `quit` will always use code `0` and `quitWithStatus` will take an explicit code. `quitWithErrorMessage` has also been extended to optionally take a code.
