### PR TITLE
defines a new RenderInstType RIT_DecalRoad;

### DIFF
--- a/Engine/source/environment/decalRoad.cpp
+++ b/Engine/source/environment/decalRoad.cpp
@@ -732,7 +732,7 @@ void DecalRoad::prepRenderImage( SceneRenderState* state )
    MathUtils::getZBiasProjectionMatrix( gDecalBias, frustum, tempMat );
    coreRI.projection = tempMat;
 
-   coreRI.type = RenderPassManager::RIT_Decal;
+   coreRI.type = RenderPassManager::RIT_DecalRoad;
    coreRI.vertBuff = &mVB;
    coreRI.primBuff = &mPB;
    coreRI.matInst = matInst;

--- a/Engine/source/renderInstance/renderBinManager.h
+++ b/Engine/source/renderInstance/renderBinManager.h
@@ -160,6 +160,7 @@ inline BaseMatInstance* RenderBinManager::getMaterial( RenderInst *inst ) const
 {
    if (  inst->type == RenderPassManager::RIT_Mesh || 
          inst->type == RenderPassManager::RIT_Decal ||
+         inst->type == RenderPassManager::RIT_DecalRoad ||         
          inst->type == RenderPassManager::RIT_Translucent )
       return static_cast<MeshRenderInst*>(inst)->matInst;
 

--- a/Engine/source/renderInstance/renderGlowMgr.cpp
+++ b/Engine/source/renderInstance/renderGlowMgr.cpp
@@ -88,6 +88,7 @@ RenderGlowMgr::RenderGlowMgr()
                                  Point2I( 512, 512 ) )
 {
    notifyType( RenderPassManager::RIT_Decal );
+   notifyType( RenderPassManager::RIT_DecalRoad );
    notifyType( RenderPassManager::RIT_Translucent );
 
    mNamedTarget.registerWithName( "glowbuffer" );

--- a/Engine/source/renderInstance/renderPassManager.cpp
+++ b/Engine/source/renderInstance/renderPassManager.cpp
@@ -51,6 +51,7 @@ const RenderInstType RenderPassManager::RIT_Terrain("Terrain");
 const RenderInstType RenderPassManager::RIT_Object("Object");      
 const RenderInstType RenderPassManager::RIT_ObjectTranslucent("ObjectTranslucent");
 const RenderInstType RenderPassManager::RIT_Decal("Decal");
+const RenderInstType RenderPassManager::RIT_DecalRoad("DecalRoad");
 const RenderInstType RenderPassManager::RIT_Water("Water");
 const RenderInstType RenderPassManager::RIT_Foliage("Foliage");
 const RenderInstType RenderPassManager::RIT_Translucent("Translucent");

--- a/Engine/source/renderInstance/renderPassManager.h
+++ b/Engine/source/renderInstance/renderPassManager.h
@@ -108,6 +108,7 @@ public:
    static const RenderInstType RIT_Object;   // objects that do their own rendering
    static const RenderInstType RIT_ObjectTranslucent;// self rendering; but sorted with static const RenderInstType RIT_Translucent
    static const RenderInstType RIT_Decal;
+   static const RenderInstType RIT_DecalRoad;
    static const RenderInstType RIT_Water;
    static const RenderInstType RIT_Foliage;
    static const RenderInstType RIT_Translucent;

--- a/Engine/source/renderInstance/renderPrePassMgr.cpp
+++ b/Engine/source/renderInstance/renderPrePassMgr.cpp
@@ -79,6 +79,7 @@ RenderPrePassMgr::RenderPrePassMgr( bool gatherDepth,
       mPrePassMatInstance( NULL )
 {
    notifyType( RenderPassManager::RIT_Decal );
+   notifyType( RenderPassManager::RIT_DecalRoad );
    notifyType( RenderPassManager::RIT_Mesh );
    notifyType( RenderPassManager::RIT_Terrain );
    notifyType( RenderPassManager::RIT_Object );
@@ -191,7 +192,7 @@ void RenderPrePassMgr::addElement( RenderInst *inst )
       return;
 
    // First what type of render instance is it?
-   const bool isDecalMeshInst = inst->type == RenderPassManager::RIT_Decal;
+   const bool isDecalMeshInst = ((inst->type == RenderPassManager::RIT_Decal)||(inst->type == RenderPassManager::RIT_DecalRoad));
 
    const bool isMeshInst = inst->type == RenderPassManager::RIT_Mesh;
 

--- a/Templates/Full/game/core/scripts/client/renderManager.cs
+++ b/Templates/Full/game/core/scripts/client/renderManager.cs
@@ -62,6 +62,8 @@ function initRenderManager()
      
    DiffuseRenderPassManager.addManager( new RenderObjectMgr()              { bintype = "Shadow"; renderOrder = 0.7; processAddOrder = 0.7; } );
    DiffuseRenderPassManager.addManager( new RenderMeshMgr()                { bintype = "Decal"; renderOrder = 0.8; processAddOrder = 0.8; } );
+   DiffuseRenderPassManager.addManager( new RenderMeshMgr()                { bintype = "DecalRoad"; renderOrder = 0.8; processAddOrder = 0.8; basicOnly = true; } );
+   DiffuseRenderPassManager.addManager( new RenderMeshMgr()                { bintype = "Decal"; renderOrder = 0.81; processAddOrder = 0.81; } );
    DiffuseRenderPassManager.addManager( new RenderOcclusionMgr()           { bintype = "Occluder"; renderOrder = 0.9; processAddOrder = 0.9; } );
      
    // We now render translucent objects that should handle


### PR DESCRIPTION
engine:
renderPassManager.h - definition
renderPassManager.cpp - reference string
script:
\game\core\scripts\client\renderManager.cs - controls the rendering order of object types.
immediate purpose: provides a render sorting mechanism specific to decal roads.
long term impact: includes a basiconly flag used by deferred shading to denote that this will only be rendered using the basic lighting functionality, as opposed to the higher-order advanced lighting mechanisms.
