### PR TITLE
Bumped minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.3)
+cmake_minimum_required (VERSION 2.8.12)
 
 set(TORQUE_APP_NAME "" CACHE STRING "the app name")
 


### PR DESCRIPTION
2.8.12 is the lowest known working version number for all platforms. 2.8.7 is known not to work on Ubuntu 12.10.
