### PR TITLE
Reduce minimum tab width in PostFX manager

### DIFF
--- a/Templates/Empty/game/core/scripts/client/postFx/postFXManager.gui
+++ b/Templates/Empty/game/core/scripts/client/postFx/postFXManager.gui
@@ -78,7 +78,7 @@
       new GuiTabBookCtrl(ppOptionsTabBook) {
          tabPosition = "Top";
          tabMargin = "7";
-         minTabWidth = "64";
+         minTabWidth = "32";
          tabHeight = "20";
          allowReorder = "0";
          defaultPage = "-1";

--- a/Templates/Full/game/core/scripts/client/postFx/postFXManager.gui
+++ b/Templates/Full/game/core/scripts/client/postFx/postFXManager.gui
@@ -78,7 +78,7 @@
       new GuiTabBookCtrl(ppOptionsTabBook) {
          tabPosition = "Top";
          tabMargin = "7";
-         minTabWidth = "64";
+         minTabWidth = "32";
          tabHeight = "20";
          allowReorder = "0";
          defaultPage = "-1";


### PR DESCRIPTION
#761 added another tab to the PostFX manager GUI, which resulted in the tab list becoming too wide. This is because the default minimum width of 64 makes some tabs much wider than their actual text content. This patch reduces the minimum width to 32, allowing some tabs to shrink to fit their text, and allowing all tabs to remain in the same line.
