### PR TITLE
Fix lighting errors when all lights are disabled.

### DIFF
--- a/Engine/source/lighting/advanced/advancedLightBinManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightBinManager.cpp
@@ -244,7 +244,6 @@ void AdvancedLightBinManager::render( SceneRenderState *state )
 
    // Get the sunlight. If there's no sun, and no lights in the bins, no draw
    LightInfo *sunLight = mLightManager->getSpecialLight( LightManager::slSunLightType, false );
-
    GFXDEBUGEVENT_SCOPE( AdvancedLightBinManager_Render, ColorI::RED );
 
    // Tell the superclass we're about to render

--- a/Engine/source/lighting/advanced/advancedLightBinManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightBinManager.cpp
@@ -244,8 +244,6 @@ void AdvancedLightBinManager::render( SceneRenderState *state )
 
    // Get the sunlight. If there's no sun, and no lights in the bins, no draw
    LightInfo *sunLight = mLightManager->getSpecialLight( LightManager::slSunLightType, false );
-   if( !sunLight && mLightBin.empty() )
-      return;
 
    GFXDEBUGEVENT_SCOPE( AdvancedLightBinManager_Render, ColorI::RED );
 


### PR DESCRIPTION
When scene has zero lights sources actives, last ```RenderTexTargetBinManager```render target  are used for render. This cause render artifatcs.

![screenshot 2014-12-03 23 48 13](https://cloud.githubusercontent.com/assets/2388307/5290412/e0372976-7b46-11e4-8556-19bbb8190648.png)

Thx @Lopuska for the fix :)

For replicate:

* Remove or hidde all light sources on editor.