### PR TITLE
Remove GFXDevice::disableShader

### DIFF
--- a/Engine/source/gfx/D3D9/gfxD3D9Device.h
+++ b/Engine/source/gfx/D3D9/gfxD3D9Device.h
@@ -238,6 +238,7 @@ protected:
    // }
 
    virtual GFXShader* createShader();
+   void disableShaders();
 
    /// Device helper function
    virtual D3DPRESENT_PARAMETERS setupPresentParams( const GFXVideoMode &mode, const HWND &hwnd ) const = 0;
@@ -271,7 +272,6 @@ public:
 
    virtual F32  getPixelShaderVersion() const { return mPixVersion; }
    virtual void setPixelShaderVersion( F32 version ){ mPixVersion = version; }
-   virtual void disableShaders();
    virtual void setShader( GFXShader *shader );
    virtual U32  getNumSamplers() const { return mNumSamplers; }
    virtual U32  getNumRenderTargets() const { return mNumRenderTargets; }

--- a/Engine/source/gfx/gl/gfxGLDevice.h
+++ b/Engine/source/gfx/gl/gfxGLDevice.h
@@ -90,7 +90,6 @@ public:
    virtual void  setPixelShaderVersion( F32 version ) { mPixelShaderVersion = version; }
    
    virtual void setShader(GFXShader* shd);
-   virtual void disableShaders(); ///< Equivalent to setShader(NULL)
    
    /// @attention GL cannot check if the given format supports blending or filtering!
    virtual GFXFormat selectSupportedFormat(GFXTextureProfile *profile,


### PR DESCRIPTION
Remove GFXDevice::disableShader becouse we are going to remove Fixed Function Pipeline and we need a shader for render.
