### PR TITLE
Fix buffer overflows

### DIFF
--- a/Engine/source/core/stringBuffer.cpp
+++ b/Engine/source/core/stringBuffer.cpp
@@ -359,7 +359,7 @@ void StringBuffer::getCopy8(UTF8 *buff, const U32 buffSize) const
 {
    incRequestCount8();
    AssertFatal(mBuffer.last() == 0, "StringBuffer::get UTF8 - not a null terminated string!");
-   convertUTF16toUTF8(mBuffer.address(), buff, buffSize);
+   convertUTF16toUTF8N(mBuffer.address(), buff, buffSize);
 }
 
 void StringBuffer::getCopy(UTF16 *buff, const U32 buffSize) const
@@ -408,7 +408,7 @@ void StringBuffer::updateBuffer8()
 {
    U32 slackLen = getUTF8BufferSizeEstimate();
    mBuffer8.setSize(slackLen);
-   U32 len = convertUTF16toUTF8(mBuffer.address(), mBuffer8.address(), slackLen);
+   U32 len = convertUTF16toUTF8N(mBuffer.address(), mBuffer8.address(), slackLen);
    mBuffer8.setSize(len+1);
    mBuffer8.compact();
    mDirty8 = false;

--- a/Engine/source/core/stringBuffer.cpp
+++ b/Engine/source/core/stringBuffer.cpp
@@ -186,7 +186,7 @@ void StringBuffer::append(const UTF8* in)
    
    // convert to UTF16, because that's our internal format.
    // if the conversion fails, exit.
-   UTF16* tmp = convertUTF8toUTF16(in);
+   UTF16* tmp = createUTF16string(in);
    AssertFatal(tmp, "StringBuffer::append(UTF8) - could not convert UTF8 string!");
    if(!tmp)
       return;
@@ -231,7 +231,7 @@ void StringBuffer::insert(const U32 charOffset, const UTF8* in)
    
    // convert to UTF16, because that's our internal format.
    // if the conversion fails, exit.
-   UTF16* tmp = convertUTF8toUTF16(in);
+   UTF16* tmp = createUTF16string(in);
    AssertFatal(tmp, "StringBuffer::insert(UTF8) - could not convert UTF8 string!");
    if(!tmp)
       return;
@@ -377,7 +377,7 @@ UTF8* StringBuffer::createCopy8() const
    incRequestCount8();
    // convert will create a buffer of the appropriate size for a null terminated
    // input string.
-   UTF8* out = convertUTF16toUTF8(mBuffer.address());
+   UTF8* out = createUTF8string(mBuffer.address());
    return out;
 }
 

--- a/Engine/source/core/stringBuffer.cpp
+++ b/Engine/source/core/stringBuffer.cpp
@@ -141,7 +141,7 @@ void StringBuffer::set(const UTF8 *in)
    incRequestCount8();
    // Convert and store. Note that a UTF16 version of the string cannot be longer.
    FrameTemp<UTF16> tmpBuff(dStrlen(in)+1);
-   if(!in || in[0] == 0 || !convertUTF8toUTF16(in, tmpBuff, dStrlen(in)+1))
+   if(!in || in[0] == 0 || !convertUTF8toUTF16N(in, tmpBuff, dStrlen(in)+1))
    {
       // Easy out, it's a blank string, or a bad string.
       mBuffer.clear();

--- a/Engine/source/core/strings/unicode.cpp
+++ b/Engine/source/core/strings/unicode.cpp
@@ -159,7 +159,6 @@ U32 convertUTF8toUTF16N(const UTF8 *unistring, UTF16 *outbuffer, U32 len)
    {
       const UTF16Cache &cache = (*cacheItr).value;
       cache.copyToBuffer(outbuffer, len);
-      outbuffer[len-1] = '\0';
       return getMin(cache.mLength,len - 1);
    }
 #endif

--- a/Engine/source/core/strings/unicode.cpp
+++ b/Engine/source/core/strings/unicode.cpp
@@ -191,7 +191,7 @@ U32 convertUTF8toUTF16N(const UTF8 *unistring, UTF16 *outbuffer, U32 len)
 }
 
 //-----------------------------------------------------------------------------
-U32 convertUTF16toUTF8( const UTF16 *unistring, UTF8  *outbuffer, U32 len)
+U32 convertUTF16toUTF8N( const UTF16 *unistring, UTF8  *outbuffer, U32 len)
 {
    AssertFatal(len >= 1, "Buffer for unicode conversion must be large enough to hold at least the null terminator.");
    PROFILE_START(convertUTF16toUTF8);
@@ -274,7 +274,7 @@ UTF8*  convertUTF16toUTF8( const UTF16* unistring)
    FrameTemp<UTF8> buf(len);
       
    // perform conversion
-   nCodeunits = convertUTF16toUTF8( unistring, buf, len);
+   nCodeunits = convertUTF16toUTF8N( unistring, buf, len);
    
    // add 1 for the NULL terminator the converter promises it included.
    nCodeunits++;

--- a/Engine/source/core/strings/unicode.cpp
+++ b/Engine/source/core/strings/unicode.cpp
@@ -509,21 +509,6 @@ U32 dStrlen(const UTF32 *unistring)
 }
 
 //-----------------------------------------------------------------------------
-U32 dStrncmp(const UTF16* unistring1, const UTF16* unistring2, U32 len)
-{
-   UTF16 c1, c2;
-   for(U32 i = 0; i<len; i++)
-   {
-      c1 = *unistring1++;
-      c2 = *unistring2++;
-      if(c1 < c2) return -1;
-      if(c1 > c2) return 1;
-      if(!c1) return 0;
-   }
-   return 0;
-}
-
-//-----------------------------------------------------------------------------
 
 const UTF16* dStrrchr(const UTF16* unistring, U32 c)
 {

--- a/Engine/source/core/strings/unicode.cpp
+++ b/Engine/source/core/strings/unicode.cpp
@@ -242,7 +242,7 @@ U32 convertUTF16toUTF8DoubleNULL( const UTF16 *unistring, UTF8  *outbuffer, U32 
 //-----------------------------------------------------------------------------
 // Functions that convert buffers of unicode code points
 //-----------------------------------------------------------------------------
-UTF16* convertUTF8toUTF16( const UTF8* unistring)
+UTF16* createUTF16string( const UTF8* unistring)
 {
    PROFILE_SCOPE(convertUTF8toUTF16_create);
    
@@ -264,7 +264,7 @@ UTF16* convertUTF8toUTF16( const UTF8* unistring)
 }
 
 //-----------------------------------------------------------------------------
-UTF8*  convertUTF16toUTF8( const UTF16* unistring)
+UTF8*  createUTF8string( const UTF16* unistring)
 {
    PROFILE_SCOPE(convertUTF16toUTF8_create);
 

--- a/Engine/source/core/strings/unicode.cpp
+++ b/Engine/source/core/strings/unicode.cpp
@@ -146,7 +146,7 @@ inline bool isAboveBMP(U32 codepoint)
 }
 
 //-----------------------------------------------------------------------------
-U32 convertUTF8toUTF16(const UTF8 *unistring, UTF16 *outbuffer, U32 len)
+U32 convertUTF8toUTF16N(const UTF8 *unistring, UTF16 *outbuffer, U32 len)
 {
    AssertFatal(len >= 1, "Buffer for unicode conversion must be large enough to hold at least the null terminator.");
    PROFILE_SCOPE(convertUTF8toUTF16);
@@ -252,7 +252,7 @@ UTF16* convertUTF8toUTF16( const UTF8* unistring)
    FrameTemp<UTF16> buf(len);
    
    // perform conversion
-   nCodepoints = convertUTF8toUTF16( unistring, buf, len);
+   nCodepoints = convertUTF8toUTF16N( unistring, buf, len);
    
    // add 1 for the NULL terminator the converter promises it included.
    nCodepoints++;

--- a/Engine/source/core/strings/unicode.cpp
+++ b/Engine/source/core/strings/unicode.cpp
@@ -244,7 +244,7 @@ U32 convertUTF16toUTF8DoubleNULL( const UTF16 *unistring, UTF8  *outbuffer, U32 
 //-----------------------------------------------------------------------------
 UTF16* createUTF16string( const UTF8* unistring)
 {
-   PROFILE_SCOPE(convertUTF8toUTF16_create);
+   PROFILE_SCOPE(createUTF16string);
    
    // allocate plenty of memory.
    U32 nCodepoints, len = dStrlen(unistring) + 1;
@@ -266,7 +266,7 @@ UTF16* createUTF16string( const UTF8* unistring)
 //-----------------------------------------------------------------------------
 UTF8*  createUTF8string( const UTF16* unistring)
 {
-   PROFILE_SCOPE(convertUTF16toUTF8_create);
+   PROFILE_SCOPE(createUTF8string);
 
    // allocate plenty of memory.
    U32 nCodeunits, len = dStrlen(unistring) * 3 + 1;

--- a/Engine/source/core/strings/unicode.h
+++ b/Engine/source/core/strings/unicode.h
@@ -62,9 +62,9 @@
 ///   calling delete[] on these buffers.
 /// - Because they allocate memory, do not use these functions in a tight loop.
 /// - These are useful when you need a new long term copy of a string.
-UTF16* convertUTF8toUTF16( const UTF8 *unistring);
+UTF16* createUTF16string( const UTF8 *unistring);
 
-UTF8*  convertUTF16toUTF8( const UTF16 *unistring);
+UTF8*  createUTF8string( const UTF16 *unistring);
 
 //-----------------------------------------------------------------------------
 /// Functions that convert buffers of unicode code points, into a provided buffer.

--- a/Engine/source/core/strings/unicode.h
+++ b/Engine/source/core/strings/unicode.h
@@ -118,10 +118,6 @@ U32 dStrlen(const UTF16 *unistring);
 U32 dStrlen(const UTF32 *unistring);
 
 //-----------------------------------------------------------------------------
-/// Comparing unicode strings
-U32 dStrncmp(const UTF16* unistring1, const UTF16* unistring2, U32 len);
-
-//-----------------------------------------------------------------------------
 /// Scanning for characters in unicode strings
 UTF16* dStrrchr(UTF16* unistring, U32 c);
 const UTF16* dStrrchr(const UTF16* unistring, U32 c);

--- a/Engine/source/core/strings/unicode.h
+++ b/Engine/source/core/strings/unicode.h
@@ -79,9 +79,15 @@ UTF8*  convertUTF16toUTF8( const UTF16 *unistring);
 /// - Output is null terminated. Be sure to provide 1 extra byte, U16 or U32 for
 ///   the null terminator, or you will see truncated output.
 /// - If the provided buffer is too small, the output will be truncated.
-U32 convertUTF8toUTF16(const UTF8 *unistring, UTF16 *outbuffer, U32 len);
+U32 convertUTF8toUTF16N(const UTF8 *unistring, UTF16 *outbuffer, U32 len);
 
 U32 convertUTF16toUTF8( const UTF16 *unistring, UTF8  *outbuffer, U32 len);
+
+template <size_t N>
+inline U32 convertUTF8toUTF16(const UTF8 *unistring, UTF16 (&outbuffer)[N])
+{
+   return convertUTF8toUTF16N(unistring, outbuffer, (U32) N);
+}
 
 //-----------------------------------------------------------------------------
 /// Functions that converts one unicode codepoint at a time

--- a/Engine/source/core/strings/unicode.h
+++ b/Engine/source/core/strings/unicode.h
@@ -83,12 +83,14 @@ U32 convertUTF8toUTF16N(const UTF8 *unistring, UTF16 *outbuffer, U32 len);
 
 U32 convertUTF16toUTF8N( const UTF16 *unistring, UTF8  *outbuffer, U32 len);
 
+/// Safe conversion function for statically sized buffers.
 template <size_t N>
 inline U32 convertUTF8toUTF16(const UTF8 *unistring, UTF16 (&outbuffer)[N])
 {
    return convertUTF8toUTF16N(unistring, outbuffer, (U32) N);
 }
 
+/// Safe conversion function for statically sized buffers.
 template <size_t N>
 inline U32 convertUTF16toUTF8(const UTF16 *unistring, UTF8 (&outbuffer)[N])
 {

--- a/Engine/source/core/strings/unicode.h
+++ b/Engine/source/core/strings/unicode.h
@@ -81,12 +81,18 @@ UTF8*  convertUTF16toUTF8( const UTF16 *unistring);
 /// - If the provided buffer is too small, the output will be truncated.
 U32 convertUTF8toUTF16N(const UTF8 *unistring, UTF16 *outbuffer, U32 len);
 
-U32 convertUTF16toUTF8( const UTF16 *unistring, UTF8  *outbuffer, U32 len);
+U32 convertUTF16toUTF8N( const UTF16 *unistring, UTF8  *outbuffer, U32 len);
 
 template <size_t N>
 inline U32 convertUTF8toUTF16(const UTF8 *unistring, UTF16 (&outbuffer)[N])
 {
    return convertUTF8toUTF16N(unistring, outbuffer, (U32) N);
+}
+
+template <size_t N>
+inline U32 convertUTF16toUTF8(const UTF16 *unistring, UTF8 (&outbuffer)[N])
+{
+   return convertUTF16toUTF8N(unistring, outbuffer, (U32) N);
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/core/util/str.cpp
+++ b/Engine/source/core/util/str.cpp
@@ -346,7 +346,7 @@ class String::StringData : protected StringDataImpl
          {
             // Do this atomically to protect interned strings.
             
-            UTF16* utf16 = convertUTF8toUTF16( mData );
+            UTF16* utf16 = createUTF16string( mData );
             if( !dCompareAndSwap( mUTF16,( UTF16* ) NULL, utf16 ) )
                delete [] utf16;
          }
@@ -580,7 +580,7 @@ String::String(const UTF16 *str)
 
    if( str && str[ 0 ] )
    {
-      UTF8* utf8 = convertUTF16toUTF8( str );
+      UTF8* utf8 = createUTF8string( str );
       U32 len = dStrlen( utf8 );
       _string = new ( len ) StringData( utf8 );
       delete [] utf8;

--- a/Engine/source/core/util/test/strTest.cpp
+++ b/Engine/source/core/util/test/strTest.cpp
@@ -44,7 +44,7 @@ protected:
          : mData( str ), mLength( str ? dStrlen( str ) : 0 ), mUTF16( NULL )
       {
          if( str )
-            mUTF16 = convertUTF8toUTF16( mData );
+            mUTF16 = createUTF16string( mData );
       }
       ~StrTest()
       {

--- a/Engine/source/gfx/gFont.cpp
+++ b/Engine/source/gfx/gFont.cpp
@@ -423,7 +423,7 @@ U32 GFont::getStrNWidth(const UTF8 *str, U32 n)
 {
    // UTF8 conversion is expensive. Avoid converting in a tight loop.
    FrameTemp<UTF16> str16(n + 1);
-   convertUTF8toUTF16(str, str16, n + 1);
+   convertUTF8toUTF16N(str, str16, n + 1);
    return getStrNWidth(str16, dStrlen(str16));
 }
 
@@ -462,7 +462,7 @@ U32 GFont::getStrNWidth(const UTF16 *str, U32 n)
 U32 GFont::getStrNWidthPrecise(const UTF8 *str, U32 n)
 {
    FrameTemp<UTF16> str16(n + 1);
-   convertUTF8toUTF16(str, str16, n + 1);
+   convertUTF8toUTF16N(str, str16, n + 1);
    return getStrNWidthPrecise(str16, dStrlen(str16));
 }
 

--- a/Engine/source/gfx/gfxDrawUtil.cpp
+++ b/Engine/source/gfx/gfxDrawUtil.cpp
@@ -148,7 +148,7 @@ U32 GFXDrawUtil::drawTextN( GFont *font, const Point2I &ptDraw, const UTF8 *in_s
 
    // Convert to UTF16 temporarily.
    n++; // space for null terminator
-   FrameTemp<UTF16> ubuf( n * sizeof(UTF16) );
+   FrameTemp<UTF16> ubuf( n );
    convertUTF8toUTF16N(in_string, ubuf, n);
 
    return drawTextN( font, ptDraw, ubuf, n, colorTable, maxColorIndex, rot );

--- a/Engine/source/gfx/gfxDrawUtil.cpp
+++ b/Engine/source/gfx/gfxDrawUtil.cpp
@@ -149,7 +149,7 @@ U32 GFXDrawUtil::drawTextN( GFont *font, const Point2I &ptDraw, const UTF8 *in_s
    // Convert to UTF16 temporarily.
    n++; // space for null terminator
    FrameTemp<UTF16> ubuf( n * sizeof(UTF16) );
-   convertUTF8toUTF16(in_string, ubuf, n);
+   convertUTF8toUTF16N(in_string, ubuf, n);
 
    return drawTextN( font, ptDraw, ubuf, n, colorTable, maxColorIndex, rot );
 }

--- a/Engine/source/gui/controls/guiTextEditCtrl.cpp
+++ b/Engine/source/gui/controls/guiTextEditCtrl.cpp
@@ -279,7 +279,7 @@ void GuiTextEditCtrl::setText( const UTF16* txt)
 {
    if(txt && txt[0] != 0)
    {
-      UTF8* txt8 = convertUTF16toUTF8( txt );
+      UTF8* txt8 = createUTF8string( txt );
       Parent::setText( txt8 );
       delete[] txt8;
       mTextBuffer.set( txt );

--- a/Engine/source/platformWin32/nativeDialogs/fileDialog.cpp
+++ b/Engine/source/platformWin32/nativeDialogs/fileDialog.cpp
@@ -79,7 +79,7 @@ static LRESULT PASCAL OKBtnFolderHackProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
             char *filePath;
 #ifdef UNICODE
             char fileBuf[MAX_PATH];
-            convertUTF16toUTF8(ofn->lpstrFile, fileBuf, sizeof(fileBuf));
+            convertUTF16toUTF8(ofn->lpstrFile, fileBuf);
             filePath = fileBuf;
 #else
             filePath = ofn->lpstrFile;
@@ -140,7 +140,7 @@ static UINT_PTR CALLBACK FolderHookProc(HWND hdlg, UINT uMsg, WPARAM wParam, LPA
 
                      char filePath[MAX_PATH];
 #ifdef UNICODE
-                     convertUTF16toUTF8(buf, filePath, sizeof(filePath));
+                     convertUTF16toUTF8(buf, filePath);
 #else
                      dStrcpy( filePath, buf );
 #endif
@@ -158,7 +158,7 @@ static UINT_PTR CALLBACK FolderHookProc(HWND hdlg, UINT uMsg, WPARAM wParam, LPA
                            
 #ifdef UNICODE
                            char buf2[MAX_PATH];
-                           convertUTF16toUTF8(buf, buf2, sizeof(buf2));
+                           convertUTF16toUTF8(buf, buf2);
 #else
                            char *buf2 = buf;
 #endif
@@ -442,7 +442,7 @@ bool FileDialog::Execute()
    // Handle Result Properly for Unicode as well as ANSI
 #ifdef UNICODE
    if(pszFileTitle[0] || ! ( mData.mStyle & FileDialogData::FDS_OPEN && mData.mStyle & FileDialogData::FDS_MULTIPLEFILES ))
-      convertUTF16toUTF8( (UTF16*)pszFile, (UTF8*)pszResult, sizeof(pszResult));
+      convertUTF16toUTF8( (UTF16*)pszFile, pszResult);
    else
       convertUTF16toUTF8DoubleNULL( (UTF16*)pszFile, (UTF8*)pszResult, sizeof(pszResult));
 #else

--- a/Engine/source/platformWin32/nativeDialogs/fileDialog.cpp
+++ b/Engine/source/platformWin32/nativeDialogs/fileDialog.cpp
@@ -324,10 +324,10 @@ bool FileDialog::Execute()
    UTF16 pszFileTitle[MAX_PATH];
    UTF16 pszDefaultExtension[MAX_PATH];
    // Convert parameters to UTF16*'s
-   convertUTF8toUTF16((UTF8 *)mData.mDefaultFile, pszFile, sizeof(pszFile));
-   convertUTF8toUTF16((UTF8 *)mData.mDefaultPath, pszInitialDir, sizeof(pszInitialDir));
-   convertUTF8toUTF16((UTF8 *)mData.mTitle, pszTitle, sizeof(pszTitle));
-   convertUTF8toUTF16((UTF8 *)mData.mFilters, pszFilter, sizeof(pszFilter) );
+   convertUTF8toUTF16((UTF8 *)mData.mDefaultFile, pszFile);
+   convertUTF8toUTF16((UTF8 *)mData.mDefaultPath, pszInitialDir);
+   convertUTF8toUTF16((UTF8 *)mData.mTitle, pszTitle);
+   convertUTF8toUTF16((UTF8 *)mData.mFilters, pszFilter);
 #else
    // Not Unicode, All char*'s!
    char pszFile[MAX_PATH];

--- a/Engine/source/platformWin32/nativeDialogs/win32MsgBox.cpp
+++ b/Engine/source/platformWin32/nativeDialogs/win32MsgBox.cpp
@@ -101,8 +101,8 @@ S32 Platform::messageBox(const UTF8 *title, const UTF8 *message, MBButtons butto
       pWindow->setCursorVisible(true);
 
 #ifdef UNICODE
-   const UTF16 *msg = convertUTF8toUTF16(message);
-   const UTF16 *t = convertUTF8toUTF16(title);
+   const UTF16 *msg = createUTF16string(message);
+   const UTF16 *t = createUTF16string(title);
 #else
    const UTF8 *msg = message;
    const UTF8 *t = title;

--- a/Engine/source/platformWin32/winConsole.cpp
+++ b/Engine/source/platformWin32/winConsole.cpp
@@ -67,7 +67,7 @@ void WinConsole::enable(bool enabled)
       {
 #ifdef UNICODE
          UTF16 buf[512];
-         convertUTF8toUTF16((UTF8 *)title, buf, sizeof(buf));
+         convertUTF8toUTF16((UTF8 *)title, buf);
          SetConsoleTitle(buf);
 #else
          SetConsoleTitle(title);

--- a/Engine/source/platformWin32/winDInputDevice.cpp
+++ b/Engine/source/platformWin32/winDInputDevice.cpp
@@ -588,7 +588,7 @@ const char* DInputDevice::getName()
 {
 #ifdef UNICODE
    static UTF8 buf[512];
-   convertUTF16toUTF8(mDeviceInstance.tszInstanceName, buf, sizeof(buf));
+   convertUTF16toUTF8(mDeviceInstance.tszInstanceName, buf);
    return (const char *)buf;
 #else
    return mDeviceInstance.tszInstanceName;
@@ -600,7 +600,7 @@ const char* DInputDevice::getProductName()
 {
 #ifdef UNICODE
    static UTF8 buf[512];
-   convertUTF16toUTF8(mDeviceInstance.tszProductName, buf, sizeof(buf));
+   convertUTF16toUTF8(mDeviceInstance.tszProductName, buf);
    return (const char *)buf;
 #else
    return mDeviceInstance.tszProductName;

--- a/Engine/source/platformWin32/winExec.cpp
+++ b/Engine/source/platformWin32/winExec.cpp
@@ -88,15 +88,15 @@ ExecuteThread::ExecuteThread(const char *executable, const char *args /* = NULL 
 
 #ifdef UNICODE
    WCHAR exe[ 1024 ];
-   convertUTF8toUTF16( exeBuf, exe, sizeof( exe ) / sizeof( exe[ 0 ] ) );
+   convertUTF8toUTF16( exeBuf, exe );
 
    TempAlloc< WCHAR > argsBuf( ( args ? dStrlen( args ) : 0 ) + 1 );
    argsBuf[ argsBuf.size - 1 ] = 0;
 
    if( args )
-      convertUTF8toUTF16( args, argsBuf, argsBuf.size );
+      convertUTF8toUTF16N( args, argsBuf, argsBuf.size );
    if( directory )
-      convertUTF8toUTF16( directory, dirBuf, dirBuf.size );
+      convertUTF8toUTF16N( directory, dirBuf, dirBuf.size );
 #else
    char* exe = exeBuf;
    char* argsBuf = args;
@@ -162,7 +162,7 @@ void Platform::openFolder(const char* path )
 
 #ifdef UNICODE
    WCHAR p[ 1024 ];
-   convertUTF8toUTF16( filePath, p, sizeof( p ) / sizeof( p[ 0 ] ) );
+   convertUTF8toUTF16( filePath, p );
 #else
    char* p = filePath;
 #endif
@@ -179,7 +179,7 @@ void Platform::openFile(const char* path )
 
 #ifdef UNICODE
    WCHAR p[ 1024 ];
-   convertUTF8toUTF16( filePath, p, sizeof( p ) / sizeof( p[ 0 ] ) );
+   convertUTF8toUTF16( filePath, p );
 #else
    char* p = filePath;
 #endif

--- a/Engine/source/platformWin32/winFileio.cpp
+++ b/Engine/source/platformWin32/winFileio.cpp
@@ -601,7 +601,7 @@ static bool recurseDumpPath(const char *path, const char *pattern, Vector<Platfo
    do
    {
 #ifdef UNICODE
-      convertUTF16toUTF8( findData.cFileName, buf, buf.size );
+      convertUTF16toUTF8N( findData.cFileName, buf, buf.size );
       char* fnbuf = buf;
 #else
       char *fnbuf = findData.cFileName;
@@ -1213,10 +1213,10 @@ void Platform::getVolumeInformationList( Vector<VolumeInformation>& out_rVolumeI
 
 #ifdef UNICODE
             char buf[ sizeof( lpszFileSystem ) / sizeof( lpszFileSystem[ 0 ] ) * 3 + 1 ];
-            convertUTF16toUTF8( lpszFileSystem, buf, sizeof( buf ) / sizeof( buf[ 0 ] ) );
+            convertUTF16toUTF8( lpszFileSystem, buf );
             info.FileSystem = StringTable->insert( buf );
 
-            convertUTF16toUTF8( lpszVolumeName, buf, sizeof( buf ) / sizeof( buf[ 0 ] ) );
+            convertUTF16toUTF8( lpszVolumeName );
             info.Name = StringTable->insert( buf );
 #else
             info.FileSystem = StringTable->insert( lpszFileSystem );
@@ -1276,7 +1276,7 @@ bool Platform::hasSubDirectory(const char *pPath)
 
 #ifdef UNICODE
          char fileName[ 1024 ];
-         convertUTF16toUTF8( findData.cFileName, fileName, sizeof( fileName ) / sizeof( fileName[ 0 ] ) );
+         convertUTF16toUTF8( findData.cFileName, fileName );
 #else
          char* fileName = findData.cFileName;
 #endif
@@ -1397,7 +1397,7 @@ static bool recurseDumpDirectories(const char *basePath, const char *subPath, Ve
             continue;
 
 #ifdef UNICODE
-         convertUTF16toUTF8( findData.cFileName, fileName, fileName.size );
+         convertUTF16toUTF8N( findData.cFileName, fileName, fileName.size );
 #else
          char* fileName = findData.cFileName;
 #endif
@@ -1472,7 +1472,7 @@ StringTableEntry osGetTemporaryDirectory()
 #ifdef UNICODE
    TempAlloc< char > dirBuffer( len * 3 + 1 );
    char* dir = dirBuffer;
-   convertUTF16toUTF8( buffer, dir, dirBuffer.size );
+   convertUTF16toUTF8N( buffer, dir, dirBuffer.size );
 #else
    char* dir = buf;
 #endif

--- a/Engine/source/platformWin32/winFileio.cpp
+++ b/Engine/source/platformWin32/winFileio.cpp
@@ -1216,7 +1216,7 @@ void Platform::getVolumeInformationList( Vector<VolumeInformation>& out_rVolumeI
             convertUTF16toUTF8( lpszFileSystem, buf );
             info.FileSystem = StringTable->insert( buf );
 
-            convertUTF16toUTF8( lpszVolumeName );
+            convertUTF16toUTF8( lpszVolumeName, buf );
             info.Name = StringTable->insert( buf );
 #else
             info.FileSystem = StringTable->insert( lpszFileSystem );

--- a/Engine/source/platformWin32/winFileio.cpp
+++ b/Engine/source/platformWin32/winFileio.cpp
@@ -54,7 +54,7 @@ bool dFileDelete(const char * name)
    TempAlloc< TCHAR > buf( dStrlen( name ) + 1 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( name, buf, buf.size );
+   convertUTF8toUTF16N( name, buf, buf.size );
 #else
    dStrcpy( buf, name );
 #endif
@@ -74,8 +74,8 @@ bool dFileRename(const char *oldName, const char *newName)
    TempAlloc< TCHAR > newf( dStrlen( newName ) + 1 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( oldName, oldf, oldf.size );
-   convertUTF8toUTF16( newName, newf, newf.size );
+   convertUTF8toUTF16N( oldName, oldf, oldf.size );
+   convertUTF8toUTF16N( newName, newf, newf.size );
 #else
    dStrcpy(oldf, oldName);
    dStrcpy(newf, newName);
@@ -93,7 +93,7 @@ bool dFileTouch(const char * name)
    TempAlloc< TCHAR > buf( dStrlen( name ) + 1 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( name, buf, buf.size );
+   convertUTF8toUTF16N( name, buf, buf.size );
 #else
    dStrcpy( buf, name );
 #endif
@@ -119,8 +119,8 @@ bool dPathCopy(const char *fromName, const char *toName, bool nooverwrite)
    TempAlloc< TCHAR > to( dStrlen( toName ) + 1 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( fromName, from, from.size );
-   convertUTF8toUTF16( toName, to, to.size );
+   convertUTF8toUTF16N( fromName, from, from.size );
+   convertUTF8toUTF16N( toName, to, to.size );
 #else
    dStrcpy( from, fromName );
    dStrcpy( to, toName );
@@ -187,8 +187,8 @@ bool dPathCopy(const char *fromName, const char *toName, bool nooverwrite)
          backslash(toFile);
          
 #ifdef UNICODE
-         convertUTF8toUTF16( tempBuf, wtempBuf, wtempBuf.size );
-         convertUTF8toUTF16( tempBuf1, wtempBuf1, wtempBuf1.size );
+         convertUTF8toUTF16N( tempBuf, wtempBuf, wtempBuf.size );
+         convertUTF8toUTF16N( tempBuf1, wtempBuf1, wtempBuf1.size );
          WCHAR* f = wtempBuf1;
          WCHAR* t = wtempBuf;
 #else
@@ -256,7 +256,7 @@ File::FileStatus File::open(const char *filename, const AccessMode openMode)
    TempAlloc< TCHAR > fname( dStrlen( filename ) + 1 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( filename, fname, fname.size );
+   convertUTF8toUTF16N( filename, fname, fname.size );
 #else
    dStrcpy(fname, filename);
 #endif
@@ -586,7 +586,7 @@ static bool recurseDumpPath(const char *path, const char *pattern, Vector<Platfo
 
 #ifdef UNICODE
    TempAlloc< WCHAR > searchBuf( buf.size );
-   convertUTF8toUTF16( buf, searchBuf, searchBuf.size );
+   convertUTF8toUTF16N( buf, searchBuf, searchBuf.size );
    WCHAR* search = searchBuf;
 #else
    char *search = buf;
@@ -665,7 +665,7 @@ bool Platform::getFileTimes(const char *filePath, FileTime *createTime, FileTime
    TempAlloc< TCHAR > fp( dStrlen( filePath ) + 1 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( filePath, fp, fp.size );
+   convertUTF8toUTF16N( filePath, fp, fp.size );
 #else
    dStrcpy( fp, filePath );
 #endif
@@ -697,7 +697,7 @@ bool Platform::createPath(const char *file)
 
 #ifdef UNICODE
    TempAlloc< WCHAR > fileBuf( pathbuf.size );
-   convertUTF8toUTF16( file, fileBuf, fileBuf.size );
+   convertUTF8toUTF16N( file, fileBuf, fileBuf.size );
    const WCHAR* fileName = fileBuf;
    const WCHAR* dir;
 #else
@@ -820,7 +820,7 @@ bool Platform::setCurrentDirectory(StringTableEntry newDir)
    TempAlloc< TCHAR > buf( dStrlen( newDir ) + 2 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( newDir, buf, buf.size - 1 );
+   convertUTF8toUTF16N( newDir, buf, buf.size - 1 );
 #else
    dStrcpy( buf, newDir );
 #endif
@@ -935,7 +935,7 @@ bool Platform::isFile(const char *pFilePath)
    TempAlloc< TCHAR > buf( dStrlen( pFilePath ) + 1 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( pFilePath, buf, buf.size );
+   convertUTF8toUTF16N( pFilePath, buf, buf.size );
 #else
    dStrcpy( buf, pFilePath );
 #endif
@@ -974,7 +974,7 @@ S32 Platform::getFileSize(const char *pFilePath)
    TempAlloc< TCHAR > buf( dStrlen( pFilePath ) + 1 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( pFilePath, buf, buf.size );
+   convertUTF8toUTF16N( pFilePath, buf, buf.size );
 #else
    dStrcpy( buf, pFilePath );
 #endif
@@ -1011,7 +1011,7 @@ bool Platform::isDirectory(const char *pDirPath)
    TempAlloc< TCHAR > buf( dStrlen( pDirPath ) + 1 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( pDirPath, buf, buf.size );
+   convertUTF8toUTF16N( pDirPath, buf, buf.size );
 #else
    dStrcpy( buf, pDirPath );
 #endif
@@ -1057,8 +1057,8 @@ bool Platform::isSubDirectory(const char *pParent, const char *pDir)
    TempAlloc< TCHAR > dir( dStrlen( pDir ) + 1 );
 
 #ifdef UNICODE
-   convertUTF8toUTF16( fileName, file, file.size );
-   convertUTF8toUTF16( pDir, dir, dir.size );
+   convertUTF8toUTF16N( fileName, file, file.size );
+   convertUTF8toUTF16N( pDir, dir, dir.size );
 #else
    dStrcpy( file, fileName );
    dStrcpy( dir, pDir );
@@ -1251,7 +1251,7 @@ bool Platform::hasSubDirectory(const char *pPath)
 
 #ifdef UNICODE
    WCHAR buf[ 1024 ];
-   convertUTF8toUTF16( searchBuf, buf, sizeof( buf ) / sizeof( buf[ 0 ] ) );
+   convertUTF8toUTF16( searchBuf, buf );
    WCHAR* search = buf;
 #else
    char* search = searchBuf;
@@ -1335,7 +1335,7 @@ static bool recurseDumpDirectories(const char *basePath, const char *subPath, Ve
 
 #ifdef UNICODE
    TempAlloc< WCHAR > searchStr( dStrlen( search ) + 1 );
-   convertUTF8toUTF16( search, searchStr, searchStr.size );
+   convertUTF8toUTF16N( search, searchStr, searchStr.size );
 #else
    char* searchStr = search;
 #endif

--- a/Engine/source/platformWin32/winFileio.cpp
+++ b/Engine/source/platformWin32/winFileio.cpp
@@ -802,7 +802,7 @@ StringTableEntry Platform::getCurrentDirectory()
    forwardslash( buf );
 
 #ifdef UNICODE
-   char* utf8 = convertUTF16toUTF8( buf );
+   char* utf8 = createUTF8string( buf );
    StringTableEntry result = StringTable->insert( utf8 );
    SAFE_DELETE_ARRAY( utf8 );
    return result;
@@ -847,8 +847,8 @@ static void getExecutableInfo( StringTableEntry* path, StringTableEntry* exe )
          if( delimiter )
             *delimiter = '\0';
 
-         char* pathBuf = convertUTF16toUTF8( cen_buf );
-         char* exeBuf = convertUTF16toUTF8( delimiter + 1 );
+         char* pathBuf = createUTF8string( cen_buf );
+         char* exeBuf = createUTF8string( delimiter + 1 );
 
          pathEntry = StringTable->insert( pathBuf );
          exeEntry = StringTable->insert( exeBuf );

--- a/Engine/source/platformWin32/winFont.cpp
+++ b/Engine/source/platformWin32/winFont.cpp
@@ -104,7 +104,7 @@ BOOL CALLBACK EnumFamCallBack(LPLOGFONT logFont, LPNEWTEXTMETRIC textMetric, DWO
 
    const U32 len = dStrlen( logFont->lfFaceName ) * 3 + 1;
    FrameTemp<UTF8> buffer( len );
-   convertUTF16toUTF8( logFont->lfFaceName, buffer, len );
+   convertUTF16toUTF8N( logFont->lfFaceName, buffer, len );
 
    fonts->push_back( StringTable->insert( buffer ) );
 

--- a/Engine/source/platformWin32/winRedbook.cpp
+++ b/Engine/source/platformWin32/winRedbook.cpp
@@ -144,7 +144,7 @@ bool Win32RedBookDevice::open()
    openParms.lpstrDeviceType = (LPCWSTR)MCI_DEVTYPE_CD_AUDIO;
 
    UTF16 buf[512];
-   convertUTF8toUTF16((UTF8 *)mDeviceName, buf, sizeof(buf));
+   convertUTF8toUTF16((UTF8 *)mDeviceName, buf);
    openParms.lpstrElementName = buf;
 #else
    openParms.lpstrDeviceType = (LPCSTR)MCI_DEVTYPE_CD_AUDIO;

--- a/Engine/source/platformWin32/winUser.cpp
+++ b/Engine/source/platformWin32/winUser.cpp
@@ -52,7 +52,7 @@ const char *Platform::getUserDataDirectory()
 
 #ifdef UNICODE
    char path[ MAX_PATH * 3 + 1 ];
-   convertUTF16toUTF8( szBuffer, path, sizeof( path ) );
+   convertUTF16toUTF8( szBuffer, path );
 #else
    char* path = szBuffer;
 #endif
@@ -78,7 +78,7 @@ const char *Platform::getUserHomeDirectory()
 
 #ifdef UNICODE
    char path[ MAX_PATH * 3 + 1 ];
-   convertUTF16toUTF8( szBuffer, path, sizeof( path ) );
+   convertUTF16toUTF8( szBuffer, path );
 #else
    char* path = szBuffer;
 #endif

--- a/Engine/source/platformWin32/winVolume.cpp
+++ b/Engine/source/platformWin32/winVolume.cpp
@@ -720,13 +720,13 @@ String   Platform::FS::getAssetDir()
    {
       TCHAR buf[ 2048 ];
       ::GetModuleFileNameW( NULL, buf, sizeof( buf ) );
-      convertUTF16toUTF8( buf, cen_buf, sizeof( cen_buf ) );
+      convertUTF16toUTF8( buf, cen_buf );
    }
    else
    {
       TCHAR buf[ 2048 ];
       GetCurrentDirectoryW( sizeof( buf ) / sizeof( buf[ 0 ] ), buf );
-      convertUTF16toUTF8( buf, cen_buf, sizeof( cen_buf ) );
+      convertUTF16toUTF8( buf, cen_buf );
       return Path::CleanSeparators(cen_buf);
    }
 #else

--- a/Engine/source/platformWin32/winWindow.cpp
+++ b/Engine/source/platformWin32/winWindow.cpp
@@ -362,7 +362,7 @@ S32 WINAPI WinMain( HINSTANCE hInstance, HINSTANCE, LPSTR lpszCmdLine, S32)
    {
       TCHAR buf[ moduleNameSize ];
       GetModuleFileNameW( NULL, buf, moduleNameSize );
-      convertUTF16toUTF8( buf, moduleName, moduleNameSize );
+      convertUTF16toUTF8( buf, moduleName );
    }
 #else
    GetModuleFileNameA(NULL, moduleName, moduleNameSize);
@@ -440,7 +440,7 @@ S32 torque_winmain( HINSTANCE hInstance, HINSTANCE, LPSTR lpszCmdLine, S32)
    {
       TCHAR buf[ moduleNameSize ];
       GetModuleFileNameW( NULL, buf, moduleNameSize );
-      convertUTF16toUTF8( buf, moduleName, moduleNameSize );
+      convertUTF16toUTF8( buf, moduleName );
    }
 #else
    GetModuleFileNameA(NULL, moduleName, moduleNameSize);
@@ -541,7 +541,7 @@ bool Platform::openWebBrowser( const char* webAddress )
       RegCloseKey( regKey );
       sHaveKey = true;
 
-      convertUTF16toUTF8(sWebKey,utf8WebKey,512);
+      convertUTF16toUTF8(sWebKey,utf8WebKey);
 
 #ifdef UNICODE
       char *p = dStrstr((const char *)utf8WebKey, "%1"); 

--- a/Engine/source/platformWin32/winWindow.cpp
+++ b/Engine/source/platformWin32/winWindow.cpp
@@ -104,7 +104,7 @@ bool Platform::excludeOtherInstances(const char *mutexName)
 {
 #ifdef UNICODE
    UTF16 b[512];
-   convertUTF8toUTF16((UTF8 *)mutexName, b, sizeof(b));
+   convertUTF8toUTF16((UTF8 *)mutexName, b);
    gMutexHandle = CreateMutex(NULL, true, b);
 #else
    gMutexHandle = CreateMutex(NULL, true, mutexName);
@@ -164,7 +164,7 @@ bool Platform::checkOtherInstances(const char *mutexName)
    
 #ifdef UNICODE
    UTF16 b[512];
-   convertUTF8toUTF16((UTF8 *)mutexName, b, sizeof(b));
+   convertUTF8toUTF16((UTF8 *)mutexName, b);
    pMutex  = CreateMutex(NULL, true, b);
 #else
    pMutex = CreateMutex(NULL, true, mutexName);
@@ -197,8 +197,8 @@ void Platform::AlertOK(const char *windowTitle, const char *message)
    ShowCursor(true);
 #ifdef UNICODE
    UTF16 m[1024], t[512];
-   convertUTF8toUTF16((UTF8 *)windowTitle, t, sizeof(t));
-   convertUTF8toUTF16((UTF8 *)message, m, sizeof(m));
+   convertUTF8toUTF16((UTF8 *)windowTitle, t);
+   convertUTF8toUTF16((UTF8 *)message, m);
    MessageBox(NULL, m, t, MB_ICONINFORMATION | MB_SETFOREGROUND | MB_TASKMODAL | MB_OK);
 #else
    MessageBox(NULL, message, windowTitle, MB_ICONINFORMATION | MB_SETFOREGROUND | MB_TASKMODAL | MB_OK);
@@ -211,8 +211,8 @@ bool Platform::AlertOKCancel(const char *windowTitle, const char *message)
    ShowCursor(true);
 #ifdef UNICODE
    UTF16 m[1024], t[512];
-   convertUTF8toUTF16((UTF8 *)windowTitle, t, sizeof(t));
-   convertUTF8toUTF16((UTF8 *)message, m, sizeof(m));
+   convertUTF8toUTF16((UTF8 *)windowTitle, t);
+   convertUTF8toUTF16((UTF8 *)message, m);
    return MessageBox(NULL, m, t, MB_ICONINFORMATION | MB_SETFOREGROUND | MB_TASKMODAL | MB_OKCANCEL) == IDOK;
 #else
    return MessageBox(NULL, message, windowTitle, MB_ICONINFORMATION | MB_SETFOREGROUND | MB_TASKMODAL | MB_OKCANCEL) == IDOK;
@@ -225,8 +225,8 @@ bool Platform::AlertRetry(const char *windowTitle, const char *message)
    ShowCursor(true);
 #ifdef UNICODE
    UTF16 m[1024], t[512];
-   convertUTF8toUTF16((UTF8 *)windowTitle, t, sizeof(t));
-   convertUTF8toUTF16((UTF8 *)message, m, sizeof(m));
+   convertUTF8toUTF16((UTF8 *)windowTitle, t);
+   convertUTF8toUTF16((UTF8 *)message, m);
    return (MessageBox(NULL, m, t, MB_ICONINFORMATION | MB_SETFOREGROUND | MB_TASKMODAL | MB_RETRYCANCEL) == IDRETRY);
 #else
    return (MessageBox(NULL, message, windowTitle, MB_ICONINFORMATION | MB_SETFOREGROUND | MB_TASKMODAL | MB_RETRYCANCEL) == IDRETRY);
@@ -241,8 +241,8 @@ Platform::ALERT_ASSERT_RESULT Platform::AlertAssert(const char *windowTitle, con
 
 #ifdef UNICODE
    UTF16 messageUTF[1024], title[512];
-   convertUTF8toUTF16((UTF8 *)windowTitle, title, sizeof(title));
-   convertUTF8toUTF16((UTF8 *)message, messageUTF, sizeof(messageUTF));
+   convertUTF8toUTF16((UTF8 *)windowTitle, title);
+   convertUTF8toUTF16((UTF8 *)message, messageUTF);
 #else
    const char* messageUTF = message;
    const char* title = windowTitle;
@@ -560,7 +560,7 @@ bool Platform::openWebBrowser( const char* webAddress )
 #ifdef UNICODE
    dSprintf( buf, sizeof( buf ), "%s %s", utf8WebKey, webAddress );   
    UTF16 b[1024];
-   convertUTF8toUTF16((UTF8 *)buf, b, sizeof(b));
+   convertUTF8toUTF16((UTF8 *)buf, b);
 #else
    dSprintf( buf, sizeof( buf ), "%s %s", sWebKey, webAddress );   
 #endif

--- a/Engine/source/windowManager/win32/win32CursorController.cpp
+++ b/Engine/source/windowManager/win32/win32CursorController.cpp
@@ -160,6 +160,10 @@ void Win32CursorController::setCursorShape( const UTF8 *fileName, bool reload )
    
    if ( gCursorShape )
       SetCursor( gCursorShape );
+
+#ifdef UNICODE
+   delete[] lFileName;
+#endif
 }
 
 // Console function to set the current cursor shape given the cursor shape

--- a/Engine/source/windowManager/win32/win32CursorController.cpp
+++ b/Engine/source/windowManager/win32/win32CursorController.cpp
@@ -150,7 +150,7 @@ static HCURSOR gCursorShape = NULL;
 void Win32CursorController::setCursorShape( const UTF8 *fileName, bool reload )
 {
 #ifdef UNICODE
-   const UTF16 *lFileName = convertUTF8toUTF16( fileName );
+   const UTF16 *lFileName = createUTF16string( fileName );
 #else
    const UTF8  *lFileName = fileName;
 #endif


### PR DESCRIPTION
Fixes about 15 actual buffer overflows due to incorrect use of sizeof on UTF16 strings, and provides safer functions to use for static sized buffers. We found that some of these (in fileDialog.cpp) were regularly writing into caller's stack frames.