### PR TITLE
Add a new keybind to profile for exactly two seconds

### DIFF
--- a/Templates/Empty/game/scripts/client/default.bind.cs
+++ b/Templates/Empty/game/scripts/client/default.bind.cs
@@ -465,6 +465,23 @@ function doProfile(%val)
    else
    {
       // key up -- finish off profile
+      endProfile(true);
+   }
+}
+
+function startProfile(%val)
+{
+   if (%val)
+   {
+      doProfile(true);
+      schedule(2000, 0, endProfile, true);
+   }
+}
+
+function endProfile(%val)
+{
+   if (%val)
+   {
       echo("Ending profile session...");
 
       profilerDumpToFile("profilerDumpToFile" @ getSimTime() @ ".txt");
@@ -473,6 +490,7 @@ function doProfile(%val)
 }
 
 GlobalActionMap.bind(keyboard, "ctrl F3", doProfile);
+GlobalActionMap.bind(keyboard, "alt F3", startProfile);
 
 //------------------------------------------------------------------------------
 // Misc.

--- a/Templates/Full/game/scripts/client/default.bind.cs
+++ b/Templates/Full/game/scripts/client/default.bind.cs
@@ -639,6 +639,23 @@ function doProfile(%val)
    else
    {
       // key up -- finish off profile
+      endProfile(true);
+   }
+}
+
+function startProfile(%val)
+{
+   if (%val)
+   {
+      doProfile(true);
+      schedule(2000, 0, endProfile, true);
+   }
+}
+
+function endProfile(%val)
+{
+   if (%val)
+   {
       echo("Ending profile session...");
 
       profilerDumpToFile("profilerDumpToFile" @ getSimTime() @ ".txt");
@@ -647,6 +664,7 @@ function doProfile(%val)
 }
 
 GlobalActionMap.bind(keyboard, "ctrl F3", doProfile);
+GlobalActionMap.bind(keyboard, "alt F3", startProfile);
 
 //------------------------------------------------------------------------------
 // Misc.


### PR DESCRIPTION
This might be helpful if you want to compare profiles over the same length of time, instead of relying on holding down the profile key combo for an approximate length of time.
