### PR TITLE
Fix off-by-one error in cursor hiding/showing function

### DIFF
--- a/Engine/source/windowManager/win32/win32CursorController.cpp
+++ b/Engine/source/windowManager/win32/win32CursorController.cpp
@@ -106,7 +106,7 @@ void Win32CursorController::setCursorVisible( bool visible )
    if( visible )
       ShowCursor( true );
    else
-      while( ShowCursor(false) > 0 );
+      while( ShowCursor(false) >= 0 );
 }
 
 bool Win32CursorController::isCursorVisible()


### PR DESCRIPTION
Fix incorrect API use according to msdn.

Source: http://msdn.microsoft.com/en-us/library/windows/desktop/ms648396%28v=vs.85%29.aspx
"cursor is displayed only if the display count is greater than or equal to 0"
