### PR TITLE
Allow normals on shadowed surfaces

### DIFF
--- a/Templates/Empty/game/shaders/common/lighting.hlsl
+++ b/Templates/Empty/game/shaders/common/lighting.hlsl
@@ -36,6 +36,7 @@ uniform float4 inLightColor[4];
 #endif
 
 uniform float4 ambient;
+#define ambientCameraFactor 0.3
 uniform float specularPower;
 uniform float4 specularColor;
 

--- a/Templates/Empty/game/shaders/common/lighting/advanced/vectorLightP.hlsl
+++ b/Templates/Empty/game/shaders/common/lighting/advanced/vectorLightP.hlsl
@@ -202,7 +202,7 @@ float4 main( FarFrustumQuadConnectP IN,
                                     
    float Sat_NL_Att = saturate( dotNL * shadowed ) * lightBrightness;
    float3 lightColorOut = lightMapParams.rgb * lightColor.rgb;
-   float4 addToResult = lightAmbient;
+   float4 addToResult = (lightAmbient * (1 - ambientCameraFactor)) + ( lightAmbient * ambientCameraFactor * saturate(dot(normalize(-IN.vsEyeRay), normal)) );
 
    // TODO: This needs to be removed when lightmapping is disabled
    // as its extra work per-pixel on dynamic lit scenes.

--- a/Templates/Full/game/shaders/common/lighting.hlsl
+++ b/Templates/Full/game/shaders/common/lighting.hlsl
@@ -36,6 +36,7 @@ uniform float4 inLightColor[4];
 #endif
 
 uniform float4 ambient;
+#define ambientCameraFactor 0.3
 uniform float specularPower;
 uniform float4 specularColor;
 

--- a/Templates/Full/game/shaders/common/lighting/advanced/vectorLightP.hlsl
+++ b/Templates/Full/game/shaders/common/lighting/advanced/vectorLightP.hlsl
@@ -202,7 +202,7 @@ float4 main( FarFrustumQuadConnectP IN,
                                     
    float Sat_NL_Att = saturate( dotNL * shadowed ) * lightBrightness;
    float3 lightColorOut = lightMapParams.rgb * lightColor.rgb;
-   float4 addToResult = lightAmbient;
+   float4 addToResult = (lightAmbient * (1 - ambientCameraFactor)) + ( lightAmbient * ambientCameraFactor * saturate(dot(normalize(-IN.vsEyeRay), normal)) );
 
    // TODO: This needs to be removed when lightmapping is disabled
    // as its extra work per-pixel on dynamic lit scenes.


### PR DESCRIPTION
Changed ambient for use a factor of light with camera direction, this allow normals on shadowed surfaces.

Before: 
![screenshot 2014-12-08 20 54 47](https://cloud.githubusercontent.com/assets/8334203/5369077/a494c988-7fdc-11e4-92bc-a1c74fe023ea.jpg)

After:
![screenshot 2014-12-08 20 54 58](https://cloud.githubusercontent.com/assets/8334203/5369079/ab464a04-7fdc-11e4-9ab5-eafaca9011ba.jpg)

(on behalf of Luis)