### PR TITLE
Enable gamepad input when the startup GUI wakes

### DIFF
--- a/Templates/Empty/game/scripts/gui/startupGui.cs
+++ b/Templates/Empty/game/scripts/gui/startupGui.cs
@@ -45,6 +45,12 @@ function loadStartup()
    //SFXPlayOnce(AudioGui, "art/sound/gui/startup");//SFXPlay(startsnd);
 }
 
+function StartupGui::onWake(%this)
+{
+   $enableDirectInput = "1";
+   activateDirectInput();
+}
+
 function StartupGui::click(%this)
 {
    %this.done = true;

--- a/Templates/Full/game/scripts/gui/startupGui.cs
+++ b/Templates/Full/game/scripts/gui/startupGui.cs
@@ -45,6 +45,12 @@ function loadStartup()
    //SFXPlayOnce(AudioGui, "art/sound/gui/startup");//SFXPlay(startsnd);
 }
 
+function StartupGui::onWake(%this)
+{
+   $enableDirectInput = "1";
+   activateDirectInput();
+}
+
 function StartupGui::click(%this)
 {
    %this.done = true;


### PR DESCRIPTION
Fixes #262. The existing calls in `PlayGui::onWake` were left in as it's possible the splash screen GUI might be skipped, so in those cases we rely on the `PlayGui` to enable inputs.
