### PR TITLE
Fix AMD render problem with missed meshes.

### DIFF
--- a/Engine/source/ts/tsMesh.cpp
+++ b/Engine/source/ts/tsMesh.cpp
@@ -2428,7 +2428,7 @@ void TSMesh::_createVBIB( TSVertexBufferHandle &vb, GFXPrimitiveBufferHandle &pb
             pInfo.startIndex = draw.start;
             // Use the first index to determine which 16-bit address space we are operating in
             pInfo.startVertex = indices[draw.start] & 0xFFFF0000;
-            pInfo.minIndex = pInfo.startVertex;
+            pInfo.minIndex = 0; // minIndex are zero based index relative to startVertex. See @GFXDevice
             pInfo.numVertices = getMin((U32)0x10000, mNumVerts - pInfo.startVertex);
             break;
 
@@ -2439,7 +2439,7 @@ void TSMesh::_createVBIB( TSVertexBufferHandle &vb, GFXPrimitiveBufferHandle &pb
             pInfo.startIndex = draw.start;
             // Use the first index to determine which 16-bit address space we are operating in
             pInfo.startVertex = indices[draw.start] & 0xFFFF0000;
-            pInfo.minIndex = pInfo.startVertex;
+            pInfo.minIndex = 0; // minIndex are zero based index relative to startVertex. See @GFXDevice
             pInfo.numVertices = getMin((U32)0x10000, mNumVerts - pInfo.startVertex);
             break;
 


### PR DESCRIPTION
Fixes an issue when rendering certain meshes on AMD cards

Example mesh rendering on a 6870:
![15kv-amd-bad](https://cloud.githubusercontent.com/assets/8334203/5368113/fe3f91a0-7fcf-11e4-85b5-dc08579e8e22.jpg)

Should look like this:
![15kv-amd-good](https://cloud.githubusercontent.com/assets/8334203/5368123/20f540aa-7fd0-11e4-8dbf-810e563cf5b3.jpg)

dae (thanks to Nadeox for the test case):
https://www.dropbox.com/s/dvew91p97nxt2pc/15kV.dae?dl=0

Note: This is a bugfix by Luis, but I am using this as a safe jumping-off point for contributing to t3d. Hi everyone :)
