### PR TITLE
dxt5-based parallax support

### DIFF
--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -393,8 +393,7 @@ void ProcessedShaderMaterial::_determineFeatures(  U32 stageNum,
       // Only allow parallax if we have a normal map and
       // we're not using DXTnm compression.
       if (  mMaterial->mParallaxScale[stageNum] > 0.0f &&
-         fd.features[ MFT_NormalMap ] &&
-         !fd.features[ MFT_IsDXTnm ] )
+         fd.features[ MFT_NormalMap ] )
          fd.features.addFeature( MFT_Parallax );
 
       // If not parallax then allow per-pixel specular if

--- a/Engine/source/shaderGen/HLSL/bumpHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/bumpHLSL.cpp
@@ -345,8 +345,16 @@ void ParallaxFeatHLSL::processPix(  Vector<ShaderComponent*> &componentList,
    Var *normalMap = getNormalMapTex();
 
    // Call the library function to do the rest.
+   if(fd.features.hasFeature( MFT_IsDXTnm, getProcessIndex() ))
+   {
+      meta->addStatement( new GenOp( "   @.xy += parallaxOffsetDxtnm( @, @.xy, @, @ );\r\n", 
+         texCoord, normalMap, texCoord, negViewTS, parallaxInfo ) );
+   }
+   else
+   {
    meta->addStatement( new GenOp( "   @.xy += parallaxOffset( @, @.xy, @, @ );\r\n", 
       texCoord, normalMap, texCoord, negViewTS, parallaxInfo ) );
+   }
 
    // TODO: Fix second UV maybe?
 

--- a/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
+++ b/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
@@ -454,10 +454,18 @@ void TerrainDetailMapFeatHLSL::processPix(   Vector<ShaderComponent*> &component
    {
       // Get the rest of our inputs.
       Var *normalMap = _getNormalMapTex();
-
+      
       // Call the library function to do the rest.
-      meta->addStatement( new GenOp( "   @.xy += parallaxOffset( @, @.xy, @, @.z * @ );\r\n", 
-         inDet, normalMap, inDet, negViewTS, detailInfo, detailBlend ) );
+      if (fd.features.hasFeature(MFT_IsDXTnm, detailIndex))
+      {
+         meta->addStatement(new GenOp("   @.xy += parallaxOffsetDxtnm( @, @.xy, @, @.z * @ );\r\n",
+            inDet, normalMap, inDet, negViewTS, detailInfo, detailBlend));
+      }
+      else
+      {
+         meta->addStatement(new GenOp("   @.xy += parallaxOffset( @, @.xy, @, @.z * @ );\r\n",
+            inDet, normalMap, inDet, negViewTS, detailInfo, detailBlend));
+      }
    }
 
    // If this is a prepass then we skip color.

--- a/Templates/Empty/game/shaders/common/torque.hlsl
+++ b/Templates/Empty/game/shaders/common/torque.hlsl
@@ -151,6 +151,21 @@ float2 parallaxOffset( sampler2D texMap, float2 texCoord, float3 negViewTS, floa
    return offset;
 }
 
+/// Same as above but for dxt5nm where the deoth is stored in the red channel instead of the alpha
+float2 parallaxOffsetDxtnm(sampler2D texMap, float2 texCoord, float3 negViewTS, float depthScale)
+{
+   float depth = tex2D(texMap, texCoord).r;
+   float2 offset = negViewTS.xy * (depth * depthScale);
+
+   for (int i = 0; i < PARALLAX_REFINE_STEPS; i++)
+   {
+      depth = (depth + tex2D(texMap, texCoord + offset).r) * 0.5;
+      offset = negViewTS.xy * (depth * depthScale);
+   }
+
+   return offset;
+}
+
 
 /// The maximum value for 16bit per component integer HDR encoding.
 static const float HDR_RGB16_MAX = 100.0;


### PR DESCRIPTION
from @rextimmy
script (hlsl file):  defines a variant on parallaxOffset for use with dxt5 files, parallaxOffsetDxtnm
engine: when generating shaders, checks the material feature MFT_IsDXTnm to see if it is present in a given material definition. if so, it inserts a codeline into the shader referencing the above mentioned method instead of the former version.
immediate purpose: pretty much what it says on the tin.
long term purpose: @eightyeight brought up http://graphics.cs.brown.edu/games/SteepParallax/ as something we may want to look into. this tags the relevant area as well.
