### PR TITLE
Fix persistent underwater effect.

### DIFF
--- a/Engine/source/environment/waterObject.cpp
+++ b/Engine/source/environment/waterObject.cpp
@@ -891,6 +891,10 @@ void WaterObject::onRemove()
    {
       mPlaneReflector.unregisterReflector();
       cleanupMaterials();
+
+      PostEffect *underWaterEffect = getUnderwaterEffect( );
+      if( underWaterEffect )
+         underWaterEffect->disable( );
    }
 
    Parent::onRemove();


### PR DESCRIPTION
Fixes  #841 - Underwater fog/caustics/turbulence effects don't disappear when they should 
