### PR TITLE
Fixes for issue on void CameraSpline::buildTimeMap().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ projects.xml
 Qt*.dll
 Templates/Full/game/resources/
 Templates/Full/game/shaders/procedural/
+Templates/Full/buildFiles/

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,5 @@ My Projects/
 Project Manager.exe
 projects.xml
 Qt*.dll
+Templates/Full/game/resources/
+Templates/Full/game/shaders/procedural/

--- a/Engine/source/T3D/cameraSpline.cpp
+++ b/Engine/source/T3D/cameraSpline.cpp
@@ -165,8 +165,8 @@ void CameraSpline::buildTimeMap()
 
       if ((segment / sublength) < epsilon || time == (mSize - 1) || mFloor(lt) != mFloor(time)) 
       {
-		 length += sublength;
-		 sublength = 0.0f;
+         length += sublength;
+         sublength = 0.0f;
          map.mTime = time;
          map.mDistance = length;
          mTimeMap.push_back(map);

--- a/Engine/source/T3D/cameraSpline.cpp
+++ b/Engine/source/T3D/cameraSpline.cpp
@@ -160,7 +160,7 @@ void CameraSpline::buildTimeMap()
 
       value(time, &ki, true);
       length += (ki.mPosition - kj.mPosition).len();
-	  sublength += (ki.mPosition - kj.mPosition).len();
+      sublength += (ki.mPosition - kj.mPosition).len();
       F32 segment = (ki.mPosition - ka.mPosition).len();
 
       if ((segment / sublength) < epsilon || time == (mSize - 1) || mFloor(lt) != mFloor(time)) 

--- a/Engine/source/T3D/cameraSpline.cpp
+++ b/Engine/source/T3D/cameraSpline.cpp
@@ -145,6 +145,7 @@ void CameraSpline::buildTimeMap()
    Knot ka,kj,ki;
    value(0, &kj, true);
    F32 length = 0.0f;
+   F32 sublength = 0.0f;
    ka = kj;
 
    // Loop through the knots and add nodes. Nodes are added for every knot and
@@ -159,10 +160,13 @@ void CameraSpline::buildTimeMap()
 
       value(time, &ki, true);
       length += (ki.mPosition - kj.mPosition).len();
+	  sublength += (ki.mPosition - kj.mPosition).len();
       F32 segment = (ki.mPosition - ka.mPosition).len();
 
-      if ((segment / length) < epsilon || time == (mSize - 1) || mFloor(lt) != mFloor(time)) 
+      if ((segment / sublength) < epsilon || time == (mSize - 1) || mFloor(lt) != mFloor(time)) 
       {
+		 length += sublength;
+		 sublength = 0.0f;
          map.mTime = time;
          map.mDistance = length;
          mTimeMap.push_back(map);


### PR DESCRIPTION
Sorry if it's not the way to do that. May be I should start a 'New Issue' in Git, you tell me. But any way, this is my (first) contribution...

Steps to reproduce the issue:
Draw a Path with 4 Markers in line. Like this:
![image](https://cloud.githubusercontent.com/assets/2324012/5798878/4c0f30cc-9fcc-11e4-92dd-214d28ef39e6.png)

Then add a breakpoint in CameraSpline::buildTimeMap(), and look at mTimeMap vector. It should have just 4 elements, because (as it's said in the comments) the algorithm  should add every knot and whenever the spline length and segment length deviate by epsilon. This is not happening, look it has lots of elements (43):
![image](https://cloud.githubusercontent.com/assets/2324012/5798955/454955b4-9fcd-11e4-967e-5eb2f07b30f5.png)

Applying this changes the algorithm do what should do:
![image](https://cloud.githubusercontent.com/assets/2324012/5798988/82194530-9fcd-11e4-8af8-3940a28397ee.png)

And the spline is shown and work properly:
![image](https://cloud.githubusercontent.com/assets/2324012/5799016/af960430-9fcd-11e4-8e75-9cd1a1cfb8c9.png)
Moving a knot:
![image](https://cloud.githubusercontent.com/assets/2324012/5799023/c0de59fe-9fcd-11e4-84e7-13d3164e7cf6.png)
Hope it helps!