### PR TITLE
Use a strong reference instead of more manual reference counting

### DIFF
--- a/Engine/source/sim/netEvent.cpp
+++ b/Engine/source/sim/netEvent.cpp
@@ -310,8 +310,8 @@ void NetConnection::eventReadPacket(BitStream *bstream)
          setLastError("Invalid packet. (bad event class id)");
          return;
       }
-      NetEvent *evt = (NetEvent *) ConsoleObject::create(getNetClassGroup(), NetClassTypeEvent, classId);
-      if(!evt)
+      StrongRefPtr<NetEvent> evt = (NetEvent *) ConsoleObject::create(getNetClassGroup(), NetClassTypeEvent, classId);
+      if(evt.isNull())
       {
          setLastError("Invalid packet. (bad ghost class id)");
          return;
@@ -344,7 +344,7 @@ void NetConnection::eventReadPacket(BitStream *bstream)
       if(unguaranteedPhase)
       {
          evt->process(this);
-         evt->decRef();
+         evt = NULL;
          if(mErrorBuffer.isNotEmpty())
             return;
          continue;


### PR DESCRIPTION
Replaces part of #1078. Instead of doing manual reference counting, we use a `StrongRefPtr` in this method.