### PR TITLE
Fix a crash when change a material reflect cubemap.

### DIFF
--- a/Engine/source/materials/processedMaterial.h
+++ b/Engine/source/materials/processedMaterial.h
@@ -73,7 +73,7 @@ public:
    /// The cubemap to use when the texture type is
    /// set to Material::Cube.
    /// @see mTexType
-   GFXCubemap *mCubeMap;
+   GFXCubemapHandle mCubeMap;
 
    U32 mNumTex;
 


### PR DESCRIPTION
Fix for  #694 Cubemap R6025 

This is the problem of allow pointers and smart pointers on same code.

What happens:
- We have a pointer to object
- We assign pointer to StrongPtr
- Bla, bla bla bla...
- Clean StrongPointer -> 0 refs -> delete object... oh no!!! :(
- We use our first pointer... pointing to a deleted object :(
