### PR TITLE
banding corrections.

### DIFF
--- a/Engine/source/lighting/advanced/advancedLightManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightManager.cpp
@@ -99,7 +99,7 @@ void AdvancedLightManager::activate( SceneManager *sceneManager )
    // we prefer the floating point format if it works.
    Vector<GFXFormat> formats;
    formats.push_back( GFXFormatR16G16B16A16F );
-   formats.push_back( GFXFormatR16G16B16A16 );
+   //formats.push_back( GFXFormatR16G16B16A16 );
    GFXFormat blendTargetFormat = GFX->selectSupportedFormat( &GFXDefaultRenderTargetProfile,
                                                          formats,
                                                          true,

--- a/Templates/Full/game/core/scripts/client/renderManager.cs
+++ b/Templates/Full/game/core/scripts/client/renderManager.cs
@@ -33,7 +33,7 @@ function initRenderManager()
    {
       enabled = "false";
       
-      format = "GFXFormatR8G8B8A8";
+      format = "GFXFormatR16G16B16A16F";
       depthFormat = "GFXFormatD24S8";
       aaLevel = 0; // -1 = match backbuffer
       

--- a/Templates/Full/game/shaders/common/gl/scatterSkyP.glsl
+++ b/Templates/Full/game/shaders/common/gl/scatterSkyP.glsl
@@ -71,5 +71,8 @@ void main()
       discard;
 
    OUT_FragColor0.a = 1;
+
+   OUT_FragColor0 = clamp(OUT_FragColor0, 0.0, 1.0);
+
    OUT_FragColor0 = hdrEncode( OUT_FragColor0 );
 }

--- a/Templates/Full/game/shaders/common/scatterSkyP.hlsl
+++ b/Templates/Full/game/shaders/common/scatterSkyP.hlsl
@@ -62,6 +62,6 @@ float4 main( Conn In ) : COLOR0
    Out = lerp( color, nightSkyColor, nightInterpAndExposure.y );
    
    Out.a = 1;
-
+   Out = saturate(Out);
    return hdrEncode( Out );
 }


### PR DESCRIPTION
script
rendermanager.cs- Like it says at the bottom of the file, PFX_PassthruShader is just that, a bottleneck through which all shaders run. The end result of that is that the lighting buffer, which at a minimum uses 16RBG becomes downsampled and bands. Steps were taken with stock torque to mitigate that, but with linearization incoming, the effect is exacerbated.
script(hlsl/glsl) - the saturate command (clamp in glsl) ensures the results fall into a 0-1 range (you'd get a black circle in the center of the sun otherwise)

source: simplification

immediate purpose - slightly noticeable smoothing of light banding with heavily bright lights in extremely dark environments

long term impact - shuts off a future issue with corrected lighting calculations.
