### PR TITLE
Added OpenGL module with some additions to the project generator

### DIFF
--- a/Tools/projectGenerator/classes/Generator.php
+++ b/Tools/projectGenerator/classes/Generator.php
@@ -240,6 +240,18 @@ class T3D_Generator
             array_push( self::$project_cur->defines, $d."=".$v );
     }
     
+    static function isDefined( $d )
+    {
+        foreach( self::$project_cur->defines as $v )
+        {
+            if( $v === $d )
+                return true;
+            else if( strpos( $v, $d . "=" ) === 0 )
+                return true;
+        }
+        return false;
+    }
+    
     static function disableProjectWarning( $warning )
     {
         array_push( self::$project_cur->disabledWarnings, $warning );

--- a/Tools/projectGenerator/modules/opengl.inc
+++ b/Tools/projectGenerator/modules/opengl.inc
@@ -1,0 +1,47 @@
+<?php
+//-----------------------------------------------------------------------------
+// Copyright (c) 2014 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
+beginModule('openGL');
+
+	addProjectDefine('TORQUE_OPENGL');
+
+	addEngineSrcDir("shaderGen/GLSL");
+
+	if(!isDefined("TORQUE_DEDICATED"))
+	{
+		addEngineSrcDir("gfx/gl");
+		addEngineSrcDir("gfx/gl/tGL");
+		addEngineSrcDir("shaderGen/GLSL");
+		addEngineSrcDir("terrain/glsl");
+		addEngineSrcDir("forest/glsl");
+		addLibSrcFile("glew/src/glew.c");
+	}
+
+	if(!isDefined("TORQUE_SDL"))
+	{
+		addEngineSrcDir("gfx/gl/win32");
+	}
+
+endModule();
+
+?>

--- a/Tools/projectGenerator/projectGenUtils.inc
+++ b/Tools/projectGenerator/projectGenUtils.inc
@@ -288,6 +288,11 @@ function addProjectDefines()
 	else
 		echo( "addProjectDefines() - no arguments passed!" );
 }
+/// Has a preprocessor directive been defined?
+function isDefined( $d )
+{
+    return T3D_Generator::isDefined( $d );
+}
 
 function setProjectGUID( $guid )
 {


### PR DESCRIPTION
Adds a Project Generator module for OpenGL. This required adding the ability to check Project Generator defines after they have been added. Note the PHP code here isn't verified, so I may be doing it wrong. Also note that it's not reliable - it's dependent on the order in which PG modules are executed, so you can only check for defines that have already been added.
