### PR TITLE
Change RenderParticleMgr for use sampler names

### DIFF
--- a/Engine/source/renderInstance/renderParticleMgr.cpp
+++ b/Engine/source/renderInstance/renderParticleMgr.cpp
@@ -438,13 +438,13 @@ void RenderParticleMgr::renderInstance(ParticleRenderInst *ri, SceneRenderState 
       GFX->setShader( mParticleShader );
       GFX->setShaderConstBuffer( mParticleShaderConsts.mShaderConsts );
 
-      GFX->setTexture( 0, ri->diffuseTex );
+      GFX->setTexture( mParticleShaderConsts.mSamplerDiffuse->getSamplerRegister(), ri->diffuseTex );
 
       // Set up the prepass texture.
       if ( mParticleShaderConsts.mPrePassTargetParamsSC->isValid() )
       {
          GFXTextureObject *texObject = mPrepassTarget ? mPrepassTarget->getTexture(0) : NULL;
-         GFX->setTexture( 1, texObject );
+         GFX->setTexture( mParticleShaderConsts.mSamplerPrePassTex->getSamplerRegister(), texObject );
 
          Point4F rtParams( 0.0f, 0.0f, 1.0f, 1.0f );
          if ( texObject )
@@ -477,7 +477,7 @@ void RenderParticleMgr::renderInstance(ParticleRenderInst *ri, SceneRenderState 
       // Set offscreen texture
       Point4F rtParams;
       GFXTextureObject *particleSource = mNamedTarget.getTexture();
-      GFX->setTexture( 0, particleSource );
+      GFX->setTexture( mParticleCompositeShaderConsts.mSamplerColorSource->getSamplerRegister(), particleSource );
       if(particleSource)
       {
          ScreenSpace::RenderTargetParameters(particleSource->getSize(), mNamedTarget.getViewport(), rtParams);
@@ -486,7 +486,7 @@ void RenderParticleMgr::renderInstance(ParticleRenderInst *ri, SceneRenderState 
 
       // And edges
       GFXTextureObject *texObject = mEdgeTarget ? mEdgeTarget->getTexture() : NULL;
-      GFX->setTexture( 1, texObject );
+      GFX->setTexture( mParticleCompositeShaderConsts.mSamplerEdgeSource->getSamplerRegister(), texObject );
       if(texObject)
       {
          ScreenSpace::RenderTargetParameters(texObject->getSize(), mEdgeTarget->getViewport(), rtParams);
@@ -557,6 +557,11 @@ bool RenderParticleMgr::_initShader()
       mParticleShaderConsts.mAlphaScaleSC = mParticleShader->getShaderConstHandle( "$alphaScale" );
       mParticleShaderConsts.mFSModelViewProjSC = mParticleShader->getShaderConstHandle( "$fsModelViewProj" );
       mParticleShaderConsts.mPrePassTargetParamsSC = mParticleShader->getShaderConstHandle( "$prePassTargetParams" );
+
+      //samplers
+      mParticleShaderConsts.mSamplerDiffuse = mParticleShader->getShaderConstHandle("$diffuseMap");
+      mParticleShaderConsts.mSamplerPrePassTex = mParticleShader->getShaderConstHandle("$prepassTex");
+      mParticleShaderConsts.mSamplerParaboloidLightMap = mParticleShader->getShaderConstHandle("$paraboloidLightMap");
    }
 
    shaderData = NULL;
@@ -572,6 +577,8 @@ bool RenderParticleMgr::_initShader()
    {
       mParticleCompositeShaderConsts.mShaderConsts = mParticleCompositeShader->allocConstBuffer();
       mParticleCompositeShaderConsts.mScreenRect = mParticleCompositeShader->getShaderConstHandle( "$screenRect" );
+      mParticleCompositeShaderConsts.mSamplerColorSource = mParticleCompositeShader->getShaderConstHandle( "$colorSource" );
+      mParticleCompositeShaderConsts.mSamplerEdgeSource = mParticleCompositeShader->getShaderConstHandle( "$edgeSource" );
       mParticleCompositeShaderConsts.mEdgeTargetParamsSC = mParticleCompositeShader->getShaderConstHandle( "$edgeTargetParams" );
       mParticleCompositeShaderConsts.mOffscreenTargetParamsSC = mParticleCompositeShader->getShaderConstHandle( "$offscreenTargetParams" );
    }

--- a/Engine/source/renderInstance/renderParticleMgr.h
+++ b/Engine/source/renderInstance/renderParticleMgr.h
@@ -110,6 +110,9 @@ protected:
       GFXShaderConstHandle *mPrePassTargetParamsSC;
       GFXShaderConstHandle *mAlphaFactorSC;
       GFXShaderConstHandle *mAlphaScaleSC;
+      GFXShaderConstHandle *mSamplerDiffuse;
+      GFXShaderConstHandle *mSamplerPrePassTex;
+      GFXShaderConstHandle *mSamplerParaboloidLightMap;
 
    } mParticleShaderConsts;
 
@@ -118,6 +121,8 @@ protected:
       GFXShaderConstBufferRef mShaderConsts;
       GFXShaderConstHandle *mSystemDepth;
       GFXShaderConstHandle *mScreenRect;
+      GFXShaderConstHandle *mSamplerColorSource;
+      GFXShaderConstHandle *mSamplerEdgeSource;
       GFXShaderConstHandle *mEdgeTargetParamsSC;
       GFXShaderConstHandle *mOffscreenTargetParamsSC;
    } mParticleCompositeShaderConsts;


### PR DESCRIPTION
Change RenderParticleMgr for use sampler names instead of harcoded locations for allow OpenGL.
