### PR TITLE
Fixed define bug for OpenGL shadergen. 

### DIFF
--- a/Engine/source/shaderGen/GLSL/shaderCompGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderCompGLSL.cpp
@@ -405,6 +405,7 @@ void VertPixelConnectorGLSL::printStructDefines( Stream &stream, bool in )
       {
          dSprintf((char*)output, sizeof(output), "#define %s_%s _%s_\r\n", connectionDir, var->name, var->connectName);
          stream.write( dStrlen((char*)output), output );
+         continue;
       }
 
       if( deprecatedDefines.contains((char*)var->name))


### PR DESCRIPTION
 Defines were "defining" structure properties out for IN structures sometimes.

example shadergen glsl output where this bug happened to me:

         // struct VertexData
         // {
         //    vec3 position;
         //    vec3 normal;
         //    vec3 T;
         //    vec3 B;
         //    vec2 texCoord;
         //    vec2 texCoord2;
         // } IN;
         //
         // out vec4 _TEXCOORD2_;
         //
         // #define texCoord2 OUT_texCoord2
         // #define OUT_outVpos _TEXCOORD2_