### PR TITLE
Add additional padding on unescape scenarios.  Also fix appendformat whi...

### DIFF
--- a/Engine/source/core/util/str.cpp
+++ b/Engine/source/core/util/str.cpp
@@ -1486,7 +1486,7 @@ S32 String::StrFormat::append(const char * str, S32 len)
    }
 
    S32 newSize = _dynamicSize;
-   while (newSize < _len+len)
+   while (newSize < _len+len+1)
       newSize *= 2;
    if (newSize != _dynamicSize)
       _dynamicBuffer = (char*) dRealloc(_dynamicBuffer, newSize);


### PR DESCRIPTION
expandEscapes was causing corruption on strings as worst case scenario was not worse enough.  

String::StrFormat::formatAppend was not using vsnprintf correctly and would corrupt when crossing allocation boundaries when appending to an existing string.