### PR TITLE
Disable all post effects by default

### DIFF
--- a/Templates/Empty/game/core/scripts/client/postFx/default.postfxpreset.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/default.postfxpreset.cs
@@ -20,6 +20,11 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
+$PostFXManager::Settings::EnableDOF = "0";
+$PostFXManager::Settings::EnabledSSAO = "0";
+$PostFXManager::Settings::EnableHDR = "0";
+$PostFXManager::Settings::EnableLightRays = "0";
+$PostFXManager::Settings::EnablePostFX = "0";
 $PostFXManager::Settings::DOF::BlurCurveFar = "";
 $PostFXManager::Settings::DOF::BlurCurveNear = "";
 $PostFXManager::Settings::DOF::BlurMax = "";

--- a/Templates/Full/game/core/scripts/client/postFx/default.postfxpreset.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/default.postfxpreset.cs
@@ -20,6 +20,11 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
+$PostFXManager::Settings::EnableDOF = "0";
+$PostFXManager::Settings::EnabledSSAO = "0";
+$PostFXManager::Settings::EnableHDR = "0";
+$PostFXManager::Settings::EnableLightRays = "0";
+$PostFXManager::Settings::EnablePostFX = "0";
 $PostFXManager::Settings::DOF::BlurCurveFar = "";
 $PostFXManager::Settings::DOF::BlurCurveNear = "";
 $PostFXManager::Settings::DOF::BlurMax = "";


### PR DESCRIPTION
Fixes the PostFX defaults part of #806, but not the water effect issues, which are more severe (see #841).
