### PR TITLE
New Physics doc group

### DIFF
--- a/Engine/source/T3D/rigidShape.cpp
+++ b/Engine/source/T3D/rigidShape.cpp
@@ -92,7 +92,7 @@ ConsoleDocClass( RigidShapeData,
    "@see RigidShape\n"
    "@see ShapeBase\n\n"
 
-   "@ingroup Platform\n"
+   "@ingroup Physics\n"
 );
 
 
@@ -149,7 +149,7 @@ ConsoleDocClass( RigidShape,
    "@see RigidShapeData\n"
    "@see ShapeBase\n\n"
    
-   "@ingroup Platform\n"
+   "@ingroup Physics\n"
 );
 
 


### PR DESCRIPTION
For #765. Because this makes more sense. TODO: add more classes to the physics group, like the physics abstraction classes, which are currently not in any group.
