### PR TITLE
dynamic cubemapped statics

### DIFF
--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -90,6 +90,9 @@ ConsoleDocClass( TSStatic,
 );
 
 TSStatic::TSStatic()
+:
+   cubeDescId( 0 ),
+   reflectorDesc( NULL )
 {
    mNetFlags.set(Ghostable | ScopeAlways);
 
@@ -179,6 +182,11 @@ void TSStatic::initPersistFields()
          "Enables translucent sorting of the TSStatic by its origin instead of the bounds." );
 
    endGroup("Rendering");
+
+   addGroup( "Reflection" );
+      addField( "cubeReflectorDesc", TypeRealString, Offset( cubeDescName, TSStatic ), 
+         "References a ReflectorDesc datablock that defines performance and quality properties for dynamic reflections.\n");
+   endGroup( "Reflection" );
 
    addGroup("Collision");
 
@@ -279,6 +287,14 @@ bool TSStatic::onAdd()
 
    addToScene();
 
+   if ( isClientObject() )
+   {      
+      mCubeReflector.unregisterReflector();
+
+      if ( reflectorDesc )
+         mCubeReflector.registerReflector( this, reflectorDesc );      
+   }
+
    _updateShouldTick();
 
    return true;
@@ -336,6 +352,16 @@ bool TSStatic::_createShape()
 
    if ( mAmbientThread )
       mShapeInstance->setSequence( mAmbientThread, ambientSeq, 0);
+
+   // Resolve CubeReflectorDesc.
+   if ( cubeDescName.isNotEmpty() )
+   {
+      Sim::findObject( cubeDescName, reflectorDesc );
+   }
+   else if( cubeDescId > 0 )
+   {
+      Sim::findObject( cubeDescId, reflectorDesc );
+   }
 
    return true;
 }
@@ -402,6 +428,8 @@ void TSStatic::onRemove()
    mShapeInstance = NULL;
 
    mAmbientThread = NULL;
+   if ( isClientObject() )
+       mCubeReflector.unregisterReflector();
 
    Parent::onRemove();
 }
@@ -504,6 +532,12 @@ void TSStatic::prepRenderImage( SceneRenderState* state )
 
    F32 invScale = (1.0f/getMax(getMax(mObjScale.x,mObjScale.y),mObjScale.z));   
 
+   // If we're currently rendering our own reflection we
+   // don't want to render ourselves into it.
+   if ( mCubeReflector.isRendering() )
+      return;
+
+
    if ( mForceDetail == -1 )
       mShapeInstance->setDetailFromDistance( state, dist * invScale );
    else
@@ -519,6 +553,9 @@ void TSStatic::prepRenderImage( SceneRenderState* state )
    rdata.setSceneState( state );
    rdata.setFadeOverride( 1.0f );
    rdata.setOriginSort( mUseOriginSort );
+
+   if ( mCubeReflector.isEnabled() )
+      rdata.setCubemap( mCubeReflector.getCubemap() );
 
    // If we have submesh culling enabled then prepare
    // the object space frustum to pass to the shape.
@@ -543,6 +580,20 @@ void TSStatic::prepRenderImage( SceneRenderState* state )
    MatrixF mat = getRenderTransform();
    mat.scale( mObjScale );
    GFX->setWorldMatrix( mat );
+
+   if ( state->isDiffusePass() && mCubeReflector.isEnabled() && mCubeReflector.getOcclusionQuery() )
+   {
+       RenderPassManager *pass = state->getRenderPass();
+       OccluderRenderInst *ri = pass->allocInst<OccluderRenderInst>();  
+       
+       ri->type = RenderPassManager::RIT_Occluder;
+       ri->query = mCubeReflector.getOcclusionQuery();
+       mObjToWorld.mulP( mObjBox.getCenter(), &ri->position );
+       ri->scale.set( mObjBox.getExtents() );
+       ri->orientation = pass->allocUniqueXform( mObjToWorld ); 
+       ri->isSphere = false;
+       state->getRenderPass()->addInst( ri );
+   }
 
    mShapeInstance->animate();
    mShapeInstance->render( rdata );
@@ -628,6 +679,10 @@ U32 TSStatic::packUpdate(NetConnection *con, U32 mask, BitStream *stream)
    if ( mLightPlugin )
       retMask |= mLightPlugin->packUpdate(this, AdvancedStaticOptionsMask, con, mask, stream);
 
+   if( stream->writeFlag( reflectorDesc != NULL ) )
+   {
+      stream->writeRangedU32( reflectorDesc->getId(), DataBlockObjectIdFirst,  DataBlockObjectIdLast );
+   }
    return retMask;
 }
 
@@ -685,6 +740,11 @@ void TSStatic::unpackUpdate(NetConnection *con, BitStream *stream)
    if ( mLightPlugin )
    {
       mLightPlugin->unpackUpdate(this, con, stream);
+   }
+
+   if( stream->readFlag() )
+   {
+      cubeDescId = stream->readRangedU32( DataBlockObjectIdFirst, DataBlockObjectIdLast );
    }
 
    if ( isProperlyAdded() )

--- a/Engine/source/T3D/tsStatic.h
+++ b/Engine/source/T3D/tsStatic.h
@@ -39,6 +39,10 @@
 #include "ts/tsShape.h"
 #endif
 
+#ifndef _REFLECTOR_H_
+   #include "scene/reflector.h"
+#endif
+
 class TSShapeInstance;
 class TSThread;
 class TSStatic;
@@ -134,6 +138,11 @@ protected:
 
    /// Start or stop processing ticks depending on our state.
    void _updateShouldTick();
+
+   String cubeDescName;
+   U32 cubeDescId;
+   ReflectorDesc *reflectorDesc;
+   CubeReflector mCubeReflector;
 
 protected:
 

--- a/Templates/Full/game/art/datablocks/environment.cs
+++ b/Templates/Full/game/art/datablocks/environment.cs
@@ -84,3 +84,15 @@ datablock LightningData(DefaultStorm)
    thunderSounds[2] = ThunderCrash3Sound;
    thunderSounds[3] = ThunderCrash4Sound;
 };
+
+datablock ReflectorDesc( DefaultCubeDesc )
+{  
+   texSize = 256;
+   nearDist = 0.1;
+   farDist = 1000.0;
+   objectTypeMask = 0xFFFFFFFF;
+   detailAdjust = 1.0;
+   priority = 1.0;
+   maxRateMs = 15;
+   useOcclusionQuery = true;
+};


### PR DESCRIPTION
engine: implements the capacity for tsstatic objects to allow themselves to use the reflector system in order to display dynamic cubemaps.

script: defines a calibrated reflectordesc that reflects all object types within the space of approximately half stock veiwdistance
usage: cubeReflectorDesc = DefaultCubeDesc placed in a given object-insatnces entry that uses a material with a dynamiccubemap = true; flag.
immediate purpose: consistency of application of materials.
long term impact: tags steps required in order to associate a given runtime generated cubemap with an object-instance. in the future, this is likely to give way to an area cubemap, or a screenspace reflection.
