### PR TITLE
OpenGL: Add project define for GLEW with php generator.

### DIFF
--- a/Tools/projectGenerator/modules/opengl.inc
+++ b/Tools/projectGenerator/modules/opengl.inc
@@ -45,8 +45,11 @@ beginModule('openGL');
     
 	addIncludePath( getAppLibSrcDir() . 'glew/include/' );
     
-	if ( T3D_Generator::$platform == "win32" )
-		addProjectLibInput('OpenGL32.lib');
+    if ( T3D_Generator::$platform == "win32" )
+    {
+        addProjectLibInput('OpenGL32.lib');
+        addProjectDefine('GLEW_STATIC');
+    }
 
 endModule();
 


### PR DESCRIPTION
Fixes `LNK4049: locally defined symbol` on all OpenGL functions
