### PR TITLE
Show the canvas immediately in unix because the splash doesn't work

### DIFF
--- a/Templates/Empty/game/main.cs
+++ b/Templates/Empty/game/main.cs
@@ -40,7 +40,7 @@ function createCanvas(%windowTitle)
    // Create the Canvas
    %foo = new GuiCanvas(Canvas)
    {
-      displayWindow = false;
+      displayWindow = $platform !$= "windows";
    };
    
    // Set the window title

--- a/Templates/Empty/game/main.cs.in
+++ b/Templates/Empty/game/main.cs.in
@@ -40,7 +40,7 @@ function createCanvas(%windowTitle)
    // Create the Canvas
    %foo = new GuiCanvas(Canvas)
    {
-      displayWindow = false;
+      displayWindow = $platform !$= "windows";
    };
    
    // Set the window title

--- a/Templates/Full/game/main.cs
+++ b/Templates/Full/game/main.cs
@@ -40,7 +40,7 @@ function createCanvas(%windowTitle)
    // Create the Canvas
    %foo = new GuiCanvas(Canvas)
    {
-      displayWindow = false;
+      displayWindow = $platform !$= "windows";
    };
    
    // Set the window title

--- a/Templates/Full/game/main.cs.in
+++ b/Templates/Full/game/main.cs.in
@@ -40,7 +40,7 @@ function createCanvas(%windowTitle)
    // Create the Canvas
    %foo = new GuiCanvas(Canvas)
    {
-      displayWindow = false;
+      displayWindow = $platform !$= "windows";
    };
    
    // Set the window title


### PR DESCRIPTION
`displaySplashScreen` doesn't work, meaning nothing appears for ages. So on unix we'll show the canvas immediately even though it looks a little ugly.