### PR TITLE
winTime month fix

### DIFF
--- a/Engine/source/platformWin32/winTime.cpp
+++ b/Engine/source/platformWin32/winTime.cpp
@@ -139,7 +139,7 @@ void Platform::fileToLocalTime(const FileTime & ft, LocalTime * lt)
          lt->sec = time->wSecond;
          lt->min = time->wMinute;
          lt->hour = time->wHour;
-         lt->month = time->wMonth;
+         lt->month = time->wMonth - 1;
          lt->monthday = time->wDay;
          lt->weekday = time->wDayOfWeek;
          lt->year = (time->wYear < 1900) ? 1900 : (time->wYear - 1900);


### PR DESCRIPTION
Windows SYSTEMTIME stores month 1-12 while T3D LocalTime stores month 0-11. This obviously causes problems with GetDateFormat used in the function Platform::localTimeToString( const LocalTime &lt ) in winTime.cpp. Especially in December ;-)
