### PR TITLE
fixed a possible crash on setting a cubemap

### DIFF
--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -394,7 +394,7 @@ void GFXDevice::updateStates(bool forceSetAll /*=false*/)
             case GFXTDT_Cube :
                {
                   mCurrentCubemap[i] = mNewCubemap[i];
-                  if (mCurrentCubemap[i])
+                  if (mCurrentCubemap[i].isValid())
                      mCurrentCubemap[i]->setToTexUnit(i);
                   else
                      setTextureInternal(i, NULL);


### PR DESCRIPTION
That's the correct way to check a StrongRefPtr<T>