### PR TITLE
Include navigation and testing modules by default

### DIFF
--- a/Engine/source/T3D/aiPlayer.cpp
+++ b/Engine/source/T3D/aiPlayer.cpp
@@ -28,6 +28,8 @@
 #include "T3D/gameBase/moveManager.h"
 #include "console/engineAPI.h"
 
+#include <cfloat>
+
 static U32 sAIPlayerLoSMask = TerrainObjectType | StaticShapeObjectType | StaticObjectType;
 
 IMPLEMENT_CO_NETOBJECT_V1(AIPlayer);

--- a/Engine/source/math/test/mMatrixTest.cpp
+++ b/Engine/source/math/test/mMatrixTest.cpp
@@ -30,7 +30,7 @@ extern void default_matF_x_matF_C(const F32 *a, const F32 *b, F32 *mresult);
 extern void mInstallLibrary_ASM();
 
 // If we're x86 and not Mac, then include these. There's probably a better way to do this.
-#if defined(TORQUE_CPU_X86) && !defined(TORQUE_OS_MAC)
+#if defined(WIN32) && defined(TORQUE_CPU_X86)
 extern "C" void Athlon_MatrixF_x_MatrixF(const F32 *matA, const F32 *matB, F32 *result);
 extern "C" void SSE_MatrixF_x_MatrixF(const F32 *matA, const F32 *matB, F32 *result);
 #endif
@@ -55,7 +55,7 @@ TEST(MatrixF, MultiplyImplmentations)
    // C will be the baseline
    default_matF_x_matF_C(m1, m2, mrC);
 
-#if defined(TORQUE_CPU_X86) && !defined(TORQUE_OS_MAC)
+#if defined(WIN32) && defined(TORQUE_CPU_X86)
    // Check the CPU info
    U32 cpuProperties = Platform::SystemInfo.processor.properties;
    bool same;

--- a/Engine/source/navigation/navPath.cpp
+++ b/Engine/source/navigation/navPath.cpp
@@ -37,6 +37,7 @@
 #include "math/mathIO.h"
 
 #include <DetourDebugDraw.h>
+#include <climits>
 
 extern bool gEditingMission;
 

--- a/Engine/source/platform/test/platformFileIOTest.cpp
+++ b/Engine/source/platform/test/platformFileIOTest.cpp
@@ -97,8 +97,8 @@ TEST(File, TouchAndTime)
       << "Somehow failed to delete our test file.";
 };
 
-// Mac has no implementations for these functions, so we 'def it out for now.
-#ifndef __MACOSX__
+// Mac/Linux have no implementations for these functions, so we 'def it out for now.
+#ifdef WIN32
 TEST(Platform, Volumes)
 {
    Vector<const char*> names;

--- a/Engine/source/platform/test/platformTimerTest.cpp
+++ b/Engine/source/platform/test/platformTimerTest.cpp
@@ -44,24 +44,26 @@ TEST(Platform, Sleep)
       << "We didn't sleep at least as long as we requested!";
 };
 
+struct handle
+{
+   S32 mElapsedTime;
+   S32 mNumberCalls;
+
+   handle() : mElapsedTime(0), mNumberCalls(0) {}
+
+   void timeEvent(S32 timeDelta)
+   {
+      mElapsedTime += timeDelta;
+      mNumberCalls++;
+      
+      if(mElapsedTime >= 1000)
+         Process::requestShutdown();
+   }
+};
+
 TEST(TimeManager, BasicAPI)
 {
-   struct handle
-   {
-      S32 mElapsedTime;
-      S32 mNumberCalls;
-
-      void timeEvent(S32 timeDelta)
-      {
-         mElapsedTime += timeDelta;
-         mNumberCalls++;
-      
-         if(mElapsedTime >= 1000)
-            Process::requestShutdown();
-      }
-   } handler;
-
-   handler.mElapsedTime = handler.mNumberCalls = 0;
+   handle handler;
 
    // Initialize the time manager...
    TimeManager time;

--- a/Engine/source/platform/test/profilerTest.cpp
+++ b/Engine/source/platform/test/profilerTest.cpp
@@ -33,10 +33,10 @@ TEST(Profiler, ProfileStartEnd)
    // Do work.
    if(true)
    {
-      PROFILE_END(ProfileStartEndTest);
+      PROFILE_END();
       return;
    }
-   PROFILE_END(ProfileStartEndTest);
+   PROFILE_END();
 }
 
 TEST(Profiler, ProfileScope)

--- a/Tools/CMake/modules/module_navigation.cmake
+++ b/Tools/CMake/modules/module_navigation.cmake
@@ -21,8 +21,7 @@
 # -----------------------------------------------------------------------------
 
 # Navigation module
-option(TORQUE_NAVIGATION "Enable Navigation module" OFF)
-#mark_as_advanced(TORQUE_NAVIGATION)
+option(TORQUE_NAVIGATION "Enable Navigation module" ON)
 
 if(TORQUE_NAVIGATION)
 	addDef( "TORQUE_NAVIGATION_ENABLED" )

--- a/Tools/CMake/modules/module_testing.cmake
+++ b/Tools/CMake/modules/module_testing.cmake
@@ -20,7 +20,7 @@
 # IN THE SOFTWARE.
 # -----------------------------------------------------------------------------
 
-option(TORQUE_TESTING "Enable unit test module" OFF)
+option(TORQUE_TESTING "Enable unit test module" ON)
 mark_as_advanced(TORQUE_TESTING)
 
 if(TORQUE_TESTING)

--- a/projects.xml
+++ b/projects.xml
@@ -34,8 +34,8 @@ Here are some examples:
     <module name="razerHydra" path="$RAZERHYDRA_SDK_PATH">Razer Hydra Controller</module>
     <module name="oculusVR" path="$OCULUSVR_SDK_PATH">Oculus VR Devices</module>
     <module name="webDeploy">Web Deployment</module>
-    <module name="navigation">Recast Navigation</module>
-    <module name="testing">Unit testing</module>
+    <module name="navigation" default="1">Recast Navigation</module>
+    <module name="testing" default="1">Unit testing</module>
     <moduleGroup description="Physics Library">
       <module name="" donotwrite="1" default="1">Torque Physics</module>
       <module name="physX">PhysX 2.8 Physics Library</module>


### PR DESCRIPTION
 * They are both useful and can easily be turned off.
 * Navigation being off by default causes problems with the navmesh editor, which is _included_ by default, but nonfunctional unless the module is included.
 * Navigation can kind of be considered a stock feature.

The only problem is that I see no way to do something equivalent with the project generator. We could add `includeModule` to the Templates' default config files, but this won't show up in the manager UI when you create a new project.