### PR TITLE
Added Drop To Ground functionality to Forest, needs new icon though

### DIFF
--- a/Engine/source/forest/editor/forestBrushTool.h
+++ b/Engine/source/forest/editor/forestBrushTool.h
@@ -53,7 +53,8 @@ public:
    {
       Paint = 0,
       Erase,
-      EraseSelected
+      EraseSelected,
+	  DropToGround
    };
 
    ForestBrushTool();
@@ -61,6 +62,12 @@ public:
 
    // SimObject
    DECLARE_CONOBJECT( ForestBrushTool );
+
+    DECLARE_CALLBACK(void, onMouseDown, ());
+    DECLARE_CALLBACK(void, onActivated, ());
+    DECLARE_CALLBACK(void, onDeactivated, ());
+    DECLARE_CALLBACK(void, syncBrushToolbar, ());
+
    static void initPersistFields();
    virtual bool onAdd();
    virtual void onRemove();
@@ -90,6 +97,7 @@ protected:
    virtual void _action( const Point3F &point );
    virtual void _paint( const Point3F &point );
    virtual void _erase( const Point3F &point );
+   virtual void _DropToGround( const Point3F &point );
       
    bool _updateBrushPoint( const Gui3DMouseEvent &event_ );   
    virtual void _collectElements();

--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -5058,15 +5058,13 @@ ConsoleMethod(GuiTreeViewCtrl, getSelectedObject, S32, 2, 3, "( int index=0 ) - 
    return -1;
 }
 
-ConsoleMethod(GuiTreeViewCtrl, getSelectedObjectList, const char*, 2, 2, 
-              "Returns a space sperated list of all selected object ids.")
+const char* GuiTreeViewCtrl::getSelectedObjectList()
 {
-   static const U32 bufSize = 1024;
-   char* buff = Con::getReturnBuffer(bufSize);
-   dSprintf(buff,bufSize,"");
+ char* buff = Con::getReturnBuffer(1024);
+   dSprintf(buff,1024,"");
 
-   const Vector< GuiTreeViewCtrl::Item* > selectedItems = object->getSelectedItems();
-   for(S32 i = 0; i < selectedItems.size(); i++)
+   const Vector< GuiTreeViewCtrl::Item* > selectedItems = this->getSelectedItems();
+   for(int i = 0; i < selectedItems.size(); i++)
    {
       GuiTreeViewCtrl::Item *item = selectedItems[i];
 
@@ -5078,7 +5076,7 @@ ConsoleMethod(GuiTreeViewCtrl, getSelectedObjectList, const char*, 2, 2,
          //the start of the buffer where we want to write
          char* buffPart = buff+len;
          //the size of the remaining buffer (-1 cause dStrlen doesn't count the \0)
-         S32 size = bufSize-len-1;
+         S32 size	=	1024-len-1;
          //write it:
          if(size < 1)
          {

--- a/Engine/source/gui/controls/guiTreeViewCtrl.h
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.h
@@ -454,6 +454,8 @@ class GuiTreeViewCtrl : public GuiArrayCtrl
       GuiTreeViewCtrl();
       virtual ~GuiTreeViewCtrl();
 
+		const char* getSelectedObjectList();
+
       /// Used for syncing the mSelected and mSelectedItems lists.
       void syncSelection();
 

--- a/Templates/Empty/game/tools/forestEditor/main.cs
+++ b/Templates/Empty/game/tools/forestEditor/main.cs
@@ -72,6 +72,7 @@ function initializeForestEditor()
    %map.bindCmd( keyboard, "5", "ForestEditorPaintModeBtn.performClick();", "" );  // Paint
    %map.bindCmd( keyboard, "6", "ForestEditorEraseModeBtn.performClick();", "" );  // Erase
    %map.bindCmd( keyboard, "7", "ForestEditorEraseSelectedModeBtn.performClick();", "" );  // EraseSelected   
+   %map.bindCmd( keyboard, "8", "ForestEditorDropToGroundModeBtn.performClick();", "" );  // EraseSelected
    //%map.bindCmd( keyboard, "backspace", "ForestEditorGui.onDeleteKey();", "" );
    //%map.bindCmd( keyboard, "delete", "ForestEditorGui.onDeleteKey();", "" );   
    ForestEditorPlugin.map = %map;   

--- a/Templates/Empty/game/tools/worldEditor/gui/ToolsPaletteGroups/ForestEditorPalette.ed.gui
+++ b/Templates/Empty/game/tools/worldEditor/gui/ToolsPaletteGroups/ForestEditorPalette.ed.gui
@@ -160,4 +160,25 @@
       buttonType = "RadioButton";
       useMouseEvents = "0";
    };
+   new GuiBitmapButtonCtrl(ForestEditorDropToGroundModeBtn) {
+      canSaveDynamicFields = "0";
+      internalName = "ForestEditorDropToGroundMode";
+      Enabled = "1";
+      isContainer = "0";
+      Profile = "ToolsGuiButtonProfile";
+      HorizSizing = "right";
+      VertSizing = "bottom";
+      Position = "0 0";
+      Extent = "25 19";
+      MinExtent = "8 2";
+      canSave = "1";
+      Visible = "1";
+      Command = "ForestEditorGui.setActiveTool( ForestTools->BrushTool ); ForestTools->BrushTool.mode = \"DropToGround\";";  
+      tooltipprofile = "ToolsGuiToolTipProfile";
+      ToolTip = "Drop To Ground (8)";
+      hovertime = "1000";
+      bitmap = "tools/foresteditor/images/forest-editor-btn";
+      buttonType = "RadioButton";
+      useMouseEvents = "0";
+   };   
 };

--- a/Templates/Full/game/tools/forestEditor/main.cs
+++ b/Templates/Full/game/tools/forestEditor/main.cs
@@ -72,6 +72,7 @@ function initializeForestEditor()
    %map.bindCmd( keyboard, "5", "ForestEditorPaintModeBtn.performClick();", "" );  // Paint
    %map.bindCmd( keyboard, "6", "ForestEditorEraseModeBtn.performClick();", "" );  // Erase
    %map.bindCmd( keyboard, "7", "ForestEditorEraseSelectedModeBtn.performClick();", "" );  // EraseSelected   
+   %map.bindCmd( keyboard, "8", "ForestEditorDropToGroundModeBtn.performClick();", "" );  // EraseSelected
    //%map.bindCmd( keyboard, "backspace", "ForestEditorGui.onDeleteKey();", "" );
    //%map.bindCmd( keyboard, "delete", "ForestEditorGui.onDeleteKey();", "" );   
    ForestEditorPlugin.map = %map;   

--- a/Templates/Full/game/tools/worldEditor/gui/ToolsPaletteGroups/ForestEditorPalette.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/ToolsPaletteGroups/ForestEditorPalette.ed.gui
@@ -160,4 +160,25 @@
       buttonType = "RadioButton";
       useMouseEvents = "0";
    };
+   new GuiBitmapButtonCtrl(ForestEditorDropToGroundModeBtn) {
+      canSaveDynamicFields = "0";
+      internalName = "ForestEditorDropToGroundMode";
+      Enabled = "1";
+      isContainer = "0";
+      Profile = "ToolsGuiButtonProfile";
+      HorizSizing = "right";
+      VertSizing = "bottom";
+      Position = "0 0";
+      Extent = "25 19";
+      MinExtent = "8 2";
+      canSave = "1";
+      Visible = "1";
+      Command = "ForestEditorGui.setActiveTool( ForestTools->BrushTool ); ForestTools->BrushTool.mode = \"DropToGround\";";  
+      tooltipprofile = "ToolsGuiToolTipProfile";
+      ToolTip = "Drop To Ground (8)";
+      hovertime = "1000";
+      bitmap = "tools/foresteditor/images/forest-editor-btn";
+      buttonType = "RadioButton";
+      useMouseEvents = "0";
+   };   
 };


### PR DESCRIPTION
Situation is a level designer places a forest, then changes the elevation of the ground under the forest.  This allows them to just drop all the forest items back onto the ground without having to erase them and replace them.
