### PR TITLE
basiconly lighting subsystem bifurcation flag

### DIFF
--- a/Engine/source/renderInstance/renderBinManager.cpp
+++ b/Engine/source/renderInstance/renderBinManager.cpp
@@ -36,7 +36,8 @@ RenderBinManager::RenderBinManager( const RenderInstType& ritype, F32 renderOrde
    mRenderInstType( ritype ),
    mRenderOrder( renderOrder ),
    mProcessAddOrder( processAddOrder ),
-   mRenderPass( NULL )
+   mRenderPass( NULL ),
+   mBasicOnly ( false )
 {
    VECTOR_SET_ASSOCIATION( mElementList );
    mElementList.reserve( 2048 );
@@ -59,6 +60,9 @@ void RenderBinManager::initPersistFields()
 
    addField("processAddOrder", TypeF32, Offset(mProcessAddOrder, RenderBinManager),
       "Defines the order for adding instances in relation to other bins." );
+
+   addField( "basicOnly", TypeBool, Offset(mBasicOnly, RenderBinManager),
+      "Limites the render bin to basic lighting only." );
 
    Parent::initPersistFields();
 }

--- a/Engine/source/renderInstance/renderBinManager.h
+++ b/Engine/source/renderInstance/renderBinManager.h
@@ -128,6 +128,8 @@ protected:
    /// RenderInst if available, otherwise, return NULL.
    inline BaseMatInstance* getMaterial( RenderInst *inst ) const;
 
+   // Limits bin to rendering in basic lighting only.
+   bool mBasicOnly;
 };
 
 

--- a/Engine/source/renderInstance/renderMeshMgr.cpp
+++ b/Engine/source/renderInstance/renderMeshMgr.cpp
@@ -100,6 +100,9 @@ void RenderMeshMgr::render(SceneRenderState * state)
    if(!mElementList.size())
       return;
 
+   // Check if bin is disabled in advanced lighting.
+   if ( MATMGR->getPrePassEnabled() && mBasicOnly )
+      return;
 
    GFXDEBUGEVENT_SCOPE( RenderMeshMgr_Render, ColorI::GREEN );
 

--- a/Engine/source/renderInstance/renderObjectMgr.cpp
+++ b/Engine/source/renderInstance/renderObjectMgr.cpp
@@ -22,6 +22,8 @@
 #include "renderObjectMgr.h"
 #include "console/consoleTypes.h"
 #include "scene/sceneObject.h"
+#include "materials/materialManager.h"
+#include "scene/sceneRenderState.h"
 
 IMPLEMENT_CONOBJECT(RenderObjectMgr);
 
@@ -64,6 +66,10 @@ void RenderObjectMgr::render( SceneRenderState *state )
 
    // Early out if nothing to draw.
    if(!mElementList.size())
+      return;
+
+   // Check if bin is disabled in advanced lighting.
+   if ( MATMGR->getPrePassEnabled() && mBasicOnly )
       return;
 
    for( U32 i=0; i<mElementList.size(); i++ )

--- a/Engine/source/renderInstance/renderTerrainMgr.cpp
+++ b/Engine/source/renderInstance/renderTerrainMgr.cpp
@@ -35,6 +35,7 @@
 #include "terrain/terrCell.h"
 #include "terrain/terrCellMaterial.h"
 #include "math/util/matrixSet.h"
+#include "materials/materialManager.h"
 
 bool RenderTerrainMgr::smRenderWireframe = false;
 
@@ -115,6 +116,10 @@ void RenderTerrainMgr::clear()
 void RenderTerrainMgr::render( SceneRenderState *state )
 {
    if ( mInstVector.empty() )
+      return;
+
+   // Check if bin is disabled in advanced lighting.
+   if ( MATMGR->getPrePassEnabled() && mBasicOnly )
       return;
 
    PROFILE_SCOPE( RenderTerrainMgr_Render );

--- a/Templates/Full/game/core/scripts/client/renderManager.cs
+++ b/Templates/Full/game/core/scripts/client/renderManager.cs
@@ -55,13 +55,14 @@ function initRenderManager()
    
    DiffuseRenderPassManager.addManager( new RenderObjectMgr()              { bintype = "Begin"; renderOrder = 0.2; processAddOrder = 0.2; } );
    // Normal mesh rendering.
-   DiffuseRenderPassManager.addManager( new RenderTerrainMgr()             { renderOrder = 0.4; processAddOrder = 0.4; } );
-   DiffuseRenderPassManager.addManager( new RenderMeshMgr()                { bintype = "Mesh"; renderOrder = 0.5; processAddOrder = 0.5; } );
-   DiffuseRenderPassManager.addManager( new RenderImposterMgr()            { renderOrder = 0.56; processAddOrder = 0.56; } );
+   DiffuseRenderPassManager.addManager( new RenderTerrainMgr()             { renderOrder = 0.4; processAddOrder = 0.4; basicOnly = true; } );
+   DiffuseRenderPassManager.addManager( new RenderMeshMgr()                { bintype = "Mesh"; renderOrder = 0.5; processAddOrder = 0.5; basicOnly = true; } );
+   DiffuseRenderPassManager.addManager( new RenderImposterMgr()            { renderOrder = 0.56; processAddOrder = 0.56; basicOnly = true; } );
    DiffuseRenderPassManager.addManager( new RenderObjectMgr()              { bintype = "Object"; renderOrder = 0.6; processAddOrder = 0.6; } );
      
    DiffuseRenderPassManager.addManager( new RenderObjectMgr()              { bintype = "Shadow"; renderOrder = 0.7; processAddOrder = 0.7; } );
-   DiffuseRenderPassManager.addManager( new RenderMeshMgr()                { bintype = "Decal"; renderOrder = 0.8; processAddOrder = 0.8; } );
+   DiffuseRenderPassManager.addManager( new RenderMeshMgr()                { bintype = "DecalRoad"; renderOrder = 0.8; processAddOrder = 0.8; basicOnly = true; } );
+   DiffuseRenderPassManager.addManager( new RenderMeshMgr()                { bintype = "Decal"; renderOrder = 0.81; processAddOrder = 0.81; } );
    DiffuseRenderPassManager.addManager( new RenderOcclusionMgr()           { bintype = "Occluder"; renderOrder = 0.9; processAddOrder = 0.9; } );
      
    // We now render translucent objects that should handle


### PR DESCRIPTION
engine: creates and exposes a basicOnly flag, as well as early outs in relevant spots.

script: the rest of the basicoly denotations from the prior PR

immediate purpose: The basiconly flag referenced in https://github.com/GarageGames/Torque3D/pull/858

long term impact: strictly speaking, this one is only of true beneficial use for deferred shading.

Again, used to denote rendering objects which bypass the higher order lighting subsystems.
