### PR TITLE
This just adds some console spam if the PostEffect Texture isn't found. ...

### DIFF
--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -403,7 +403,9 @@ bool PostEffect::onAdd()
          texFilename = scriptPath.getFullPath() + '/' + texFilename;
 
       // Try to load the texture.
-      mTextures[i].set( texFilename, &PostFxTextureProfile, avar( "%s() - (line %d)", __FUNCTION__, __LINE__ ) );
+      bool success = mTextures[i].set( texFilename, &PostFxTextureProfile, avar( "%s() - (line %d)", __FUNCTION__, __LINE__ ) );
+      if (!success)
+         Con::errorf("Invalid Texture for PostEffect (%s), The Texture '%s' does not exist!", this->getName(), texFilename.c_str());
    }
 
    // Is the target a named target?


### PR DESCRIPTION
... I had a problem back where it was that I mistyped the texture and it took hours to find it.  This way you know  right away.
