### PR TITLE
firstPersonShadows:

### DIFF
--- a/Templates/Full/game/art/datablocks/player.cs
+++ b/Templates/Full/game/art/datablocks/player.cs
@@ -482,7 +482,7 @@ datablock DebrisData( PlayerDebris )
 datablock PlayerData(DefaultPlayerData)
 {
    renderFirstPerson = false;
-
+   firstPersonShadows = true;
    computeCRC = false;
 
    // Third person shape


### PR DESCRIPTION
follows up on https://github.com/GarageGames/Torque3D/commit/88bb577c82cd55be15b5db481558b3df7daa8066#diff-b8335f02a980665dd7dc953db7a637ca from way back when, and adds the script to turn on first person showing player shadows
