### PR TITLE
PR for issue #748

### DIFF
--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -1599,8 +1599,7 @@ void SimObject::unlinkNamespaces()
 
    // Handle object name.
 
-   StringTableEntry objectName = getName();
-   if( objectName && objectName[ 0 ] )
+   if (mNameSpace && mNameSpace->mClassRep == NULL)
       mNameSpace->decRefCountToParent();
 
    mNameSpace = NULL;


### PR DESCRIPTION
fixes #748 

Uses James' suggested fix for preventing the unlinking of the parent namespace when deleting name-conflicted objects.
