### PR TITLE
Postfx shutoffs

### DIFF
--- a/Templates/Empty/game/core/scripts/client/defaults.cs
+++ b/Templates/Empty/game/core/scripts/client/defaults.cs
@@ -333,7 +333,7 @@ new SimGroup( TextureQualityGroup )
       key["$pref::Video::textureReductionLevel"] = 0;
       key["$pref::Reflect::refractTexScale"] = 1.25;
       key["$pref::Terrain::detailScale"] = 1.5;      
-   };   
+   };
 };
 
 function TextureQualityGroup::onApply( %this, %level )
@@ -443,7 +443,7 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disableParallaxMapping"] = false;   
       key["$pref::Water::disableTrueReflections"] = false;   
       key["$pref::Video::disableSSAO"] = true;
-      key["$pref::Video::disableHDR"] = false;
+      key["$pref::Video::disableHDR"] = true;
       key["$pref::Video::disableVignette"] = false;
       key["$pref::Video::disableDOF"] = false;
       key["$pref::Video::disableLightRays"] = false;
@@ -458,12 +458,27 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disableNormalmapping"] = false;
       key["$pref::Video::disableParallaxMapping"] = false;     
       key["$pref::Water::disableTrueReflections"] = false; 
+      key["$pref::Video::disableSSAO"] = true;
+      key["$pref::Video::disableHDR"] = false;
+      key["$pref::Video::disableVignette"] = false;
+      key["$pref::Video::disableDOF"] = false;
+      key["$pref::Video::disableLightRays"] = false;
+   };
+   new ArrayObject( [Highest] )
+   {
+      class = "GraphicsQualityLevel";
+      caseSensitive = true;
+      
+      key["$pref::Video::disablePixSpecular"] = false;
+      key["$pref::Video::disableNormalmapping"] = false;
+      key["$pref::Video::disableParallaxMapping"] = false;     
+      key["$pref::Water::disableTrueReflections"] = false; 
       key["$pref::Video::disableSSAO"] = false;
       key["$pref::Video::disableHDR"] = false;
       key["$pref::Video::disableVignette"] = false;
       key["$pref::Video::disableDOF"] = false;
       key["$pref::Video::disableLightRays"] = false;
-   };   
+   };
 };
 
 function ShaderQualityGroup::onApply( %this, %level )

--- a/Templates/Empty/game/core/scripts/client/defaults.cs
+++ b/Templates/Empty/game/core/scripts/client/defaults.cs
@@ -72,6 +72,12 @@ $pref::Video::disableCubemapping = false;
 ///
 $pref::Video::disableParallaxMapping = false;
 
+$pref::Video::disableSSAO = false;
+$pref::Video::disableHDR = false;
+$pref::Video::disableLightRays = false;
+$pref::Video::disableDOF = false;
+$pref::Video::disableVignette = false;
+
 $pref::Video::Gamma = 1.0;
 
 // Console-friendly defaults
@@ -404,6 +410,11 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disableNormalmapping"] = true;
       key["$pref::Video::disableParallaxMapping"] = true;
       key["$pref::Water::disableTrueReflections"] = true;
+      key["$pref::Video::disableSSAO"] = true;
+      key["$pref::Video::disableHDR"] = true;
+      key["$pref::Video::disableVignette"] = true;
+      key["$pref::Video::disableDOF"] = true;
+      key["$pref::Video::disableLightRays"] = true;
    };
    
    new ArrayObject( [Low] )
@@ -414,7 +425,12 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disablePixSpecular"] = false;
       key["$pref::Video::disableNormalmapping"] = false;
       key["$pref::Video::disableParallaxMapping"] = true;
-      key["$pref::Water::disableTrueReflections"] = true;
+      key["$pref::Water::disableTrueReflections"] = true; 
+      key["$pref::Video::disableSSAO"] = true;
+      key["$pref::Video::disableHDR"] = true;
+      key["$pref::Video::disableVignette"] = false;
+      key["$pref::Video::disableDOF"] = false;
+      key["$pref::Video::disableLightRays"] = false;
    };
    
    new ArrayObject( [Normal] )
@@ -426,6 +442,11 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disableNormalmapping"] = false;
       key["$pref::Video::disableParallaxMapping"] = false;   
       key["$pref::Water::disableTrueReflections"] = false;   
+      key["$pref::Video::disableSSAO"] = true;
+      key["$pref::Video::disableHDR"] = false;
+      key["$pref::Video::disableVignette"] = false;
+      key["$pref::Video::disableDOF"] = false;
+      key["$pref::Video::disableLightRays"] = false;
    };
    
    new ArrayObject( [High] )
@@ -436,11 +457,19 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disablePixSpecular"] = false;
       key["$pref::Video::disableNormalmapping"] = false;
       key["$pref::Video::disableParallaxMapping"] = false;     
-      key["$pref::Water::disableTrueReflections"] = false;          
+      key["$pref::Water::disableTrueReflections"] = false; 
+      key["$pref::Video::disableSSAO"] = false;
+      key["$pref::Video::disableHDR"] = false;
+      key["$pref::Video::disableVignette"] = false;
+      key["$pref::Video::disableDOF"] = false;
+      key["$pref::Video::disableLightRays"] = false;
    };   
 };
 
-
+function ShaderQualityGroup::onApply( %this, %level )
+{
+   PostFXManager.settingsSetEnabled(true);
+}
 function GraphicsQualityAutodetect()
 {
    $pref::Video::autoDetect = false;

--- a/Templates/Empty/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
@@ -25,33 +25,33 @@ $PostFXManager::defaultPreset  = "core/scripts/client/postFx/default.postfxprese
 function PostFXManager::settingsSetEnabled(%this, %bEnablePostFX)
 {
    $PostFXManager::PostFX::Enabled = %bEnablePostFX;
-   
+      
    //if to enable the postFX, apply the ones that are enabled
    if ( %bEnablePostFX )
    {
       //SSAO, HDR, LightRays, DOF
       
-      if ( $PostFXManager::PostFX::EnableSSAO )      
+      if ( $PostFXManager::PostFX::EnableSSAO && !$pref::Video::disableSSAO)
          SSAOPostFx.enable();      
       else
          SSAOPostFx.disable();
       
-      if ( $PostFXManager::PostFX::EnableHDR )
+      if ( $PostFXManager::PostFX::EnableHDR && !$pref::Video::disableHDR)
          HDRPostFX.enable();
       else
          HDRPostFX.disable();
 
-      if ( $PostFXManager::PostFX::EnableLightRays )
+      if ( $PostFXManager::PostFX::EnableLightRays && !$pref::Video::disableLightRays)
          LightRayPostFX.enable();
       else
          LightRayPostFX.disable();
       
-      if ( $PostFXManager::PostFX::EnableDOF )
+      if ( $PostFXManager::PostFX::EnableDOF && !$pref::Video::disableDOF)
          DOFPostEffect.enable();
       else
          DOFPostEffect.disable();
 		 
-      if ( $PostFXManager::PostFX::EnableVignette )
+      if ( $PostFXManager::PostFX::EnableVignette && !$pref::Video::disableVignette)
          VignettePostEffect.enable();
       else
          VignettePostEffect.disable();

--- a/Templates/Full/game/core/scripts/client/defaults.cs
+++ b/Templates/Full/game/core/scripts/client/defaults.cs
@@ -333,7 +333,7 @@ new SimGroup( TextureQualityGroup )
       key["$pref::Video::textureReductionLevel"] = 0;
       key["$pref::Reflect::refractTexScale"] = 1.25;
       key["$pref::Terrain::detailScale"] = 1.5;      
-   };   
+   };
 };
 
 function TextureQualityGroup::onApply( %this, %level )
@@ -443,7 +443,7 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disableParallaxMapping"] = false;   
       key["$pref::Water::disableTrueReflections"] = false;   
       key["$pref::Video::disableSSAO"] = true;
-      key["$pref::Video::disableHDR"] = false;
+      key["$pref::Video::disableHDR"] = true;
       key["$pref::Video::disableVignette"] = false;
       key["$pref::Video::disableDOF"] = false;
       key["$pref::Video::disableLightRays"] = false;
@@ -458,12 +458,27 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disableNormalmapping"] = false;
       key["$pref::Video::disableParallaxMapping"] = false;     
       key["$pref::Water::disableTrueReflections"] = false; 
+      key["$pref::Video::disableSSAO"] = true;
+      key["$pref::Video::disableHDR"] = false;
+      key["$pref::Video::disableVignette"] = false;
+      key["$pref::Video::disableDOF"] = false;
+      key["$pref::Video::disableLightRays"] = false;
+   };
+   new ArrayObject( [Highest] )
+   {
+      class = "GraphicsQualityLevel";
+      caseSensitive = true;
+      
+      key["$pref::Video::disablePixSpecular"] = false;
+      key["$pref::Video::disableNormalmapping"] = false;
+      key["$pref::Video::disableParallaxMapping"] = false;     
+      key["$pref::Water::disableTrueReflections"] = false; 
       key["$pref::Video::disableSSAO"] = false;
       key["$pref::Video::disableHDR"] = false;
       key["$pref::Video::disableVignette"] = false;
       key["$pref::Video::disableDOF"] = false;
       key["$pref::Video::disableLightRays"] = false;
-   };   
+   };
 };
 
 function ShaderQualityGroup::onApply( %this, %level )

--- a/Templates/Full/game/core/scripts/client/defaults.cs
+++ b/Templates/Full/game/core/scripts/client/defaults.cs
@@ -72,6 +72,12 @@ $pref::Video::disableCubemapping = false;
 ///
 $pref::Video::disableParallaxMapping = false;
 
+$pref::Video::disableSSAO = false;
+$pref::Video::disableHDR = false;
+$pref::Video::disableLightRays = false;
+$pref::Video::disableDOF = false;
+$pref::Video::disableVignette = false;
+
 $pref::Video::Gamma = 1.0;
 
 // Console-friendly defaults
@@ -404,6 +410,11 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disableNormalmapping"] = true;
       key["$pref::Video::disableParallaxMapping"] = true;
       key["$pref::Water::disableTrueReflections"] = true;
+      key["$pref::Video::disableSSAO"] = true;
+      key["$pref::Video::disableHDR"] = true;
+      key["$pref::Video::disableVignette"] = true;
+      key["$pref::Video::disableDOF"] = true;
+      key["$pref::Video::disableLightRays"] = true;
    };
    
    new ArrayObject( [Low] )
@@ -414,7 +425,12 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disablePixSpecular"] = false;
       key["$pref::Video::disableNormalmapping"] = false;
       key["$pref::Video::disableParallaxMapping"] = true;
-      key["$pref::Water::disableTrueReflections"] = true;
+      key["$pref::Water::disableTrueReflections"] = true; 
+      key["$pref::Video::disableSSAO"] = true;
+      key["$pref::Video::disableHDR"] = true;
+      key["$pref::Video::disableVignette"] = false;
+      key["$pref::Video::disableDOF"] = false;
+      key["$pref::Video::disableLightRays"] = false;
    };
    
    new ArrayObject( [Normal] )
@@ -426,6 +442,11 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disableNormalmapping"] = false;
       key["$pref::Video::disableParallaxMapping"] = false;   
       key["$pref::Water::disableTrueReflections"] = false;   
+      key["$pref::Video::disableSSAO"] = true;
+      key["$pref::Video::disableHDR"] = false;
+      key["$pref::Video::disableVignette"] = false;
+      key["$pref::Video::disableDOF"] = false;
+      key["$pref::Video::disableLightRays"] = false;
    };
    
    new ArrayObject( [High] )
@@ -436,11 +457,19 @@ new SimGroup( ShaderQualityGroup )
       key["$pref::Video::disablePixSpecular"] = false;
       key["$pref::Video::disableNormalmapping"] = false;
       key["$pref::Video::disableParallaxMapping"] = false;     
-      key["$pref::Water::disableTrueReflections"] = false;          
+      key["$pref::Water::disableTrueReflections"] = false; 
+      key["$pref::Video::disableSSAO"] = false;
+      key["$pref::Video::disableHDR"] = false;
+      key["$pref::Video::disableVignette"] = false;
+      key["$pref::Video::disableDOF"] = false;
+      key["$pref::Video::disableLightRays"] = false;
    };   
 };
 
-
+function ShaderQualityGroup::onApply( %this, %level )
+{
+   PostFXManager.settingsSetEnabled(true);
+}
 function GraphicsQualityAutodetect()
 {
    $pref::Video::autoDetect = false;

--- a/Templates/Full/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
@@ -25,33 +25,33 @@ $PostFXManager::defaultPreset  = "core/scripts/client/postFx/default.postfxprese
 function PostFXManager::settingsSetEnabled(%this, %bEnablePostFX)
 {
    $PostFXManager::PostFX::Enabled = %bEnablePostFX;
-   
+      
    //if to enable the postFX, apply the ones that are enabled
    if ( %bEnablePostFX )
    {
       //SSAO, HDR, LightRays, DOF
       
-      if ( $PostFXManager::PostFX::EnableSSAO )      
+      if ( $PostFXManager::PostFX::EnableSSAO && !$pref::Video::disableSSAO)
          SSAOPostFx.enable();      
       else
          SSAOPostFx.disable();
       
-      if ( $PostFXManager::PostFX::EnableHDR )
+      if ( $PostFXManager::PostFX::EnableHDR && !$pref::Video::disableHDR)
          HDRPostFX.enable();
       else
          HDRPostFX.disable();
 
-      if ( $PostFXManager::PostFX::EnableLightRays )
+      if ( $PostFXManager::PostFX::EnableLightRays && !$pref::Video::disableLightRays)
          LightRayPostFX.enable();
       else
          LightRayPostFX.disable();
       
-      if ( $PostFXManager::PostFX::EnableDOF )
+      if ( $PostFXManager::PostFX::EnableDOF && !$pref::Video::disableDOF)
          DOFPostEffect.enable();
       else
          DOFPostEffect.disable();
 		 
-      if ( $PostFXManager::PostFX::EnableVignette )
+      if ( $PostFXManager::PostFX::EnableVignette && !$pref::Video::disableVignette)
          VignettePostEffect.enable();
       else
          VignettePostEffect.disable();


### PR DESCRIPTION
Adds:
$pref::Video::disableSSAO = false;
$pref::Video::disableHDR = false;
$pref::Video::disableLightRays = false;
$pref::Video::disableDOF = false;
$pref::Video::disableVignette = false;
a [Highest] entry in the shader quality dropdown.

as new prefs, which can override per map postfx settings
[Highest] = everything on
[High] = shuts off SSAO
[Normal] = additionally disables HDR
[Low] = for new flags is the same as normal, keeps the older shutoffs.
[Lowest] = takes no prisoners.