### PR TITLE
Fix for console stack

### DIFF
--- a/Engine/source/T3D/gameBase/gameConnection.cpp
+++ b/Engine/source/T3D/gameBase/gameConnection.cpp
@@ -459,6 +459,14 @@ bool GameConnection::readConnectRequest(BitStream *stream, const char **errorStr
       return false;
    }
    ConsoleValueRef connectArgv[MaxConnectArgs + 3];
+   ConsoleValue connectArgvValue[MaxConnectArgs + 3];
+
+   for(U32 i = 0; i < mConnectArgc+3; i++)
+   {
+	   connectArgv[i].value = &connectArgvValue[i];
+	   connectArgvValue[i].init();
+   }
+
    for(U32 i = 0; i < mConnectArgc; i++)
    {
       char argString[256];
@@ -466,11 +474,11 @@ bool GameConnection::readConnectRequest(BitStream *stream, const char **errorStr
       mConnectArgv[i] = dStrdup(argString);
       connectArgv[i + 3] = mConnectArgv[i];
    }
-   connectArgv[0] = "onConnectRequest";
-   connectArgv[1] = 0;
+   connectArgvValue[0].setStackStringValue("onConnectRequest");
+   connectArgvValue[1].setIntValue(0);
    char buffer[256];
    Net::addressToString(getNetAddress(), buffer);
-   connectArgv[2] = buffer;
+   connectArgvValue[2].setStackStringValue(buffer);
 
    // NOTE: Cannot convert over to IMPLEMENT_CALLBACK as it has variable args.
    const char *ret = Con::execute(this, mConnectArgc + 3, connectArgv);

--- a/Engine/source/T3D/gameBase/gameConnectionEvents.cpp
+++ b/Engine/source/T3D/gameBase/gameConnectionEvents.cpp
@@ -32,6 +32,7 @@
 #include "app/game.h"
 #include "T3D/gameBase/gameConnection.h"
 #include "T3D/gameBase/gameConnectionEvents.h"
+#include "console/engineAPI.h"
 
 #define DebugChecksum 0xF00DBAAD
 
@@ -234,7 +235,7 @@ void SimDataBlockEvent::process(NetConnection *cptr)
    if(mProcess)
    {
       //call the console function to set the number of blocks to be sent
-      Con::executef("onDataBlockObjectReceived", Con::getIntArg(mIndex), Con::getIntArg(mTotal));
+      Con::executef("onDataBlockObjectReceived", mIndex, mTotal);
 
       String &errorBuffer = NetConnection::getErrorBuffer();
                      

--- a/Engine/source/T3D/item.cpp
+++ b/Engine/source/T3D/item.cpp
@@ -292,7 +292,7 @@ IMPLEMENT_CALLBACK( Item, onStickyCollision, void, ( const char* objID ),( objID
    "@see Item, ItemData\n"
 );
 
-IMPLEMENT_CALLBACK( Item, onEnterLiquid, void, ( const char* objID, const char* waterCoverage, const char* liquidType ),( objID, waterCoverage, liquidType ),
+IMPLEMENT_CALLBACK( Item, onEnterLiquid, void, ( const char* objID, F32 waterCoverage, const char* liquidType ),( objID, waterCoverage, liquidType ),
    "Informs an Item object that it has entered liquid, along with information about the liquid type.\n"
    "@param objID Object ID for this Item object.\n"
    "@param waterCoverage How much coverage of water this Item object has.\n"
@@ -1005,7 +1005,7 @@ void Item::updatePos(const U32 /*mask*/, const F32 dt)
       {
          if(!mInLiquid && mWaterCoverage != 0.0f)
          {
-			onEnterLiquid_callback( getIdString(), Con::getFloatArg(mWaterCoverage), mLiquidType.c_str() );
+			onEnterLiquid_callback( getIdString(), mWaterCoverage, mLiquidType.c_str() );
             mInLiquid = true;
          }
          else if(mInLiquid && mWaterCoverage == 0.0f)

--- a/Engine/source/T3D/item.h
+++ b/Engine/source/T3D/item.h
@@ -114,7 +114,7 @@ class Item: public ShapeBase
 
   protected:
 	DECLARE_CALLBACK( void, onStickyCollision, ( const char* objID ));
-	DECLARE_CALLBACK( void, onEnterLiquid, ( const char* objID, const char* waterCoverage, const char* liquidType ));
+	DECLARE_CALLBACK( void, onEnterLiquid, ( const char* objID, F32 waterCoverage, const char* liquidType ));
 	DECLARE_CALLBACK( void, onLeaveLiquid, ( const char* objID, const char* liquidType ));
 
   public:

--- a/Engine/source/T3D/pathCamera.cpp
+++ b/Engine/source/T3D/pathCamera.cpp
@@ -104,7 +104,7 @@ ConsoleDocClass( PathCamera,
    "@ingroup PathCameras\n"
 );
 
-IMPLEMENT_CALLBACK( PathCamera, onNode, void, (const char* node), (node),
+IMPLEMENT_CALLBACK( PathCamera, onNode, void, (S32 node), (node),
 					"A script callback that indicates the path camera has arrived at a specific node in its path.  Server side only.\n"
 					"@param Node Unique ID assigned to this node.\n");
 
@@ -408,7 +408,7 @@ void PathCamera::popFront()
 void PathCamera::onNode(S32 node)
 {
    if (!isGhost())
-		onNode_callback(Con::getIntArg(node));
+		onNode_callback(node);
    
 }
 

--- a/Engine/source/T3D/pathCamera.h
+++ b/Engine/source/T3D/pathCamera.h
@@ -93,7 +93,7 @@ private:
 public:
    DECLARE_CONOBJECT(PathCamera);
    
-   DECLARE_CALLBACK( void, onNode, (const char* node));
+   DECLARE_CALLBACK( void, onNode, (S32 node));
 
    PathCamera();
    ~PathCamera();

--- a/Engine/source/T3D/rigidShape.cpp
+++ b/Engine/source/T3D/rigidShape.cpp
@@ -153,7 +153,7 @@ ConsoleDocClass( RigidShape,
 );
 
 
-IMPLEMENT_CALLBACK( RigidShape, onEnterLiquid, void, ( const char* objId, const char* waterCoverage, const char* liquidType ),
+IMPLEMENT_CALLBACK( RigidShape, onEnterLiquid, void, ( const char* objId, F32 waterCoverage, const char* liquidType ),
 													 ( objId, waterCoverage, liquidType ),
    "@brief Called whenever this RigidShape object enters liquid.\n\n"
    "@param objId The ID of the rigidShape object.\n"
@@ -1088,7 +1088,7 @@ void RigidShape::updatePos(F32 dt)
       // Water script callbacks      
       if (!inLiquid && mWaterCoverage != 0.0f) 
       {
-         onEnterLiquid_callback(getIdString(), Con::getFloatArg(mWaterCoverage), mLiquidType.c_str() );
+         onEnterLiquid_callback(getIdString(), mWaterCoverage, mLiquidType.c_str() );
          inLiquid = true;
       }
       else if (inLiquid && mWaterCoverage == 0.0f) 

--- a/Engine/source/T3D/rigidShape.h
+++ b/Engine/source/T3D/rigidShape.h
@@ -296,7 +296,7 @@ public:
    void unpackUpdate(NetConnection *conn,           BitStream *stream);
 
    DECLARE_CONOBJECT(RigidShape);
-   DECLARE_CALLBACK( void, onEnterLiquid, ( const char* objId, const char* waterCoverage, const char* liquidType ));
+   DECLARE_CALLBACK( void, onEnterLiquid, ( const char* objId, F32 waterCoverage, const char* liquidType ));
    DECLARE_CALLBACK( void, onLeaveLiquid, ( const char* objId, const char* liquidType ));
 };
 

--- a/Engine/source/app/badWordFilter.cpp
+++ b/Engine/source/app/badWordFilter.cpp
@@ -23,9 +23,10 @@
 #include "core/strings/stringFunctions.h"
 
 #include "console/consoleTypes.h"
+#include "console/simBase.h"
+#include "console/engineAPI.h"
 #include "app/badWordFilter.h"
 #include "core/module.h"
-#include "console/engineAPI.h"
 
 MODULE_BEGIN( BadWordFilter )
 

--- a/Engine/source/app/net/serverQuery.cpp
+++ b/Engine/source/app/net/serverQuery.cpp
@@ -1342,7 +1342,7 @@ static void processPingsAndQueries( U32 session, bool schedule )
       else
          dSprintf( msg, sizeof( msg ), "%d servers found.", foundCount );
 
-      Con::executef( "onServerQueryStatus", "done", msg, "1");
+      Con::executef( "onServerQueryStatus", "done", (const char*)msg, "1");
    }
 }
 

--- a/Engine/source/console/arrayObject.cpp
+++ b/Engine/source/console/arrayObject.cpp
@@ -103,9 +103,7 @@ S32 QSORT_CALLBACK ArrayObject::_keyFunctionCompare( const void* a, const void* 
    ArrayObject::Element* ea = ( ArrayObject::Element* )( a );
    ArrayObject::Element* eb = ( ArrayObject::Element* )( b );
    
-   ConsoleValueRef argv[] = { smCompareFunction, ea->key, eb->key }; 
-   
-   S32 result = dAtoi( Con::execute( 3, argv ) );
+   S32 result = dAtoi( Con::executef( (const char*)smCompareFunction, ea->value, eb->key ) );
    S32 res = result < 0 ? -1 : ( result > 0 ? 1 : 0 );
    return ( smDecreasing ? -res : res );
 }
@@ -115,9 +113,7 @@ S32 QSORT_CALLBACK ArrayObject::_valueFunctionCompare( const void* a, const void
    ArrayObject::Element* ea = ( ArrayObject::Element* )( a );
    ArrayObject::Element* eb = ( ArrayObject::Element* )( b );
    
-   ConsoleValueRef argv[] = { smCompareFunction, ea->value, eb->value }; 
-   
-   S32 result = dAtoi( Con::execute( 3, argv ) );
+   S32 result = dAtoi( Con::executef( (const char*)smCompareFunction, ea->value, eb->value ) );
    S32 res = result < 0 ? -1 : ( result > 0 ? 1 : 0 );
    return ( smDecreasing ? -res : res );
 }

--- a/Engine/source/console/codeBlock.cpp
+++ b/Engine/source/console/codeBlock.cpp
@@ -570,7 +570,7 @@ bool CodeBlock::compile(const char *codeFileName, StringTableEntry fileName, con
 
 }
 
-const char *CodeBlock::compileExec(StringTableEntry fileName, const char *inString, bool noCalls, S32 setFrame)
+ConsoleValueRef CodeBlock::compileExec(StringTableEntry fileName, const char *inString, bool noCalls, S32 setFrame)
 {
 	AssertFatal(Con::isMainThread(), "Compiling code on a secondary thread");
 	
@@ -635,7 +635,7 @@ const char *CodeBlock::compileExec(StringTableEntry fileName, const char *inStri
    if(!gStatementList)
    {
       delete this;
-      return "";
+      return ConsoleValueRef();
    }
 
    resetTables();

--- a/Engine/source/console/codeBlock.h
+++ b/Engine/source/console/codeBlock.h
@@ -129,7 +129,7 @@ public:
    /// with, zero being the top of the stack. If the the index is
    /// -1 a new frame is created. If the index is out of range the
    /// top stack frame is used.
-   const char *compileExec(StringTableEntry fileName, const char *script, 
+   ConsoleValueRef compileExec(StringTableEntry fileName, const char *script, 
       bool noCalls, S32 setFrame = -1 );
 
    /// Executes the existing code in the CodeBlock. The return string is any 

--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -1756,6 +1756,8 @@ const char *ConsoleValue::getStringValue()
 {
    if(type == TypeInternalString || type == TypeInternalStackString)
       return sval;
+   else if (type == TypeInternalStringStackPtr)
+      return STR.mBuffer + (U32)sval;
    if(type == TypeInternalFloat)
       return Con::getData(TypeF32, &fval, 0);
    else if(type == TypeInternalInt)
@@ -1764,10 +1766,18 @@ const char *ConsoleValue::getStringValue()
       return Con::getData(type, dataPtr, 0, enumTable);
 }
 
+StringStackPtr ConsoleValue::getStringStackPtr()
+{
+   if (type == TypeInternalStringStackPtr)
+      return (U32)sval;
+   else
+      return (U32)-1;
+}
+
 bool ConsoleValue::getBoolValue()
 {
-   if(type == TypeInternalString || type == TypeInternalStackString)
-      return dAtob(sval);
+   if(type == TypeInternalString || type == TypeInternalStackString || type == TypeInternalStringStackPtr)
+      return dAtob(getStringValue());
    if(type == TypeInternalFloat)
       return fval > 0;
    else if(type == TypeInternalInt)
@@ -1791,7 +1801,7 @@ void ConsoleValue::setIntValue(U32 val)
       ival = val;
       if(sval != typeValueEmpty)
       {
-         if (type != TypeInternalStackString) dFree(sval);
+         if (type != TypeInternalStackString && type != TypeInternalStringStackPtr) dFree(sval);
          sval = typeValueEmpty;
       }
       type = TypeInternalInt;
@@ -1816,7 +1826,7 @@ void ConsoleValue::setFloatValue(F32 val)
       ival = static_cast<U32>(val);
       if(sval != typeValueEmpty)
       {
-         if (type != TypeInternalStackString) dFree(sval);
+         if (type != TypeInternalStackString && type != TypeInternalStringStackPtr) dFree(sval);
          sval = typeValueEmpty;
       }
       type = TypeInternalFloat;

--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -1138,8 +1138,11 @@ void addCommand( const char *name,BoolCallback cb,const char *usage, S32 minArgs
    Namespace::global()->addCommand( StringTable->insert(name), cb, usage, minArgs, maxArgs, isToolOnly, header );
 }
 
-const char *evaluate(const char* string, bool echo, const char *fileName)
+ConsoleValueRef evaluate(const char* string, bool echo, const char *fileName)
 {
+   ConsoleStackFrameSaver stackSaver;
+   stackSaver.save();
+
    if (echo)
    {
       if (string[0] == '%')
@@ -1156,8 +1159,11 @@ const char *evaluate(const char* string, bool echo, const char *fileName)
 }
 
 //------------------------------------------------------------------------------
-const char *evaluatef(const char* string, ...)
+ConsoleValueRef evaluatef(const char* string, ...)
 {
+   ConsoleStackFrameSaver stackSaver;
+   stackSaver.save();
+
    char buffer[4096];
    va_list args;
    va_start(args, string);
@@ -1166,26 +1172,34 @@ const char *evaluatef(const char* string, ...)
    return newCodeBlock->compileExec(NULL, buffer, false, 0);
 }
 
-const char *execute(S32 argc, ConsoleValueRef argv[])
+//------------------------------------------------------------------------------
+
+// Internal execute for global function which does not save the stack
+ConsoleValueRef _internalExecute(S32 argc, ConsoleValueRef argv[])
+{
+   Namespace::Entry *ent;
+   StringTableEntry funcName = StringTable->insert(argv[0]);
+   ent = Namespace::global()->lookup(funcName);
+
+   if(!ent)
+   {
+      warnf(ConsoleLogEntry::Script, "%s: Unknown command.", (const char*)argv[0]);
+
+      STR.clearFunctionOffset();
+      return ConsoleValueRef();
+   }
+   return ent->execute(argc, argv, &gEvalState);
+}
+
+ConsoleValueRef execute(S32 argc, ConsoleValueRef argv[])
 {
 #ifdef TORQUE_MULTITHREAD
    if(isMainThread())
    {
 #endif
-      Namespace::Entry *ent;
-      StringTableEntry funcName = StringTable->insert(argv[0]);
-      ent = Namespace::global()->lookup(funcName);
-
-      if(!ent)
-      {
-         warnf(ConsoleLogEntry::Script, "%s: Unknown command.", (const char*)argv[0]);
-
-         // Clean up arg buffers, if any.
-         STR.clearFunctionOffset();
-         CSTK.resetFrame();
-         return "";
-      }
-      return ent->execute(argc, argv, &gEvalState);
+      ConsoleStackFrameSaver stackSaver;
+      stackSaver.save();
+	   return _internalExecute(argc, argv);
 #ifdef TORQUE_MULTITHREAD
    }
    else
@@ -1199,17 +1213,24 @@ const char *execute(S32 argc, ConsoleValueRef argv[])
 #endif
 }
 
-const char *execute(S32 argc, const char *argv[])
+ConsoleValueRef execute(S32 argc, const char *argv[])
 {
+   ConsoleStackFrameSaver stackSaver;
+   stackSaver.save();
    StringStackConsoleWrapper args(argc, argv);
    return execute(args.count(), args);
 }
 
 //------------------------------------------------------------------------------
-const char *execute(SimObject *object, S32 argc, ConsoleValueRef argv[], bool thisCallOnly)
+
+// Internal execute for object method which does not save the stack
+ConsoleValueRef _internalExecute(SimObject *object, S32 argc, ConsoleValueRef argv[], bool thisCallOnly)
 {
    if(argc < 2)
-      return "";
+   {
+      STR.clearFunctionOffset();
+      return ConsoleValueRef();
+   }
 
    // [neo, 10/05/2007 - #3010]
    // Make sure we don't get recursive calls, respect the flag!   
@@ -1229,10 +1250,8 @@ const char *execute(SimObject *object, S32 argc, ConsoleValueRef argv[], bool th
 
    if(object->getNamespace())
    {
-	  ConsoleValueRef internalArgv[StringStack::MaxArgs];
-
-	  U32 ident = object->getId();
-	  ConsoleValueRef oldIdent = argv[1];
+      U32 ident = object->getId();
+      ConsoleValueRef oldIdent = argv[1];
 
       StringTableEntry funcName = StringTable->insert(argv[0]);
       Namespace::Entry *ent = object->getNamespace()->lookup(funcName);
@@ -1241,10 +1260,8 @@ const char *execute(SimObject *object, S32 argc, ConsoleValueRef argv[], bool th
       {
          //warnf(ConsoleLogEntry::Script, "%s: undefined for object '%s' - id %d", funcName, object->getName(), object->getId());
 
-         // Clean up arg buffers, if any.
          STR.clearFunctionOffset();
-         CSTK.resetFrame();
-         return "";
+         return ConsoleValueRef();
       }
 
       // Twiddle %this argument
@@ -1252,7 +1269,7 @@ const char *execute(SimObject *object, S32 argc, ConsoleValueRef argv[], bool th
 
       SimObject *save = gEvalState.thisObject;
       gEvalState.thisObject = object;
-      const char *ret = ent->execute(argc, argv, &gEvalState);
+      ConsoleValueRef ret = ent->execute(argc, argv, &gEvalState);
       gEvalState.thisObject = save;
 
       // Twiddle it back
@@ -1260,17 +1277,52 @@ const char *execute(SimObject *object, S32 argc, ConsoleValueRef argv[], bool th
 
       return ret;
    }
+
    warnf(ConsoleLogEntry::Script, "Con::execute - %d has no namespace: %s", object->getId(), (const char*)argv[0]);
-   return "";
+   STR.clearFunctionOffset();
+   return ConsoleValueRef();
 }
 
-const char *execute(SimObject *object, S32 argc, const char *argv[], bool thisCallOnly)
+
+ConsoleValueRef execute(SimObject *object, S32 argc, ConsoleValueRef argv[], bool thisCallOnly)
 {
+   if(argc < 2)
+   {
+      STR.clearFunctionOffset();
+      return ConsoleValueRef();
+   }
+
+   ConsoleStackFrameSaver stackSaver;
+   stackSaver.save();
+
+   if (object->getNamespace() || !thisCallOnly)
+   {
+      if (isMainThread())
+      {
+         return _internalExecute(object, argc, argv, thisCallOnly);
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(argc, argv, true, &cb);
+         Sim::postEvent(object, evt, Sim::getCurrentTime());
+      }
+   }
+
+   warnf(ConsoleLogEntry::Script, "Con::execute - %d has no namespace: %s", object->getId(), (const char*)argv[0]);
+   STR.clearFunctionOffset();
+   return ConsoleValueRef();
+}
+
+ConsoleValueRef execute(SimObject *object, S32 argc, const char *argv[], bool thisCallOnly)
+{
+   ConsoleStackFrameSaver stackSaver;
+   stackSaver.save();
    StringStackConsoleWrapper args(argc, argv);
    return execute(object, args.count(), args, thisCallOnly);
 }
 
-inline const char*_executef(SimObject *obj, S32 checkArgc, S32 argc, ConsoleValueRef *argv)
+inline ConsoleValueRef _executef(SimObject *obj, S32 checkArgc, S32 argc, ConsoleValueRef *argv)
 {
    const U32 maxArg = 12;
    AssertWarn(checkArgc == argc, "Incorrect arg count passed to Con::executef(SimObject*)");
@@ -1278,42 +1330,14 @@ inline const char*_executef(SimObject *obj, S32 checkArgc, S32 argc, ConsoleValu
    return execute(obj, argc, argv);
 }
 
-#define A ConsoleValueRef
-#define OBJ SimObject* obj
-const char *executef(OBJ, A a)                                    { ConsoleValueRef params[] = {a,ConsoleValueRef()}; return _executef(obj, 2, 2, params); }
-const char *executef(OBJ, A a, A b)                               { ConsoleValueRef params[] = {a,ConsoleValueRef(),b}; return _executef(obj, 3, 3, params); }
-const char *executef(OBJ, A a, A b, A c)                          { ConsoleValueRef params[] = {a,ConsoleValueRef(),b,c}; return _executef(obj, 4, 4, params); }
-const char *executef(OBJ, A a, A b, A c, A d)                     { ConsoleValueRef params[] = {a,ConsoleValueRef(),b,c,d}; return _executef(obj, 5, 5, params); }
-const char *executef(OBJ, A a, A b, A c, A d, A e)                { ConsoleValueRef params[] = {a,ConsoleValueRef(),b,c,d,e}; return _executef(obj, 6, 6, params); }
-const char *executef(OBJ, A a, A b, A c, A d, A e, A f)           { ConsoleValueRef params[] = {a,ConsoleValueRef(),b,c,d,e,f}; return _executef(obj, 7, 7, params); }
-const char *executef(OBJ, A a, A b, A c, A d, A e, A f, A g)      { ConsoleValueRef params[] = {a,ConsoleValueRef(),b,c,d,e,f,g}; return _executef(obj, 8, 8, params); }
-const char *executef(OBJ, A a, A b, A c, A d, A e, A f, A g, A h) { ConsoleValueRef params[] = {a,ConsoleValueRef(),b,c,d,e,f,g,h}; return _executef(obj, 9, 9, params); }
-const char *executef(OBJ, A a, A b, A c, A d, A e, A f, A g, A h, A i) { ConsoleValueRef params[] = {a,ConsoleValueRef(),b,c,d,e,f,g,h,i}; return _executef(obj, 10, 10, params); }
-const char *executef(OBJ, A a, A b, A c, A d, A e, A f, A g, A h, A i, A j) { ConsoleValueRef params[] = {a,ConsoleValueRef(),b,c,d,e,f,g,h,i,j}; return _executef(obj, 11, 11, params); }
-const char *executef(OBJ, A a, A b, A c, A d, A e, A f, A g, A h, A i, A j, A k) { ConsoleValueRef params[] = {a,ConsoleValueRef(),b,c,d,e,f,g,h,i,j,k}; return _executef(obj, 12, 12, params); }
-
 //------------------------------------------------------------------------------
-inline const char*_executef(S32 checkArgc, S32 argc, ConsoleValueRef *argv)
+inline ConsoleValueRef _executef(S32 checkArgc, S32 argc, ConsoleValueRef *argv)
 {
    const U32 maxArg = 10;
    AssertFatal(checkArgc == argc, "Incorrect arg count passed to Con::executef()");
    AssertFatal(argc <= maxArg, "Too many args passed to Con::_executef(). Please update the function to handle more.");
    return execute(argc, argv);
 }
-   
-#define A ConsoleValueRef
-const char *executef(A a)                                    { ConsoleValueRef params[] = {a}; return _executef(1, 1, params); }
-const char *executef(A a, A b)                               { ConsoleValueRef params[] = {a,b}; return _executef(2, 2, params); }
-const char *executef(A a, A b, A c)                          { ConsoleValueRef params[] = {a,b,c}; return _executef(3, 3, params); }
-const char *executef(A a, A b, A c, A d)                     { ConsoleValueRef params[] = {a,b,c,d}; return _executef(4, 4, params); }
-const char *executef(A a, A b, A c, A d, A e)                { ConsoleValueRef params[] = {a,b,c,d,e}; return _executef(5, 5, params); }
-const char *executef(A a, A b, A c, A d, A e, A f)           { ConsoleValueRef params[] = {a,b,c,d,e,f}; return _executef(1, 1, params); }
-const char *executef(A a, A b, A c, A d, A e, A f, A g)      { ConsoleValueRef params[] = {a,b,c,d,e,f,g}; return _executef(1, 1, params); }
-const char *executef(A a, A b, A c, A d, A e, A f, A g, A h) { ConsoleValueRef params[] = {a,b,c,d,e,f,g,h}; return _executef(1, 1, params); }
-const char *executef(A a, A b, A c, A d, A e, A f, A g, A h, A i) { ConsoleValueRef params[] = {a,b,c,d,e,f,g,h,i}; return _executef(1, 1, params); }
-const char *executef(A a, A b, A c, A d, A e, A f, A g, A h, A i, A j) { ConsoleValueRef params[] = {a,b,c,d,e,f,g,h,i,j}; return _executef(1, 1, params); }
-#undef A
-
 
 //------------------------------------------------------------------------------
 bool isFunction(const char *fn)
@@ -1576,10 +1600,13 @@ DefineEngineFunction( logWarning, void, ( const char* message ),,
    Con::warnf( "%s", message );
 }
 
+//------------------------------------------------------------------------------
+
+extern ConsoleValueStack CSTK;
+
 ConsoleValueRef::ConsoleValueRef(const ConsoleValueRef &ref)
 {
-	value = ref.value;
-	stringStackValue = ref.stringStackValue;
+   value = ref.value;
 }
 
 ConsoleValueRef::ConsoleValueRef(const char *newValue) : value(NULL)
@@ -1612,6 +1639,49 @@ ConsoleValueRef::ConsoleValueRef(F64 newValue) : value(NULL)
    *this = newValue;
 }
 
+ConsoleValueRef& ConsoleValueRef::operator=(const ConsoleValueRef &newValue)
+{
+   value = newValue.value;
+   return *this;
+}
+
+ConsoleValueRef& ConsoleValueRef::operator=(const char *newValue)
+{
+   AssertFatal(value, "value should not be NULL");
+   value->setStringValue(newValue);
+   return *this;
+}
+
+ConsoleValueRef& ConsoleValueRef::operator=(S32 newValue)
+{
+   AssertFatal(value, "value should not be NULL");
+   value->setIntValue(newValue);
+   return *this;
+}
+
+ConsoleValueRef& ConsoleValueRef::operator=(U32 newValue)
+{
+   AssertFatal(value, "value should not be NULL");
+   value->setIntValue(newValue);
+   return *this;
+}
+
+ConsoleValueRef& ConsoleValueRef::operator=(F32 newValue)
+{
+   AssertFatal(value, "value should not be NULL");
+   value->setFloatValue(newValue);
+   return *this;
+}
+
+ConsoleValueRef& ConsoleValueRef::operator=(F64 newValue)
+{
+   AssertFatal(value, "value should not be NULL");
+   value->setFloatValue(newValue);
+   return *this;
+}
+
+//------------------------------------------------------------------------------
+
 StringStackWrapper::StringStackWrapper(int targc, ConsoleValueRef targv[])
 {
    argv = new const char*[targc];
@@ -1636,10 +1706,13 @@ StringStackWrapper::~StringStackWrapper()
 StringStackConsoleWrapper::StringStackConsoleWrapper(int targc, const char** targ)
 {
    argv = new ConsoleValueRef[targc];
+   argvValue = new ConsoleValue[targc];
    argc = targc;
 
    for (int i=0; i<targc; i++) {
-      argv[i] = ConsoleValueRef(targ[i]);
+      argvValue[i].init();
+      argv[i].value = &argvValue[i];
+      argvValue[i].setStackStringValue(targ[i]);
    }
 }
 
@@ -1650,7 +1723,10 @@ StringStackConsoleWrapper::~StringStackConsoleWrapper()
       argv[i] = 0;
    }
    delete[] argv;
+   delete[] argvValue;
 }
+
+//------------------------------------------------------------------------------
 
 S32 ConsoleValue::getSignedIntValue()
 {
@@ -1752,70 +1828,49 @@ void ConsoleValue::setFloatValue(F32 val)
    }
 }
 
+//------------------------------------------------------------------------------
 
-const char *ConsoleValueRef::getStringArgValue()
+ConsoleValueRef _BaseEngineConsoleCallbackHelper::_exec()
 {
-   if (value)
+   ConsoleValueRef returnValue;
+   if( mThis )
    {
-      if (stringStackValue == NULL)
-         stringStackValue = Con::getStringArg(value->getStringValue());
-      return stringStackValue;
+      // Cannot invoke callback until object has been registered
+      if (mThis->isProperlyAdded()) {
+         returnValue = Con::_internalExecute( mThis, mArgc, mArgv, false );
+      } else {
+         STR.clearFunctionOffset();
+         returnValue = ConsoleValueRef();
+      }
    }
    else
+      returnValue = Con::_internalExecute( mArgc, mArgv );
+
+   mArgc = mInitialArgc; // reset args
+   return returnValue;
+}
+
+ConsoleValueRef _BaseEngineConsoleCallbackHelper::_execLater(SimConsoleThreadExecEvent *evt)
+{
+   mArgc = mInitialArgc; // reset args
+   Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
+   return evt->getCB().waitForResult();
+}
+
+//------------------------------------------------------------------------------
+
+void ConsoleStackFrameSaver::save()
+{
+   CSTK.pushFrame();
+   STR.pushFrame();
+   mSaved = true;
+}
+
+void ConsoleStackFrameSaver::restore()
+{
+   if (mSaved)
    {
-      return "";
+      CSTK.popFrame();
+      STR.popFrame();
    }
-}
-
-
-extern ConsoleValueStack CSTK;
-   
-ConsoleValueRef& ConsoleValueRef::operator=(const ConsoleValueRef &newValue)
-{
-   value = newValue.value;
-   stringStackValue = newValue.stringStackValue;
-   return *this;
-}
-
-ConsoleValueRef& ConsoleValueRef::operator=(const char *newValue)
-{
-   value = CSTK.pushStackString(newValue);
-   stringStackValue = NULL;
-   return *this;
-}
-
-ConsoleValueRef& ConsoleValueRef::operator=(S32 newValue)
-{
-   value = CSTK.pushFLT(newValue);
-   stringStackValue = NULL;
-   return *this;
-}
-
-ConsoleValueRef& ConsoleValueRef::operator=(U32 newValue)
-{
-   value = CSTK.pushUINT(newValue);
-   stringStackValue = NULL;
-   return *this;
-}
-
-ConsoleValueRef& ConsoleValueRef::operator=(F32 newValue)
-{
-   value = CSTK.pushFLT(newValue);
-   stringStackValue = NULL;
-   return *this;
-}
-
-ConsoleValueRef& ConsoleValueRef::operator=(F64 newValue)
-{
-   value = CSTK.pushFLT(newValue);
-   stringStackValue = NULL;
-   return *this;
-}
-
-namespace Con
-{
-	void resetStackFrame()
-	{
-		CSTK.resetFrame();
-	}
 }

--- a/Engine/source/console/console.h
+++ b/Engine/source/console/console.h
@@ -44,6 +44,8 @@ struct ConsoleFunctionHeader;
 class EngineEnumTable;
 typedef EngineEnumTable EnumTable;
 
+typedef U32 StringStackPtr;
+
 template< typename T > S32 TYPEID();
 
 
@@ -121,8 +123,9 @@ public:
    
    enum
    {
-      TypeInternalInt = -4,
-      TypeInternalFloat = -3,
+      TypeInternalInt = -5,
+      TypeInternalFloat = -4,
+      TypeInternalStringStackPtr = -3,
       TypeInternalStackString = -2,
       TypeInternalString = -1,
    };
@@ -166,6 +169,7 @@ public:
    S32 getSignedIntValue();
    F32 getFloatValue();
    const char *getStringValue();
+   StringStackPtr getStringStackPtr();
    bool getBoolValue();
    
    void setIntValue(U32 val);
@@ -173,6 +177,7 @@ public:
    void setFloatValue(F32 val);
    void setStringValue(const char *value);
    void setStackStringValue(const char *value);
+   void setStringStackPtrValue(StringStackPtr ptr);
    void setBoolValue(bool val);
    
    void init()
@@ -187,7 +192,7 @@ public:
    void cleanup()
    {
       if (type <= TypeInternalString &&
-          sval != typeValueEmpty && type != TypeInternalStackString )
+          sval != typeValueEmpty && type != TypeInternalStackString && type != TypeInternalStringStackPtr)
          dFree(sval);
       sval = typeValueEmpty;
       type = ConsoleValue::TypeInternalString;
@@ -219,6 +224,7 @@ public:
    static ConsoleValueRef fromValue(ConsoleValue *value) { ConsoleValueRef ref; ref.value = value; return ref; }
 
    const char *getStringValue() { return value ? value->getStringValue() : ""; }
+   StringStackPtr getStringStackPtrValue() { return value ? value->getStringStackPtr() : 0; }
 
    inline U32 getIntValue() { return value ? value->getIntValue() : 0; }
    inline S32 getSignedIntValue() { return value ? value->getSignedIntValue() : 0; }
@@ -231,10 +237,12 @@ public:
    inline operator S32() { return getSignedIntValue(); }
    inline operator F32() { return getFloatValue(); }
    inline operator bool() { return getBoolValue(); }
-
-   inline bool isString() { return value ? value->type >= ConsoleValue::TypeInternalStackString : true; }
+   
+   inline bool isStringStackPtr() { return value ? value->type == ConsoleValue::TypeInternalStringStackPtr : false; }
+   inline bool isString() { return value ? value->type >= ConsoleValue::TypeInternalStringStackPtr : true; }
    inline bool isInt() { return value ? value->type == ConsoleValue::TypeInternalInt : false; }
    inline bool isFloat() { return value ? value->type == ConsoleValue::TypeInternalFloat : false; }
+   inline S32 getType() { return value ? value->type : -1; }
 
    // Note: operators replace value
    ConsoleValueRef& operator=(const ConsoleValueRef &other);

--- a/Engine/source/console/console.h
+++ b/Engine/source/console/console.h
@@ -874,17 +874,17 @@ namespace Con
 	///
 	/// @see _EngineConsoleExecCallbackHelper
 	///
-	template<typename A> ConsoleValueRef executef(A a) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(); }
-	template<typename A, typename B> ConsoleValueRef executef(A a, B b) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b); }
-	template<typename A, typename B, typename C> ConsoleValueRef executef(A a, B b, C c) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c); }
-	template<typename A, typename B, typename C, typename D> ConsoleValueRef executef(A a, B b, C c, D d) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d); }
-	template<typename A, typename B, typename C, typename D, typename E> ConsoleValueRef executef(A a, B b, C c, D d, E e) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e); }
-	template<typename A, typename B, typename C, typename D, typename E, typename F> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f); }
-	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f, g); }
-	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f, g, h); }
-	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f, g, h, i); }
-	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f, g, h, i, j); }
-	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f, g, h, i, j, k); }
+	template<typename A> ConsoleValueRef executef(A a) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(); }
+	template<typename A, typename B> ConsoleValueRef executef(A a, B b) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b); }
+	template<typename A, typename B, typename C> ConsoleValueRef executef(A a, B b, C c) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c); }
+	template<typename A, typename B, typename C, typename D> ConsoleValueRef executef(A a, B b, C c, D d) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d); }
+	template<typename A, typename B, typename C, typename D, typename E> ConsoleValueRef executef(A a, B b, C c, D d, E e) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e, f); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e, f, g); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e, f, g, h); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e, f, g, h, i); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e, f, g, h, i, j); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e, f, g, h, i, j, k); }
 	/// }
 };
 

--- a/Engine/source/console/console.h
+++ b/Engine/source/console/console.h
@@ -885,6 +885,7 @@ namespace Con
 	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e, f, g, h, i); }
 	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e, f, g, h, i, j); }
 	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e, f, g, h, i, j, k); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.template call<ConsoleValueRef>(b, c, d, e, f, g, h, i, j, k, l); }
 	/// }
 };
 

--- a/Engine/source/console/console.h
+++ b/Engine/source/console/console.h
@@ -181,6 +181,7 @@ public:
       fval = 0;
       sval = typeValueEmpty;
       bufferLen = 0;
+	  type = TypeInternalString;
    }
    
    void cleanup()
@@ -203,9 +204,8 @@ class ConsoleValueRef
 {
 public:
    ConsoleValue *value;
-   const char *stringStackValue;
 
-   ConsoleValueRef() : value(0), stringStackValue(0) { ; }
+   ConsoleValueRef() : value(0) { ; }
    ~ConsoleValueRef() { ; }
 
    ConsoleValueRef(const ConsoleValueRef &ref);
@@ -216,8 +216,9 @@ public:
    ConsoleValueRef(F32 value);
    ConsoleValueRef(F64 value);
 
+   static ConsoleValueRef fromValue(ConsoleValue *value) { ConsoleValueRef ref; ref.value = value; return ref; }
+
    const char *getStringValue() { return value ? value->getStringValue() : ""; }
-   const char *getStringArgValue();
 
    inline U32 getIntValue() { return value ? value->getIntValue() : 0; }
    inline S32 getSignedIntValue() { return value ? value->getSignedIntValue() : 0; }
@@ -229,6 +230,7 @@ public:
    inline operator U32() { return getIntValue(); }
    inline operator S32() { return getSignedIntValue(); }
    inline operator F32() { return getFloatValue(); }
+   inline operator bool() { return getBoolValue(); }
 
    inline bool isString() { return value ? value->type >= ConsoleValue::TypeInternalStackString : true; }
    inline bool isInt() { return value ? value->type == ConsoleValue::TypeInternalInt : false; }
@@ -281,6 +283,7 @@ public:
 class StringStackConsoleWrapper
 {
 public:
+   ConsoleValue *argvValue;
    ConsoleValueRef *argv;
    int argc;
 
@@ -753,23 +756,9 @@ namespace Con
    /// char* argv[] = {"abs", "-9"};
    /// char* result = execute(2, argv);
    /// @endcode
-   const char *execute(S32 argc, const char* argv[]);
-   const char *execute(S32 argc, ConsoleValueRef argv[]);
-
-   /// @see execute(S32 argc, const char* argv[])
-   // Note: this can't be ConsoleValueRef& since the compiler will confuse it with SimObject*
-#define ARG ConsoleValueRef
-   const char *executef( ARG);
-   const char *executef( ARG, ARG);
-   const char *executef( ARG, ARG, ARG);
-   const char *executef( ARG, ARG, ARG, ARG);
-   const char *executef( ARG, ARG, ARG, ARG, ARG);
-   const char *executef( ARG, ARG, ARG, ARG, ARG, ARG);
-   const char *executef( ARG, ARG, ARG, ARG, ARG, ARG, ARG);
-   const char *executef( ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG);
-   const char *executef( ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG);
-   const char *executef( ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG);
-#undef ARG
+   /// NOTE: this function restores the console stack on return.
+   ConsoleValueRef execute(S32 argc, const char* argv[]);
+   ConsoleValueRef execute(S32 argc, ConsoleValueRef argv[]);
 
    /// Call a Torque Script member function of a SimObject from C/C++ code.
    /// @param object    Object on which to execute the method call.
@@ -783,35 +772,23 @@ namespace Con
    /// char* argv[] = {"setMode", "", "2"};
    /// char* result = execute(mysimobject, 3, argv);
    /// @endcode
-   const char *execute(SimObject *object, S32 argc, const char *argv[], bool thisCallOnly = false);
-   const char *execute(SimObject *object, S32 argc, ConsoleValueRef argv[], bool thisCallOnly = false);
-
-   /// @see execute(SimObject *, S32 argc, ConsoleValueRef argv[])
-#define ARG ConsoleValueRef
-   const char *executef(SimObject *, ARG);
-   const char *executef(SimObject *, ARG, ARG);
-   const char *executef(SimObject *, ARG, ARG, ARG);
-   const char *executef(SimObject *, ARG, ARG, ARG, ARG);
-   const char *executef(SimObject *, ARG, ARG, ARG, ARG, ARG);
-   const char *executef(SimObject *, ARG, ARG, ARG, ARG, ARG, ARG);
-   const char *executef(SimObject *, ARG, ARG, ARG, ARG, ARG, ARG, ARG);
-   const char *executef(SimObject *, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG);
-   const char *executef(SimObject *, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG);
-   const char *executef(SimObject *, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG);
-   const char *executef(SimObject *, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG, ARG);
-#undef ARG
+   /// NOTE: this function restores the console stack on return.
+   ConsoleValueRef execute(SimObject *object, S32 argc, const char* argv[], bool thisCallOnly = false);
+   ConsoleValueRef execute(SimObject *object, S32 argc, ConsoleValueRef argv[], bool thisCallOnly = false);
 
    /// Evaluate an arbitrary chunk of code.
    ///
    /// @param  string   Buffer containing code to execute.
    /// @param  echo     Should we echo the string to the console?
    /// @param  fileName Indicate what file this code is coming from; used in error reporting and such.
-   const char *evaluate(const char* string, bool echo = false, const char *fileName = NULL);
+   /// NOTE: This function restores the console stack on return.
+   ConsoleValueRef evaluate(const char* string, bool echo = false, const char *fileName = NULL);
 
    /// Evaluate an arbitrary line of script.
    ///
    /// This wraps dVsprintf(), so you can substitute parameters into the code being executed.
-   const char *evaluatef(const char* string, ...);
+   /// NOTE: This function restores the console stack on return.
+   ConsoleValueRef evaluatef(const char* string, ...);
 
    /// @}
 
@@ -831,13 +808,11 @@ namespace Con
    char* getReturnBuffer( const StringBuilder& str );
 
    char* getArgBuffer(U32 bufferSize);
-   ConsoleValueRef getFloatArg(F64 arg);
-   ConsoleValueRef getIntArg  (S32 arg);
-   char* getStringArg( const char *arg );
+   char* getFloatArg(F64 arg);
+   char* getIntArg  (S32 arg);
+   char* getStringArg( const char* arg );
    char* getStringArg( const String& arg );
    /// @}
-
-   void resetStackFrame();
 
    /// @name Namespaces
    /// @{
@@ -872,19 +847,45 @@ namespace Con
    /// @name Dynamic Type System
    /// @{
 
-   ///
-/*   void registerType( const char *typeName, S32 type, S32 size, GetDataFunction gdf, SetDataFunction sdf, bool isDatablockType = false );
-   void registerType( const char* typeName, S32 type, S32 size, bool isDatablockType = false );
-   void registerTypeGet( S32 type, GetDataFunction gdf );
-   void registerTypeSet( S32 type, SetDataFunction sdf );
-
-   const char *getTypeName(S32 type);
-   bool isDatablockType( S32 type ); */
-
    void setData(S32 type, void *dptr, S32 index, S32 argc, const char **argv, const EnumTable *tbl = NULL, BitSet32 flag = 0);
    const char *getData(S32 type, void *dptr, S32 index, const EnumTable *tbl = NULL, BitSet32 flag = 0);
    const char *getFormattedData(S32 type, const char *data, const EnumTable *tbl = NULL, BitSet32 flag = 0);
+
    /// @}
+};
+
+struct _EngineConsoleCallbackHelper;
+template<typename P1> struct _EngineConsoleExecCallbackHelper;
+
+namespace Con
+{
+	/// @name Console Execution - executef
+	/// {
+	///
+	/// Implements a script function thunk which automatically converts parameters to relevant console types.
+	/// Can be used as follows:
+	/// - Con::executef("functionName", ...);
+	/// - Con::executef(mySimObject, "functionName", ...);
+	/// 
+	/// NOTE: if you get a rather cryptic template error coming through here, most likely you are trying to 
+	/// convert a parameter which EngineMarshallType does not have a specialization for.
+	/// Another problem can occur if you do not include "console/simBase.h" and "console/engineAPI.h" 
+	/// since _EngineConsoleExecCallbackHelper and SimConsoleThreadExecCallback are required.
+	///
+	/// @see _EngineConsoleExecCallbackHelper
+	///
+	template<typename A> ConsoleValueRef executef(A a) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(); }
+	template<typename A, typename B> ConsoleValueRef executef(A a, B b) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b); }
+	template<typename A, typename B, typename C> ConsoleValueRef executef(A a, B b, C c) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c); }
+	template<typename A, typename B, typename C, typename D> ConsoleValueRef executef(A a, B b, C c, D d) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d); }
+	template<typename A, typename B, typename C, typename D, typename E> ConsoleValueRef executef(A a, B b, C c, D d, E e) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f, g); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f, g, h); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f, g, h, i); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f, g, h, i, j); }
+	template<typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K> ConsoleValueRef executef(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k) { _EngineConsoleExecCallbackHelper<A> callback( a ); return callback.call<ConsoleValueRef>(b, c, d, e, f, g, h, i, j, k); }
+	/// }
 };
 
 extern void expandEscape(char *dest, const char *src);
@@ -1100,6 +1101,28 @@ struct ConsoleDocFragment
    {
       smFirst = this;
    }
+};
+
+
+/// Utility class to save and restore the current console stack frame
+///
+class ConsoleStackFrameSaver
+{
+public:
+
+	bool mSaved;
+
+	ConsoleStackFrameSaver() : mSaved(false)
+	{
+	}
+
+	~ConsoleStackFrameSaver()
+	{
+		restore();
+	}
+
+	void save();
+	void restore();
 };
 
 

--- a/Engine/source/console/consoleInternal.cpp
+++ b/Engine/source/console/consoleInternal.cpp
@@ -512,7 +512,7 @@ void ConsoleValue::setStringValue(const char * value)
 */
 	   if (value == typeValueEmpty)
       {
-            if (sval && sval != typeValueEmpty && type != TypeInternalStackString) dFree(sval);
+            if (sval && sval != typeValueEmpty && type != TypeInternalStackString && type != TypeInternalStringStackPtr) dFree(sval);
             sval = typeValueEmpty;
             bufferLen = 0;
             fval = 0.f;
@@ -541,7 +541,7 @@ void ConsoleValue::setStringValue(const char * value)
       // may as well pad to the next cache line
       U32 newLen = ((stringLen + 1) + 15) & ~15;
 	  
-      if(sval == typeValueEmpty || type == TypeInternalStackString)
+      if(sval == typeValueEmpty || type == TypeInternalStackString || type == TypeInternalStringStackPtr)
          sval = (char *) dMalloc(newLen);
       else if(newLen > bufferLen)
          sval = (char *) dRealloc(sval, newLen);
@@ -556,7 +556,7 @@ void ConsoleValue::setStringValue(const char * value)
 }
 
 
-void ConsoleValue::setStackStringValue(const char * value)
+void ConsoleValue::setStackStringValue(const char *value)
 {
    if (value == NULL) value = typeValueEmpty;
 
@@ -564,7 +564,7 @@ void ConsoleValue::setStackStringValue(const char * value)
    {
 	   if (value == typeValueEmpty)
       {
-         if (sval && sval != typeValueEmpty && type != ConsoleValue::TypeInternalStackString) dFree(sval);
+         if (sval && sval != typeValueEmpty && type != ConsoleValue::TypeInternalStackString && type != ConsoleValue::TypeInternalStringStackPtr) dFree(sval);
          sval = typeValueEmpty;
          bufferLen = 0;
          fval = 0.f;
@@ -586,13 +586,42 @@ void ConsoleValue::setStackStringValue(const char * value)
       }
 
       type = TypeInternalStackString;
-	  sval = (char*)value;
+      sval = (char*)value;
       bufferLen = stringLen;
    }
    else
       Con::setData(type, dataPtr, 0, 1, &value, enumTable);      
 }
 
+void ConsoleValue::setStringStackPtrValue(StringStackPtr ptrValue)
+{
+   if(type <= ConsoleValue::TypeInternalString)
+   {
+      const char *value = StringStackPtrRef(ptrValue).getPtr(&STR);
+	   if (sval && sval != typeValueEmpty && type != ConsoleValue::TypeInternalStackString && type != TypeInternalStringStackPtr) dFree(sval);
+
+      U32 stringLen = dStrlen(value);
+      if(stringLen < 256)
+      {
+         fval = dAtof(value);
+         ival = dAtoi(value);
+      }
+      else
+      {
+         fval = 0.f;
+         ival = 0;
+      }
+
+      type = TypeInternalStringStackPtr;
+      sval = (char*)(value - STR.mBuffer);
+      bufferLen = stringLen;
+   }
+   else
+   {
+      const char *value = StringStackPtrRef(ptrValue).getPtr(&STR);
+      Con::setData(type, dataPtr, 0, 1, &value, enumTable);      
+   }
+}
 
 S32 Dictionary::getIntVariable(StringTableEntry name, bool *entValid)
 {
@@ -651,7 +680,8 @@ Dictionary::Entry* Dictionary::addVariable(  const char *name,
    Entry *ent = add(StringTable->insert(name));
    
    if (  ent->value.type <= ConsoleValue::TypeInternalString &&
-         ent->value.sval != typeValueEmpty && ent->value.type != ConsoleValue::TypeInternalStackString )
+         ent->value.sval != typeValueEmpty && 
+         ent->value.type != ConsoleValue::TypeInternalStackString && ent->value.type != ConsoleValue::TypeInternalStringStackPtr )
       dFree(ent->value.sval);
 
    ent->value.type = type;

--- a/Engine/source/console/consoleInternal.h
+++ b/Engine/source/console/consoleInternal.h
@@ -367,6 +367,22 @@ public:
             notify->trigger();
       }
 
+      void setStringStackPtrValue(StringStackPtr newValue)
+      {
+         if( mIsConstant )
+         {
+            Con::errorf( "Cannot assign value to constant '%s'.", name );
+            return;
+         }
+         
+         value.setStringStackPtrValue(newValue);
+         
+         
+         // Fire off the notification if we have one.
+         if ( notify )
+            notify->trigger();
+      }
+
       void setStringValue(const char *newValue)
       {
          if( mIsConstant )
@@ -495,6 +511,7 @@ public:
    void setIntVariable(S32 val);
    void setFloatVariable(F64 val);
    void setStringVariable(const char *str);
+   void setStringStackPtrVariable(StringStackPtr str);
    void setCopyVariable();
 
    void pushFrame(StringTableEntry frameName, Namespace *ns);

--- a/Engine/source/console/consoleInternal.h
+++ b/Engine/source/console/consoleInternal.h
@@ -151,7 +151,7 @@ class Namespace
          void clear();
 
          ///
-         const char *execute( S32 argc, ConsoleValueRef* argv, ExprEvalState* state );
+         ConsoleValueRef execute( S32 argc, ConsoleValueRef* argv, ExprEvalState* state );
          
          /// Return a one-line documentation text string for the function.
          String getBriefDescription( String* outRemainingDocText = NULL ) const;

--- a/Engine/source/console/engineAPI.h
+++ b/Engine/source/console/engineAPI.h
@@ -3678,6 +3678,466 @@ public:
 };
 
 
+// Override for when first parameter is presumably a SimObject*, in which case A will be absorbed as the callback
+template<typename P1> struct _EngineConsoleExecCallbackHelper : public _BaseEngineConsoleCallbackHelper
+{
+public:
+
+   _EngineConsoleExecCallbackHelper( SimObject* pThis )
+   {
+      mThis = pThis;
+      mArgc = mInitialArgc = 2;
+      mCallbackName = NULL;
+   }
+
+   
+   template< typename R, typename A >
+   R call( A a )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+0, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+0, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B >
+   R call( A a, B b )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+1, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+1, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B, typename C >
+   R call( A a, B b, C c )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+2, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+2, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B, typename C, typename D >
+   R call( A a, B b, C c, D d )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+3, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+3, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B, typename C, typename D, typename E >
+   R call( A a, B b, C c, D d, E e )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+4, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+4, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F >
+   R call( A a, B b, C c, D d, E e, F f )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+5, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+5, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
+   R call( A a, B b, C c, D d, E e, F f, G g )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+6, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+6, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
+   R call( A a, B b, C c, D d, E e, F f, G g, H h )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+7, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+         EngineMarshallData( h, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+7, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+         EngineMarshallData( h, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
+   R call( A a, B b, C c, D d, E e, F f, G g, H h, I i )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+8, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+         EngineMarshallData( h, mArgc, mArgv );
+         EngineMarshallData( i, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+8, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+         EngineMarshallData( h, mArgc, mArgv );
+         EngineMarshallData( i, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
+   R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+9, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+         EngineMarshallData( h, mArgc, mArgv );
+         EngineMarshallData( i, mArgc, mArgv );
+         EngineMarshallData( j, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+9, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+         EngineMarshallData( h, mArgc, mArgv );
+         EngineMarshallData( i, mArgc, mArgv );
+         EngineMarshallData( j, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
+   R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+10, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+         EngineMarshallData( h, mArgc, mArgv );
+         EngineMarshallData( i, mArgc, mArgv );
+         EngineMarshallData( j, mArgc, mArgv );
+         EngineMarshallData( k, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+10, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+         EngineMarshallData( h, mArgc, mArgv );
+         EngineMarshallData( i, mArgc, mArgv );
+         EngineMarshallData( j, mArgc, mArgv );
+         EngineMarshallData( k, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
+   R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l )
+   {
+      if (Con::isMainThread())
+      {
+         ConsoleStackFrameSaver sav; sav.save();
+         CSTK.reserveValues(mArgc+11, mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+         EngineMarshallData( h, mArgc, mArgv );
+         EngineMarshallData( i, mArgc, mArgv );
+         EngineMarshallData( j, mArgc, mArgv );
+         EngineMarshallData( k, mArgc, mArgv );
+         EngineMarshallData( l, mArgc, mArgv );
+
+         return R( EngineUnmarshallData< R >()( _exec() ) );
+      }
+      else
+      {
+         SimConsoleThreadExecCallback cb;
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+11, NULL, true, &cb);
+         evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
+
+         EngineMarshallData( b, mArgc, mArgv );
+         EngineMarshallData( c, mArgc, mArgv );
+         EngineMarshallData( d, mArgc, mArgv );
+         EngineMarshallData( e, mArgc, mArgv );
+         EngineMarshallData( f, mArgc, mArgv );
+         EngineMarshallData( g, mArgc, mArgv );
+         EngineMarshallData( h, mArgc, mArgv );
+         EngineMarshallData( i, mArgc, mArgv );
+         EngineMarshallData( j, mArgc, mArgv );
+         EngineMarshallData( k, mArgc, mArgv );
+         EngineMarshallData( l, mArgc, mArgv );
+
+         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
+
+         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
+      }
+   }
+   
+};
 
 // Override for when first parameter is const char*
 template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEngineConsoleCallbackHelper
@@ -4176,469 +4636,6 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( l, mArgc, mArgv );
 
          Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-};
-
-
-
-// Override for when first parameter is presumably a SimObject*, in which case A will be absorbed as the callback
-template<typename P1> struct _EngineConsoleExecCallbackHelper : public _BaseEngineConsoleCallbackHelper
-{
-public:
-
-   _EngineConsoleExecCallbackHelper( SimObject* pThis )
-   {
-      mThis = pThis;
-      mArgc = mInitialArgc = 2;
-      mCallbackName = NULL;
-   }
-
-   
-   template< typename R, typename A >
-   R call( A a )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+0, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+0, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B >
-   R call( A a, B b )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+1, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+1, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B, typename C >
-   R call( A a, B b, C c )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+2, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+2, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B, typename C, typename D >
-   R call( A a, B b, C c, D d )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+3, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+3, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B, typename C, typename D, typename E >
-   R call( A a, B b, C c, D d, E e )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+4, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+4, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F >
-   R call( A a, B b, C c, D d, E e, F f )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+5, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+5, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
-   R call( A a, B b, C c, D d, E e, F f, G g )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+6, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+6, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
-   R call( A a, B b, C c, D d, E e, F f, G g, H h )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+7, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-         EngineMarshallData( h, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+7, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-         EngineMarshallData( h, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
-   R call( A a, B b, C c, D d, E e, F f, G g, H h, I i )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+8, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-         EngineMarshallData( h, mArgc, mArgv );
-         EngineMarshallData( i, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+8, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-         EngineMarshallData( h, mArgc, mArgv );
-         EngineMarshallData( i, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
-   R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+9, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-         EngineMarshallData( h, mArgc, mArgv );
-         EngineMarshallData( i, mArgc, mArgv );
-         EngineMarshallData( j, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+9, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-         EngineMarshallData( h, mArgc, mArgv );
-         EngineMarshallData( i, mArgc, mArgv );
-         EngineMarshallData( j, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
-   R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+10, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-         EngineMarshallData( h, mArgc, mArgv );
-         EngineMarshallData( i, mArgc, mArgv );
-         EngineMarshallData( j, mArgc, mArgv );
-         EngineMarshallData( k, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+10, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-         EngineMarshallData( h, mArgc, mArgv );
-         EngineMarshallData( i, mArgc, mArgv );
-         EngineMarshallData( j, mArgc, mArgv );
-         EngineMarshallData( k, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
-
-         return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
-      }
-   }
-   
-   template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
-   R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l )
-   {
-      if (Con::isMainThread())
-      {
-         ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc+11, mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-         EngineMarshallData( h, mArgc, mArgv );
-         EngineMarshallData( i, mArgc, mArgv );
-         EngineMarshallData( j, mArgc, mArgv );
-         EngineMarshallData( k, mArgc, mArgv );
-         EngineMarshallData( l, mArgc, mArgv );
-
-         return R( EngineUnmarshallData< R >()( _exec() ) );
-      }
-      else
-      {
-         SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+11, NULL, true, &cb);
-         evt->populateArgs(mArgv);
-         mArgv[ 0 ].value->setStackStringValue(a);
-
-         EngineMarshallData( b, mArgc, mArgv );
-         EngineMarshallData( c, mArgc, mArgv );
-         EngineMarshallData( d, mArgc, mArgv );
-         EngineMarshallData( e, mArgc, mArgv );
-         EngineMarshallData( f, mArgc, mArgv );
-         EngineMarshallData( g, mArgc, mArgv );
-         EngineMarshallData( h, mArgc, mArgv );
-         EngineMarshallData( i, mArgc, mArgv );
-         EngineMarshallData( j, mArgc, mArgv );
-         EngineMarshallData( k, mArgc, mArgv );
-         EngineMarshallData( l, mArgc, mArgv );
-
-         Sim::postEvent(mThis, evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }

--- a/Engine/source/console/engineAPI.h
+++ b/Engine/source/console/engineAPI.h
@@ -53,6 +53,11 @@
    #include "console/engineStructs.h"
 #endif
 
+// Needed for the executef macros. Blame GCC.
+#ifndef _SIMEVENTS_H_
+#include "console/simEvents.h"
+#endif
+
 
 /// @file
 /// Definitions for exposing engine functionality to the control layer.
@@ -3146,7 +3151,7 @@ struct _EngineCallbackHelper
       
 };
 
-class SimConsoleThreadExecEvent;
+
 #include "console/stringStack.h"
 
 // Internal helper for callback support in legacy console system.
@@ -3199,7 +3204,7 @@ public:
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc, NULL, false, &cb);
          evt->populateArgs(mArgv);
          mArgv[ 0 ].value->setStackStringValue(mCallbackName);
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3229,7 +3234,7 @@ public:
 
          EngineMarshallData( a, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3259,7 +3264,7 @@ public:
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3291,7 +3296,7 @@ public:
          EngineMarshallData( b, mArgc, mArgv );
          EngineMarshallData( c, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3325,7 +3330,7 @@ public:
          EngineMarshallData( c, mArgc, mArgv );
          EngineMarshallData( d, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3361,7 +3366,7 @@ public:
          EngineMarshallData( d, mArgc, mArgv );
          EngineMarshallData( e, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3399,7 +3404,7 @@ public:
          EngineMarshallData( e, mArgc, mArgv );
          EngineMarshallData( f, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3439,7 +3444,7 @@ public:
          EngineMarshallData( f, mArgc, mArgv );
          EngineMarshallData( g, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3481,7 +3486,7 @@ public:
          EngineMarshallData( g, mArgc, mArgv );
          EngineMarshallData( h, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3525,7 +3530,7 @@ public:
          EngineMarshallData( h, mArgc, mArgv );
          EngineMarshallData( i, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3571,7 +3576,7 @@ public:
          EngineMarshallData( i, mArgc, mArgv );
          EngineMarshallData( j, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3619,7 +3624,7 @@ public:
          EngineMarshallData( j, mArgc, mArgv );
          EngineMarshallData( k, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -3669,7 +3674,7 @@ public:
          EngineMarshallData( k, mArgc, mArgv );
          EngineMarshallData( l, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4166,7 +4171,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          evt->populateArgs(mArgv);
          mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
@@ -4195,7 +4200,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
 
          EngineMarshallData( a, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4225,7 +4230,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4257,7 +4262,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( b, mArgc, mArgv );
          EngineMarshallData( c, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4291,7 +4296,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( c, mArgc, mArgv );
          EngineMarshallData( d, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4327,7 +4332,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( d, mArgc, mArgv );
          EngineMarshallData( e, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4365,7 +4370,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( e, mArgc, mArgv );
          EngineMarshallData( f, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4405,7 +4410,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( f, mArgc, mArgv );
          EngineMarshallData( g, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4447,7 +4452,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( g, mArgc, mArgv );
          EngineMarshallData( h, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4491,7 +4496,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( h, mArgc, mArgv );
          EngineMarshallData( i, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4537,7 +4542,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( i, mArgc, mArgv );
          EngineMarshallData( j, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4585,7 +4590,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( j, mArgc, mArgv );
          EngineMarshallData( k, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
@@ -4635,7 +4640,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          EngineMarshallData( k, mArgc, mArgv );
          EngineMarshallData( l, mArgc, mArgv );
 
-         Sim::postEvent(Sim::getRootGroup(), evt, Sim::getCurrentTime());
+         Sim::postEvent((SimObject*)Sim::getRootGroup(), evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }

--- a/Engine/source/console/engineAPI.h
+++ b/Engine/source/console/engineAPI.h
@@ -102,6 +102,10 @@ template<> struct EngineTypeTraits< const char* > : public EngineTypeTraits< Str
 template<> inline const EngineTypeInfo* TYPE< const char* >() { return TYPE< String >(); }
 
 
+
+
+
+
 /// @name Marshalling
 ///
 /// Functions for converting to/from string-based data representations.
@@ -329,20 +333,23 @@ struct _EngineTrampoline
 {
    struct Args {};
 };
+
 template< typename R, typename A >
 struct _EngineTrampoline< R( A ) >
 {
    struct Args
    {
       char data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ];
-      
+
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
    };
 };
+
 template< typename R, typename A, typename B >
 struct _EngineTrampoline< R( A, B ) >
 {
@@ -354,8 +361,10 @@ struct _EngineTrampoline< R( A, B ) >
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
+
       typename EngineTypeTraits< B >::ValueType b() const
       {
          return EngineTypeTraits< B >::ArgumentToValue(
@@ -364,6 +373,7 @@ struct _EngineTrampoline< R( A, B ) >
       }
    };
 };
+
 template< typename R, typename A, typename B, typename C >
 struct _EngineTrampoline< R( A, B, C ) >
 {
@@ -376,14 +386,17 @@ struct _EngineTrampoline< R( A, B, C ) >
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
+
       typename EngineTypeTraits< B >::ValueType b() const
       {
          return EngineTypeTraits< B >::ArgumentToValue(
             *( reinterpret_cast< const typename EngineTypeTraits< B >::ArgumentValueType* >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< C >::ValueType c() const
       {
          return EngineTypeTraits< C >::ArgumentToValue(
@@ -393,6 +406,7 @@ struct _EngineTrampoline< R( A, B, C ) >
       }
    };
 };
+
 template< typename R, typename A, typename B, typename C, typename D >
 struct _EngineTrampoline< R( A, B, C, D ) >
 {
@@ -406,14 +420,17 @@ struct _EngineTrampoline< R( A, B, C, D ) >
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
+
       typename EngineTypeTraits< B >::ValueType b() const
       {
          return EngineTypeTraits< B >::ArgumentToValue(
             *( reinterpret_cast< const typename EngineTypeTraits< B >::ArgumentValueType* >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< C >::ValueType c() const
       {
          return EngineTypeTraits< C >::ArgumentToValue(
@@ -421,6 +438,7 @@ struct _EngineTrampoline< R( A, B, C, D ) >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< D >::ValueType d() const
       {
          return EngineTypeTraits< D >::ArgumentToValue(
@@ -431,6 +449,7 @@ struct _EngineTrampoline< R( A, B, C, D ) >
       }
    };
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E >
 struct _EngineTrampoline< R( A, B, C, D, E ) >
 {
@@ -445,14 +464,17 @@ struct _EngineTrampoline< R( A, B, C, D, E ) >
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
+
       typename EngineTypeTraits< B >::ValueType b() const
       {
          return EngineTypeTraits< B >::ArgumentToValue(
             *( reinterpret_cast< const typename EngineTypeTraits< B >::ArgumentValueType* >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< C >::ValueType c() const
       {
          return EngineTypeTraits< C >::ArgumentToValue(
@@ -460,6 +482,7 @@ struct _EngineTrampoline< R( A, B, C, D, E ) >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< D >::ValueType d() const
       {
          return EngineTypeTraits< D >::ArgumentToValue(
@@ -468,6 +491,7 @@ struct _EngineTrampoline< R( A, B, C, D, E ) >
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< E >::ValueType e() const
       {
          return EngineTypeTraits< E >::ArgumentToValue(
@@ -479,6 +503,7 @@ struct _EngineTrampoline< R( A, B, C, D, E ) >
       }
    };
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F >
 struct _EngineTrampoline< R( A, B, C, D, E, F ) >
 {
@@ -494,14 +519,17 @@ struct _EngineTrampoline< R( A, B, C, D, E, F ) >
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
+
       typename EngineTypeTraits< B >::ValueType b() const
       {
          return EngineTypeTraits< B >::ArgumentToValue(
             *( reinterpret_cast< const typename EngineTypeTraits< B >::ArgumentValueType* >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< C >::ValueType c() const
       {
          return EngineTypeTraits< C >::ArgumentToValue(
@@ -509,6 +537,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F ) >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< D >::ValueType d() const
       {
          return EngineTypeTraits< D >::ArgumentToValue(
@@ -517,6 +546,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F ) >
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< E >::ValueType e() const
       {
          return EngineTypeTraits< E >::ArgumentToValue(
@@ -526,6 +556,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F ) >
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< F >::ValueType f() const
       {
          return EngineTypeTraits< F >::ArgumentToValue(
@@ -538,6 +569,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F ) >
       }
    };
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
 struct _EngineTrampoline< R( A, B, C, D, E, F, G ) >
 {
@@ -554,14 +586,17 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G ) >
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
+
       typename EngineTypeTraits< B >::ValueType b() const
       {
          return EngineTypeTraits< B >::ArgumentToValue(
             *( reinterpret_cast< const typename EngineTypeTraits< B >::ArgumentValueType* >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< C >::ValueType c() const
       {
          return EngineTypeTraits< C >::ArgumentToValue(
@@ -569,6 +604,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G ) >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< D >::ValueType d() const
       {
          return EngineTypeTraits< D >::ArgumentToValue(
@@ -577,6 +613,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G ) >
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< E >::ValueType e() const
       {
          return EngineTypeTraits< E >::ArgumentToValue(
@@ -586,6 +623,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G ) >
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< F >::ValueType f() const
       {
          return EngineTypeTraits< F >::ArgumentToValue(
@@ -596,6 +634,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G ) >
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< G >::ValueType g() const
       {
          return EngineTypeTraits< G >::ArgumentToValue(
@@ -609,6 +648,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G ) >
       }
    };
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
 struct _EngineTrampoline< R( A, B, C, D, E, F, G, H ) >
 {
@@ -626,14 +666,17 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H ) >
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
+
       typename EngineTypeTraits< B >::ValueType b() const
       {
          return EngineTypeTraits< B >::ArgumentToValue(
             *( reinterpret_cast< const typename EngineTypeTraits< B >::ArgumentValueType* >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< C >::ValueType c() const
       {
          return EngineTypeTraits< C >::ArgumentToValue(
@@ -641,6 +684,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H ) >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< D >::ValueType d() const
       {
          return EngineTypeTraits< D >::ArgumentToValue(
@@ -649,6 +693,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H ) >
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< E >::ValueType e() const
       {
          return EngineTypeTraits< E >::ArgumentToValue(
@@ -658,6 +703,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H ) >
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< F >::ValueType f() const
       {
          return EngineTypeTraits< F >::ArgumentToValue(
@@ -668,6 +714,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H ) >
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< G >::ValueType g() const
       {
          return EngineTypeTraits< G >::ArgumentToValue(
@@ -679,6 +726,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H ) >
                         sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< H >::ValueType h() const
       {
          return EngineTypeTraits< H >::ArgumentToValue(
@@ -693,6 +741,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H ) >
       }
    };
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
 struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I ) >
 {
@@ -711,14 +760,17 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I ) >
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
+
       typename EngineTypeTraits< B >::ValueType b() const
       {
          return EngineTypeTraits< B >::ArgumentToValue(
             *( reinterpret_cast< const typename EngineTypeTraits< B >::ArgumentValueType* >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< C >::ValueType c() const
       {
          return EngineTypeTraits< C >::ArgumentToValue(
@@ -726,6 +778,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I ) >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< D >::ValueType d() const
       {
          return EngineTypeTraits< D >::ArgumentToValue(
@@ -734,6 +787,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I ) >
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< E >::ValueType e() const
       {
          return EngineTypeTraits< E >::ArgumentToValue(
@@ -743,6 +797,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I ) >
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< F >::ValueType f() const
       {
          return EngineTypeTraits< F >::ArgumentToValue(
@@ -753,6 +808,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I ) >
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< G >::ValueType g() const
       {
          return EngineTypeTraits< G >::ArgumentToValue(
@@ -764,6 +820,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I ) >
                         sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< H >::ValueType h() const
       {
          return EngineTypeTraits< H >::ArgumentToValue(
@@ -776,6 +833,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I ) >
                         sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< I >::ValueType i() const
       {
          return EngineTypeTraits< I >::ArgumentToValue(
@@ -791,6 +849,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I ) >
       }
    };
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
 struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J ) >
 {
@@ -810,14 +869,17 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J ) >
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
+
       typename EngineTypeTraits< B >::ValueType b() const
       {
          return EngineTypeTraits< B >::ArgumentToValue(
             *( reinterpret_cast< const typename EngineTypeTraits< B >::ArgumentValueType* >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< C >::ValueType c() const
       {
          return EngineTypeTraits< C >::ArgumentToValue(
@@ -825,6 +887,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J ) >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< D >::ValueType d() const
       {
          return EngineTypeTraits< D >::ArgumentToValue(
@@ -833,6 +896,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J ) >
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< E >::ValueType e() const
       {
          return EngineTypeTraits< E >::ArgumentToValue(
@@ -842,6 +906,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J ) >
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< F >::ValueType f() const
       {
          return EngineTypeTraits< F >::ArgumentToValue(
@@ -852,6 +917,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J ) >
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< G >::ValueType g() const
       {
          return EngineTypeTraits< G >::ArgumentToValue(
@@ -863,6 +929,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J ) >
                         sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< H >::ValueType h() const
       {
          return EngineTypeTraits< H >::ArgumentToValue(
@@ -875,6 +942,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J ) >
                         sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< I >::ValueType i() const
       {
          return EngineTypeTraits< I >::ArgumentToValue(
@@ -888,6 +956,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J ) >
                         sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< H >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< J >::ValueType j() const
       {
          return EngineTypeTraits< J >::ArgumentToValue(
@@ -904,6 +973,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J ) >
       }
    };
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
 struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
 {
@@ -924,14 +994,17 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
       typename EngineTypeTraits< A >::ValueType a() const
       {
          return EngineTypeTraits< A >::ArgumentToValue(
-            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >( &data[ 0 ] ) ) );
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
       }
+
       typename EngineTypeTraits< B >::ValueType b() const
       {
          return EngineTypeTraits< B >::ArgumentToValue(
             *( reinterpret_cast< const typename EngineTypeTraits< B >::ArgumentValueType* >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< C >::ValueType c() const
       {
          return EngineTypeTraits< C >::ArgumentToValue(
@@ -939,6 +1012,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
                ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< D >::ValueType d() const
       {
          return EngineTypeTraits< D >::ArgumentToValue(
@@ -947,6 +1021,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
                         sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< E >::ValueType e() const
       {
          return EngineTypeTraits< E >::ArgumentToValue(
@@ -956,6 +1031,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
                         sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< F >::ValueType f() const
       {
          return EngineTypeTraits< F >::ArgumentToValue(
@@ -966,6 +1042,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
                         sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< G >::ValueType g() const
       {
          return EngineTypeTraits< G >::ArgumentToValue(
@@ -977,6 +1054,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
                         sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< H >::ValueType h() const
       {
          return EngineTypeTraits< H >::ArgumentToValue(
@@ -989,6 +1067,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
                         sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< I >::ValueType i() const
       {
          return EngineTypeTraits< I >::ArgumentToValue(
@@ -1002,6 +1081,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
                         sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< H >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< J >::ValueType j() const
       {
          return EngineTypeTraits< J >::ArgumentToValue(
@@ -1016,6 +1096,7 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
                         sizeof( typename EngineTypeTraits< H >::ArgumentValueType ) +
                         sizeof( typename EngineTypeTraits< I >::ArgumentValueType ) ] ) ) );
       }
+
       typename EngineTypeTraits< K >::ValueType k() const
       {
          return EngineTypeTraits< K >::ArgumentToValue(
@@ -1033,6 +1114,166 @@ struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) >
       }
    };
 };
+
+template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
+struct _EngineTrampoline< R( A, B, C, D, E, F, G, H, I, J, K, L ) >
+{
+   struct Args
+   {
+      char data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< H >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< I >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< J >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< K >::ArgumentValueType ) +
+                 sizeof( typename EngineTypeTraits< L >::ArgumentValueType ) ];
+
+      typename EngineTypeTraits< A >::ValueType a() const
+      {
+         return EngineTypeTraits< A >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< A >::ArgumentValueType* >
+               ( &data[ 0 ] ) ) );
+      }
+
+      typename EngineTypeTraits< B >::ValueType b() const
+      {
+         return EngineTypeTraits< B >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< B >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) ] ) ) );
+      }
+
+      typename EngineTypeTraits< C >::ValueType c() const
+      {
+         return EngineTypeTraits< C >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< C >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) ] ) ) );
+      }
+
+      typename EngineTypeTraits< D >::ValueType d() const
+      {
+         return EngineTypeTraits< D >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< D >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) ] ) ) );
+      }
+
+      typename EngineTypeTraits< E >::ValueType e() const
+      {
+         return EngineTypeTraits< E >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< E >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) ] ) ) );
+      }
+
+      typename EngineTypeTraits< F >::ValueType f() const
+      {
+         return EngineTypeTraits< F >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< F >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) ] ) ) );
+      }
+
+      typename EngineTypeTraits< G >::ValueType g() const
+      {
+         return EngineTypeTraits< G >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< G >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) ] ) ) );
+      }
+
+      typename EngineTypeTraits< H >::ValueType h() const
+      {
+         return EngineTypeTraits< H >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< H >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) ] ) ) );
+      }
+
+      typename EngineTypeTraits< I >::ValueType i() const
+      {
+         return EngineTypeTraits< I >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< I >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< H >::ArgumentValueType ) ] ) ) );
+      }
+
+      typename EngineTypeTraits< J >::ValueType j() const
+      {
+         return EngineTypeTraits< J >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< J >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< H >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< I >::ArgumentValueType ) ] ) ) );
+      }
+
+      typename EngineTypeTraits< K >::ValueType k() const
+      {
+         return EngineTypeTraits< K >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< K >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< H >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< I >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< J >::ArgumentValueType ) ] ) ) );
+      }
+
+      typename EngineTypeTraits< L >::ValueType l() const
+      {
+         return EngineTypeTraits< L >::ArgumentToValue(
+            *( reinterpret_cast< const typename EngineTypeTraits< L >::ArgumentValueType* >
+               ( &data[ sizeof( typename EngineTypeTraits< A >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< B >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< C >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< D >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< E >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< F >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< G >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< H >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< I >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< J >::ArgumentValueType ) +
+                        sizeof( typename EngineTypeTraits< K >::ArgumentValueType ) ] ) ) );
+      }
+   };
+};
+
 
 template< typename T >
 struct _EngineFunctionTrampolineBase : public _EngineTrampoline< T >
@@ -1052,6 +1293,8 @@ struct _EngineFunctionTrampoline< R() > : public _EngineFunctionTrampolineBase< 
       return R( fn() );
    }
 };
+
+
 template< typename R, typename A >
 struct _EngineFunctionTrampoline< R( A ) > : public _EngineFunctionTrampolineBase< R( A ) >
 {
@@ -1060,6 +1303,7 @@ struct _EngineFunctionTrampoline< R( A ) > : public _EngineFunctionTrampolineBas
       return R( fn( args.a() ) );
    }
 };
+
 template< typename R, typename A, typename B >
 struct _EngineFunctionTrampoline< R( A, B ) > : public _EngineFunctionTrampolineBase< R( A, B ) >
 {
@@ -1068,6 +1312,7 @@ struct _EngineFunctionTrampoline< R( A, B ) > : public _EngineFunctionTrampoline
       return R( fn( args.a(), args.b() ) );
    }
 };
+
 template< typename R, typename A, typename B, typename C >
 struct _EngineFunctionTrampoline< R( A, B, C ) > : public _EngineFunctionTrampolineBase< R( A, B, C ) >
 {
@@ -1076,6 +1321,7 @@ struct _EngineFunctionTrampoline< R( A, B, C ) > : public _EngineFunctionTrampol
       return R( fn( args.a(), args.b(), args.c() ) );
    }
 };
+
 template< typename R, typename A, typename B, typename C, typename D >
 struct _EngineFunctionTrampoline< R( A, B, C, D ) > : public _EngineFunctionTrampolineBase< R( A, B, C, D ) >
 {
@@ -1084,6 +1330,7 @@ struct _EngineFunctionTrampoline< R( A, B, C, D ) > : public _EngineFunctionTram
       return R( fn( args.a(), args.b(), args.c(), args.d() ) );
    }
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E >
 struct _EngineFunctionTrampoline< R( A, B, C, D, E ) > : public _EngineFunctionTrampolineBase< R( A, B, C, D, E ) >
 {
@@ -1092,6 +1339,7 @@ struct _EngineFunctionTrampoline< R( A, B, C, D, E ) > : public _EngineFunctionT
       return R( fn( args.a(), args.b(), args.c(), args.d(), args.e() ) );
    }
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F >
 struct _EngineFunctionTrampoline< R( A, B, C, D, E, F ) > : public _EngineFunctionTrampolineBase< R( A, B, C, D, E, F ) >
 {
@@ -1100,6 +1348,7 @@ struct _EngineFunctionTrampoline< R( A, B, C, D, E, F ) > : public _EngineFuncti
       return R( fn( args.a(), args.b(), args.c(), args.d(), args.e(), args.f() ) );
    }
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
 struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G ) > : public _EngineFunctionTrampolineBase< R( A, B, C, D, E, F, G ) >
 {
@@ -1108,6 +1357,7 @@ struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G ) > : public _EngineFun
       return R( fn( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g() ) );
    }
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
 struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G, H ) > : public _EngineFunctionTrampolineBase< R( A, B, C, D, E, F, G, H ) >
 {
@@ -1116,6 +1366,7 @@ struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G, H ) > : public _Engine
       return R( fn( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g(), args.h() ) );
    }
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
 struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G, H, I ) > : public _EngineFunctionTrampolineBase< R( A, B, C, D, E, F, G, H, I ) >
 {
@@ -1124,6 +1375,7 @@ struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G, H, I ) > : public _Eng
       return R( fn( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g(), args.h(), args.i() ) );
    }
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
 struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G, H, I, J ) > : public _EngineFunctionTrampolineBase< R( A, B, C, D, E, F, G, H, I, J ) >
 {
@@ -1132,6 +1384,7 @@ struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G, H, I, J ) > : public _
       return R( fn( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g(), args.h(), args.i(), args.j() ) );
    }
 };
+
 template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
 struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) > : public _EngineFunctionTrampolineBase< R( A, B, C, D, E, F, G, H, I, J, K ) >
 {
@@ -1140,6 +1393,18 @@ struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G, H, I, J, K ) > : publi
       return R( fn( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g(), args.h(), args.i(), args.j(), args.k() ) );
    }
 };
+
+template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
+struct _EngineFunctionTrampoline< R( A, B, C, D, E, F, G, H, I, J, K, L ) > : public _EngineFunctionTrampolineBase< R( A, B, C, D, E, F, G, H, I, J, K, L ) >
+{
+   static R jmp( R ( *fn )( A, B, C, D, E, F, G, H, I, J, K, L ), const typename _EngineFunctionTrampolineBase< R( A, B, C, D, E, F, G, H, I, J, K, L ) >::Args& args )
+   {
+      return R( fn( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g(), args.h(), args.i(), args.j(), args.k(), args.l() ) );
+   }
+};
+
+
+// Trampolines for engine methods
 
 template< typename T >
 struct _EngineMethodTrampolineBase : public _EngineTrampoline< T > {};
@@ -1158,6 +1423,8 @@ struct _EngineMethodTrampoline< Frame, R() > : public _EngineMethodTrampolineBas
       return R( f._exec() );
    }
 };
+
+
 template< typename Frame, typename R, typename A >
 struct _EngineMethodTrampoline< Frame, R( A ) > : public _EngineMethodTrampolineBase< R( A ) >
 {
@@ -1169,6 +1436,7 @@ struct _EngineMethodTrampoline< Frame, R( A ) > : public _EngineMethodTrampoline
       return R( f._exec( args.a() ) );
    }
 };
+
 template< typename Frame, typename R, typename A, typename B >
 struct _EngineMethodTrampoline< Frame, R( A, B ) > : public _EngineMethodTrampolineBase< R( A, B ) >
 {
@@ -1180,6 +1448,7 @@ struct _EngineMethodTrampoline< Frame, R( A, B ) > : public _EngineMethodTrampol
       return R( f._exec( args.a(), args.b() ) );
    }
 };
+
 template< typename Frame, typename R, typename A, typename B, typename C >
 struct _EngineMethodTrampoline< Frame, R( A, B, C ) > : public _EngineMethodTrampolineBase< R( A, B, C ) >
 {
@@ -1191,6 +1460,7 @@ struct _EngineMethodTrampoline< Frame, R( A, B, C ) > : public _EngineMethodTram
       return R( f._exec( args.a(), args.b(), args.c() ) );
    }
 };
+
 template< typename Frame, typename R, typename A, typename B, typename C, typename D >
 struct _EngineMethodTrampoline< Frame, R( A, B, C, D ) > : public _EngineMethodTrampolineBase< R( A, B, C, D ) >
 {
@@ -1202,6 +1472,7 @@ struct _EngineMethodTrampoline< Frame, R( A, B, C, D ) > : public _EngineMethodT
       return R( f._exec( args.a(), args.b(), args.c(), args.d() ) );
    }
 };
+
 template< typename Frame, typename R, typename A, typename B, typename C, typename D, typename E >
 struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E ) > : public _EngineMethodTrampolineBase< R( A, B, C, D, E ) >
 {
@@ -1213,6 +1484,7 @@ struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E ) > : public _EngineMeth
       return R( f._exec( args.a(), args.b(), args.c(), args.d(), args.e() ) );
    }
 };
+
 template< typename Frame, typename R, typename A, typename B, typename C, typename D, typename E, typename F >
 struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F ) > : public _EngineMethodTrampolineBase< R( A, B, C, D, E, F ) >
 {
@@ -1224,6 +1496,7 @@ struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F ) > : public _EngineM
       return R( f._exec( args.a(), args.b(), args.c(), args.d(), args.e(), args.f() ) );
    }
 };
+
 template< typename Frame, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
 struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G ) > : public _EngineMethodTrampolineBase< R( A, B, C, D, E, F, G ) >
 {
@@ -1235,6 +1508,7 @@ struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G ) > : public _Engi
       return R( f._exec( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g() ) );
    }
 };
+
 template< typename Frame, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
 struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G, H ) > : public _EngineMethodTrampolineBase< R( A, B, C, D, E, F, G, H ) >
 {
@@ -1246,6 +1520,7 @@ struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G, H ) > : public _E
       return R( f._exec( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g(), args.h() ) );
    }
 };
+
 template< typename Frame, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
 struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G, H, I ) > : public _EngineMethodTrampolineBase< R( A, B, C, D, E, F, G, H, I ) >
 {
@@ -1257,6 +1532,7 @@ struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G, H, I ) > : public
       return R( f._exec( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g(), args.h(), args.i() ) );
    }
 };
+
 template< typename Frame, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
 struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G, H, I, J ) > : public _EngineMethodTrampolineBase< R( A, B, C, D, E, F, G, H, I, J ) >
 {
@@ -1268,6 +1544,7 @@ struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G, H, I, J ) > : pub
       return R( f._exec( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g(), args.h(), args.i(), args.j() ) );
    }
 };
+
 template< typename Frame, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
 struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G, H, I, J, K ) > : public _EngineMethodTrampolineBase< R( A, B, C, D, E, F, G, H, I, J, K ) >
 {
@@ -1279,6 +1556,20 @@ struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G, H, I, J, K ) > : 
       return R( f._exec( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g(), args.h(), args.i(), args.j(), args.k() ) );
    }
 };
+
+template< typename Frame, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
+struct _EngineMethodTrampoline< Frame, R( A, B, C, D, E, F, G, H, I, J, K, L ) > : public _EngineMethodTrampolineBase< R( A, B, C, D, E, F, G, H, I, J, K, L ) >
+{
+   typedef R( FunctionType )( typename Frame::ObjectType*, A, B, C, D, E, F, G, H, I, J, K, L );
+   static R jmp( typename Frame::ObjectType* object, const typename _EngineFunctionTrampolineBase< R( A, B, C, D, E, F, G, H, I, J, K, L ) >::Args& args )
+   {
+      Frame f;
+      f.object = object;
+      return R( f._exec( args.a(), args.b(), args.c(), args.d(), args.e(), args.f(), args.g(), args.h(), args.i(), args.j(), args.k(), args.l() ) );
+   }
+};
+
+
 
 /// @}
 
@@ -1374,67 +1665,87 @@ struct _EngineConsoleThunkType< void >
 // The setup through operator () allows omitting the the argument list entirely.
 struct _EngineConsoleThunkCountArgs
 {
+
    template< typename A >
    U32 operator ()( A a )
    {
       return 1;
    }
+
    template< typename A, typename B >
    U32 operator ()( A a, B b )
    {
       return 2;
    }
+
    template< typename A, typename B, typename C >
    U32 operator ()( A a, B b, C c )
    {
       return 3;
    }
+
    template< typename A, typename B, typename C, typename D >
    U32 operator ()( A a, B b, C c, D d )
    {
       return 4;
    }
+
    template< typename A, typename B, typename C, typename D, typename E >
    U32 operator ()( A a, B b, C c, D d, E e )
    {
       return 5;
    }
+
    template< typename A, typename B, typename C, typename D, typename E, typename F >
    U32 operator ()( A a, B b, C c, D d, E e, F f )
    {
       return 6;
    }
+
    template< typename A, typename B, typename C, typename D, typename E, typename F, typename G >
    U32 operator ()( A a, B b, C c, D d, E e, F f, G g )
    {
       return 7;
    }
+
    template< typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
    U32 operator ()( A a, B b, C c, D d, E e, F f, G g, H h )
    {
       return 8;
    }
+
    template< typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
    U32 operator ()( A a, B b, C c, D d, E e, F f, G g, H h, I i )
    {
       return 9;
    }
+
    template< typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
    U32 operator ()( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j )
    {
       return 10;
    }
+
    template< typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
    U32 operator ()( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k )
    {
       return 11;
    }
+
+   template< typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
+   U32 operator ()( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l )
+   {
+      return 12;
+   }
+
    
    operator U32() const
    {
       return 0;
    }
 };
+
+
 
 
 // Encapsulation of a legacy console function invocation.
@@ -1457,6 +1768,7 @@ struct _EngineConsoleThunk< startArgc, R() >
       return _EngineConsoleThunkReturnValue( ( frame->*fn )() );
    }
 };
+
 template< S32 startArgc >
 struct _EngineConsoleThunk< startArgc, void() >
 {
@@ -1473,6 +1785,8 @@ struct _EngineConsoleThunk< startArgc, void() >
    }
 };
 
+
+
 template< S32 startArgc, typename R, typename A >
 struct _EngineConsoleThunk< startArgc, R( A ) >
 {
@@ -1480,16 +1794,19 @@ struct _EngineConsoleThunk< startArgc, R( A ) >
    static const S32 NUM_ARGS = 1 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A ), const _EngineFunctionDefaultArguments< void( A ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a ) );
    }
 };
+
 template< S32 startArgc, typename A >
 struct _EngineConsoleThunk< startArgc, void( A ) >
 {
@@ -1497,16 +1814,19 @@ struct _EngineConsoleThunk< startArgc, void( A ) >
    static const S32 NUM_ARGS = 1 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A ), const _EngineFunctionDefaultArguments< void( A ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
+      
       fn( a );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
+      
       ( frame->*fn )( a );
    }
 };
+
 
 template< S32 startArgc, typename R, typename A, typename B >
 struct _EngineConsoleThunk< startArgc, R( A, B ) >
@@ -1515,18 +1835,21 @@ struct _EngineConsoleThunk< startArgc, R( A, B ) >
    static const S32 NUM_ARGS = 2 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B ), const _EngineFunctionDefaultArguments< void( A, B ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a, b ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b ) );
    }
 };
+
 template< S32 startArgc, typename A, typename B >
 struct _EngineConsoleThunk< startArgc, void( A, B ) >
 {
@@ -1534,18 +1857,21 @@ struct _EngineConsoleThunk< startArgc, void( A, B ) >
    static const S32 NUM_ARGS = 2 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B ), const _EngineFunctionDefaultArguments< void( A, B ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
+      
       fn( a, b );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
+      
       ( frame->*fn )( a, b );
    }
 };
+
 
 template< S32 startArgc, typename R, typename A, typename B, typename C >
 struct _EngineConsoleThunk< startArgc, R( A, B, C ) >
@@ -1554,20 +1880,23 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C ) >
    static const S32 NUM_ARGS = 3 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B, C ), const _EngineFunctionDefaultArguments< void( A, B, C ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a, b, c ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B, C ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b, c ) );
    }
 };
+
 template< S32 startArgc, typename A, typename B, typename C >
 struct _EngineConsoleThunk< startArgc, void( A, B, C ) >
 {
@@ -1575,20 +1904,23 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C ) >
    static const S32 NUM_ARGS = 3 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B, C ), const _EngineFunctionDefaultArguments< void( A, B, C ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
+      
       fn( a, b, c );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B, C ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
+      
       ( frame->*fn )( a, b, c );
    }
 };
+
 
 template< S32 startArgc, typename R, typename A, typename B, typename C, typename D >
 struct _EngineConsoleThunk< startArgc, R( A, B, C, D ) >
@@ -1597,22 +1929,25 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D ) >
    static const S32 NUM_ARGS = 4 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B, C, D ), const _EngineFunctionDefaultArguments< void( A, B, C, D ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a, b, c, d ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B, C, D ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b, c, d ) );
    }
 };
+
 template< S32 startArgc, typename A, typename B, typename C, typename D >
 struct _EngineConsoleThunk< startArgc, void( A, B, C, D ) >
 {
@@ -1620,22 +1955,25 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D ) >
    static const S32 NUM_ARGS = 4 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B, C, D ), const _EngineFunctionDefaultArguments< void( A, B, C, D ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
+      
       fn( a, b, c, d );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B, C, D ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
+      
       ( frame->*fn )( a, b, c, d );
    }
 };
+
 
 template< S32 startArgc, typename R, typename A, typename B, typename C, typename D, typename E >
 struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E ) >
@@ -1644,24 +1982,27 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E ) >
    static const S32 NUM_ARGS = 5 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B, C, D, E ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.e ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a, b, c, d, e ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B, C, D, E ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.f ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b, c, d, e ) );
    }
 };
+
 template< S32 startArgc, typename A, typename B, typename C, typename D, typename E >
 struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E ) >
 {
@@ -1669,24 +2010,27 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E ) >
    static const S32 NUM_ARGS = 5 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B, C, D, E ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.e ) );
+      
       fn( a, b, c, d, e );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B, C, D, E ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.f ) );
+      
       ( frame->*fn )( a, b, c, d, e );
    }
 };
+
 
 template< S32 startArgc, typename R, typename A, typename B, typename C, typename D, typename E, typename F >
 struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F ) >
@@ -1695,26 +2039,29 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F ) >
    static const S32 NUM_ARGS = 6 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B, C, D, E, F ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.e ) );
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.f ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a, b, c, d, e, f ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B, C, D, E, F ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.f ) );
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.g ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b, c, d, e, f ) );
    }
 };
+
 template< S32 startArgc, typename A, typename B, typename C, typename D, typename E, typename F >
 struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F ) >
 {
@@ -1722,26 +2069,29 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F ) >
    static const S32 NUM_ARGS = 6 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B, C, D, E, F ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.e ) );
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.f ) );
+      
       fn( a, b, c, d, e, f );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B, C, D, E, F ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.f ) );
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.g ) );
+      
       ( frame->*fn )( a, b, c, d, e, f );
    }
 };
+
 
 template< S32 startArgc, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
 struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G ) >
@@ -1750,28 +2100,31 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G ) >
    static const S32 NUM_ARGS = 7 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B, C, D, E, F, G ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.e ) );
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.f ) );
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.g ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a, b, c, d, e, f, g ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B, C, D, E, F, G ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.f ) );
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.g ) );
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.h ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b, c, d, e, f, g ) );
    }
 };
+
 template< S32 startArgc, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
 struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G ) >
 {
@@ -1779,28 +2132,31 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G ) >
    static const S32 NUM_ARGS = 7 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B, C, D, E, F, G ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.e ) );
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.f ) );
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.g ) );
+      
       fn( a, b, c, d, e, f, g );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B, C, D, E, F, G ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
       E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.f ) );
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.g ) );
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.h ) );
+      
       ( frame->*fn )( a, b, c, d, e, f, g );
    }
 };
+
 
 template< S32 startArgc, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
 struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H ) >
@@ -1809,7 +2165,7 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H ) >
    static const S32 NUM_ARGS = 8 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B, C, D, E, F, G, H ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G, H ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
@@ -1817,12 +2173,13 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H ) >
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.f ) );
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.g ) );
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.h ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a, b, c, d, e, f, g, h ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B, C, D, E, F, G, H ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G, H ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
@@ -1830,9 +2187,11 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H ) >
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.g ) );
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.h ) );
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.i ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b, c, d, e, f, g, h ) );
    }
 };
+
 template< S32 startArgc, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
 struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H ) >
 {
@@ -1840,7 +2199,7 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H ) >
    static const S32 NUM_ARGS = 8 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B, C, D, E, F, G, H ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G, H ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
@@ -1848,12 +2207,13 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H ) >
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.f ) );
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.g ) );
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.h ) );
+      
       fn( a, b, c, d, e, f, g, h );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B, C, D, E, F, G, H ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G, H ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
@@ -1861,9 +2221,11 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H ) >
       F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.g ) );
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.h ) );
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.i ) );
+      
       ( frame->*fn )( a, b, c, d, e, f, g, h );
    }
 };
+
 
 template< S32 startArgc, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
 struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I ) >
@@ -1872,7 +2234,7 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I ) >
    static const S32 NUM_ARGS = 9 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B, C, D, E, F, G, H, I ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G, H, I ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
@@ -1881,12 +2243,13 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I ) >
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.g ) );
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.h ) );
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.i ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a, b, c, d, e, f, g, h, i ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B, C, D, E, F, G, H, I ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G, H, I ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
@@ -1895,9 +2258,11 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I ) >
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.h ) );
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.i ) );
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.j ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b, c, d, e, f, g, h, i ) );
    }
 };
+
 template< S32 startArgc, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
 struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I ) >
 {
@@ -1905,7 +2270,7 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I ) >
    static const S32 NUM_ARGS = 9 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B, C, D, E, F, G, H, I ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G, H, I ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
@@ -1914,12 +2279,13 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I ) >
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.g ) );
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.h ) );
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.i ) );
+      
       fn( a, b, c, d, e, f, g, h, i );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B, C, D, E, F, G, H, I ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G, H, I ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
@@ -1928,9 +2294,11 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I ) >
       G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.h ) );
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.i ) );
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.j ) );
+      
       ( frame->*fn )( a, b, c, d, e, f, g, h, i );
    }
 };
+
 
 template< S32 startArgc, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
 struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I, J ) >
@@ -1939,7 +2307,7 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I, J ) >
    static const S32 NUM_ARGS = 10 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B, C, D, E, F, G, H, I, J ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G, H, I, J ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
@@ -1949,12 +2317,13 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I, J ) >
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.h ) );
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.i ) );
       J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.j ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a, b, c, d, e, f, g, h, i, j ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B, C, D, E, F, G, H, I, J ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G, H, I, J ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
@@ -1964,9 +2333,11 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I, J ) >
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.i ) );
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.j ) );
       J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.k ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b, c, d, e, f, g, h, i, j ) );
    }
 };
+
 template< S32 startArgc, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
 struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I, J ) >
 {
@@ -1974,7 +2345,7 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I, J ) >
    static const S32 NUM_ARGS = 10 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B, C, D, E, F, G, H, I, J ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G, H, I, J ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
@@ -1984,12 +2355,13 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I, J ) >
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.h ) );
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.i ) );
       J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.j ) );
+      
       fn( a, b, c, d, e, f, g, h, i, j );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B, C, D, E, F, G, H, I, J ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G, H, I, J ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
@@ -1999,9 +2371,12 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I, J ) >
       H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.i ) );
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.j ) );
       J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.k ) );
+      
       ( frame->*fn )( a, b, c, d, e, f, g, h, i, j );
    }
 };
+
+
 template< S32 startArgc, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
 struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I, J, K ) >
 {
@@ -2009,7 +2384,7 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I, J, K ) >
    static const S32 NUM_ARGS = 11 + startArgc;
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B, C, D, E, F, G, H, I, J, K ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G, H, I, J, K ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
@@ -2020,12 +2395,13 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I, J, K ) >
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.i ) );
       J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.j ) );
       K k = ( startArgc + 10 < argc ? EngineUnmarshallData< K >()( argv[ startArgc + 10 ] ) : K( defaultArgs.k ) );
+      
       return _EngineConsoleThunkReturnValue( fn( a, b, c, d, e, f, g, h, i, j, k ) );
    }
    template< typename Frame >
    static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B, C, D, E, F, G, H, I, J, K ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G, H, I, J, K ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
@@ -2036,9 +2412,11 @@ struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I, J, K ) >
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.j ) );
       J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.k ) );
       K k = ( startArgc + 10 < argc ? EngineUnmarshallData< K >()( argv[ startArgc + 10 ] ) : K( defaultArgs.l ) );
+      
       return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b, c, d, e, f, g, h, i, j, k ) );
    }
 };
+
 template< S32 startArgc, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
 struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I, J, K ) >
 {
@@ -2046,7 +2424,7 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I, J, K ) >
    static const S32 NUM_ARGS = 11 + startArgc;
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B, C, D, E, F, G, H, I, J, K ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G, H, I, J, K ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.a ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
@@ -2057,12 +2435,13 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I, J, K ) >
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.i ) );
       J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.j ) );
       K k = ( startArgc + 10 < argc ? EngineUnmarshallData< K >()( argv[ startArgc + 10 ] ) : K( defaultArgs.k ) );
+      
       fn( a, b, c, d, e, f, g, h, i, j, k );
    }
    template< typename Frame >
    static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B, C, D, E, F, G, H, I, J, K ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G, H, I, J, K ) >& defaultArgs )
    {
-      A a = ( startArgc < argc ? EngineUnmarshallData< A >()( argv[ startArgc ] ) : A( defaultArgs.b ) );
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
       B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
       C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
       D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
@@ -2073,9 +2452,96 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I, J, K ) >
       I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.j ) );
       J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.k ) );
       K k = ( startArgc + 10 < argc ? EngineUnmarshallData< K >()( argv[ startArgc + 10 ] ) : K( defaultArgs.l ) );
+      
       ( frame->*fn )( a, b, c, d, e, f, g, h, i, j, k );
    }
 };
+
+
+template< S32 startArgc, typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
+struct _EngineConsoleThunk< startArgc, R( A, B, C, D, E, F, G, H, I, J, K, L ) >
+{
+   typedef typename _EngineConsoleThunkType< R >::ReturnType ReturnType;
+   static const S32 NUM_ARGS = 12 + startArgc;
+   static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( *fn )( A, B, C, D, E, F, G, H, I, J, K, L ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G, H, I, J, K, L ) >& defaultArgs )
+   {
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
+      B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
+      C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
+      D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
+      E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.e ) );
+      F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.f ) );
+      G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.g ) );
+      H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.h ) );
+      I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.i ) );
+      J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.j ) );
+      K k = ( startArgc + 10 < argc ? EngineUnmarshallData< K >()( argv[ startArgc + 10 ] ) : K( defaultArgs.k ) );
+      L l = ( startArgc + 11 < argc ? EngineUnmarshallData< L >()( argv[ startArgc + 11 ] ) : L( defaultArgs.l ) );
+      
+      return _EngineConsoleThunkReturnValue( fn( a, b, c, d, e, f, g, h, i, j, k, l ) );
+   }
+   template< typename Frame >
+   static ReturnType thunk( S32 argc, ConsoleValueRef *argv, R ( Frame::*fn )( A, B, C, D, E, F, G, H, I, J, K, L ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G, H, I, J, K, L ) >& defaultArgs )
+   {
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
+      B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
+      C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
+      D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
+      E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.f ) );
+      F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.g ) );
+      G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.h ) );
+      H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.i ) );
+      I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.j ) );
+      J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.k ) );
+      K k = ( startArgc + 10 < argc ? EngineUnmarshallData< K >()( argv[ startArgc + 10 ] ) : K( defaultArgs.l ) );
+      L l = ( startArgc + 11 < argc ? EngineUnmarshallData< L >()( argv[ startArgc + 11 ] ) : L( defaultArgs.l ) );
+      
+      return _EngineConsoleThunkReturnValue( ( frame->*fn )( a, b, c, d, e, f, g, h, i, j, k, l ) );
+   }
+};
+
+template< S32 startArgc, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
+struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I, J, K, L ) >
+{
+   typedef void ReturnType;
+   static const S32 NUM_ARGS = 12 + startArgc;
+   static void thunk( S32 argc, ConsoleValueRef *argv, void ( *fn )( A, B, C, D, E, F, G, H, I, J, K, L ), const _EngineFunctionDefaultArguments< void( A, B, C, D, E, F, G, H, I, J, K, L ) >& defaultArgs )
+   {
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.a ) );
+      B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.b ) );
+      C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.c ) );
+      D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.d ) );
+      E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.e ) );
+      F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.f ) );
+      G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.g ) );
+      H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.h ) );
+      I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.i ) );
+      J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.j ) );
+      K k = ( startArgc + 10 < argc ? EngineUnmarshallData< K >()( argv[ startArgc + 10 ] ) : K( defaultArgs.k ) );
+      L l = ( startArgc + 11 < argc ? EngineUnmarshallData< L >()( argv[ startArgc + 11 ] ) : L( defaultArgs.l ) );
+      
+      fn( a, b, c, d, e, f, g, h, i, j, k, l );
+   }
+   template< typename Frame >
+   static void thunk( S32 argc, ConsoleValueRef *argv, void ( Frame::*fn )( A, B, C, D, E, F, G, H, I, J, K, L ) const, Frame* frame, const _EngineFunctionDefaultArguments< void( typename Frame::ObjectType*, A, B, C, D, E, F, G, H, I, J, K, L ) >& defaultArgs )
+   {
+      A a = ( startArgc + 0 < argc ? EngineUnmarshallData< A >()( argv[ startArgc + 0 ] ) : A( defaultArgs.b ) );
+      B b = ( startArgc + 1 < argc ? EngineUnmarshallData< B >()( argv[ startArgc + 1 ] ) : B( defaultArgs.c ) );
+      C c = ( startArgc + 2 < argc ? EngineUnmarshallData< C >()( argv[ startArgc + 2 ] ) : C( defaultArgs.d ) );
+      D d = ( startArgc + 3 < argc ? EngineUnmarshallData< D >()( argv[ startArgc + 3 ] ) : D( defaultArgs.e ) );
+      E e = ( startArgc + 4 < argc ? EngineUnmarshallData< E >()( argv[ startArgc + 4 ] ) : E( defaultArgs.f ) );
+      F f = ( startArgc + 5 < argc ? EngineUnmarshallData< F >()( argv[ startArgc + 5 ] ) : F( defaultArgs.g ) );
+      G g = ( startArgc + 6 < argc ? EngineUnmarshallData< G >()( argv[ startArgc + 6 ] ) : G( defaultArgs.h ) );
+      H h = ( startArgc + 7 < argc ? EngineUnmarshallData< H >()( argv[ startArgc + 7 ] ) : H( defaultArgs.i ) );
+      I i = ( startArgc + 8 < argc ? EngineUnmarshallData< I >()( argv[ startArgc + 8 ] ) : I( defaultArgs.j ) );
+      J j = ( startArgc + 9 < argc ? EngineUnmarshallData< J >()( argv[ startArgc + 9 ] ) : J( defaultArgs.k ) );
+      K k = ( startArgc + 10 < argc ? EngineUnmarshallData< K >()( argv[ startArgc + 10 ] ) : K( defaultArgs.l ) );
+      L l = ( startArgc + 11 < argc ? EngineUnmarshallData< L >()( argv[ startArgc + 11 ] ) : L( defaultArgs.l ) );
+      
+      ( frame->*fn )( a, b, c, d, e, f, g, h, i, j, k, l );
+   }
+};
+
 
 
 /// @}
@@ -2569,7 +3035,7 @@ struct _EngineConsoleThunk< startArgc, void( A, B, C, D, E, F, G, H, I, J, K ) >
       return returnType();                                                                                                                   \
    }
 
-#include "console/stringStack.h"
+
 
 
 // Internal helper class for doing call-outs in the new interop.
@@ -2592,82 +3058,98 @@ struct _EngineCallbackHelper
          typedef R( FunctionType )( EngineObject* );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis ) );
       }
+
+      
       template< typename R, typename A >
       R call( A a ) const
       {
          typedef R( FunctionType )( EngineObject*, A );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a ) );
       }
+      
       template< typename R, typename A, typename B >
       R call( A a, B b ) const
       {
          typedef R( FunctionType )( EngineObject*, A, B );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b ) );
       }
+      
       template< typename R, typename A, typename B, typename C >
       R call( A a, B b, C c ) const
       {
          typedef R( FunctionType )( EngineObject*, A, B, C );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b, c ) );
       }
+      
       template< typename R, typename A, typename B, typename C, typename D >
       R call( A a, B b, C c, D d ) const
       {
          typedef R( FunctionType )( EngineObject*, A, B, C, D );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b, c, d ) );
       }
+      
       template< typename R, typename A, typename B, typename C, typename D, typename E >
       R call( A a, B b, C c, D d, E e ) const
       {
          typedef R( FunctionType )( EngineObject*, A, B, C, D, E );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b, c, d, e ) );
       }
+      
       template< typename R, typename A, typename B, typename C, typename D, typename E, typename F >
       R call( A a, B b, C c, D d, E e, F f ) const
       {
          typedef R( FunctionType )( EngineObject*, A, B, C, D, E, F );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b, c, d, e, f ) );
       }
+      
       template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
       R call( A a, B b, C c, D d, E e, F f, G g ) const
       {
          typedef R( FunctionType )( EngineObject*, A, B, C, D, E, F, G );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b, c, d, e, f, g ) );
       }
+      
       template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
       R call( A a, B b, C c, D d, E e, F f, G g, H h ) const
       {
          typedef R( FunctionType )( EngineObject*, A, B, C, D, E, F, G, H );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b, c, d, e, f, g, h ) );
       }
+      
       template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
       R call( A a, B b, C c, D d, E e, F f, G g, H h, I i ) const
       {
          typedef R( FunctionType )( EngineObject*, A, B, C, D, E, F, G, H, I );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b, c, d, e, f, g, h, i ) );
       }
+      
       template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
       R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j ) const
       {
          typedef R( FunctionType )( EngineObject*, A, B, C, D, E, F, G, H, I, J );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b, c, d, e, f, g, h, i, j ) );
       }
+      
       template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
       R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k ) const
       {
          typedef R( FunctionType )( EngineObject*, A, B, C, D, E, F, G, H, I, J, K );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b, c, d, e, f, g, h, i, j, k ) );
       }
+      
       template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
       R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l ) const
       {
-         typedef R( FunctionType )( EngineObject*, A, B, C, D, E, F, G, H, I, J, K, L l );
+         typedef R( FunctionType )( EngineObject*, A, B, C, D, E, F, G, H, I, J, K, L );
          return R( reinterpret_cast< FunctionType* >( const_cast<void*>(mFn) )( mThis, a, b, c, d, e, f, g, h, i, j, k, l ) );
       }
+      
 };
 
 class SimConsoleThreadExecEvent;
+#include "console/stringStack.h"
 
+// Internal helper for callback support in legacy console system.
 struct _BaseEngineConsoleCallbackHelper
 {
 public:
@@ -2687,7 +3169,7 @@ public:
    _BaseEngineConsoleCallbackHelper() {;}
 };
 
-// Internal helper for callback support in legacy console system.
+
 
 // Base helper for console callbacks
 struct _EngineConsoleCallbackHelper : public _BaseEngineConsoleCallbackHelper
@@ -2722,6 +3204,9 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+
+
+   
    template< typename R, typename A >
    R call( A a )
    {
@@ -2732,6 +3217,7 @@ public:
          mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
+
          return R( EngineUnmarshallData< R >()( _exec() ) );
       }
       else
@@ -2739,6 +3225,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+1, NULL, false, &cb);
          evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
 
@@ -2747,6 +3234,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B >
    R call( A a, B b )
    {
@@ -2766,6 +3254,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+2, NULL, false, &cb);
          evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -2775,6 +3264,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C >
    R call( A a, B b, C c )
    {
@@ -2795,7 +3285,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+3, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -2806,6 +3296,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D >
    R call( A a, B b, C c, D d )
    {
@@ -2827,7 +3318,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+4, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -2839,6 +3330,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E >
    R call( A a, B b, C c, D d, E e )
    {
@@ -2861,7 +3353,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+5, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -2874,6 +3366,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F >
    R call( A a, B b, C c, D d, E e, F f )
    {
@@ -2897,7 +3390,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+6, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -2911,6 +3404,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
    R call( A a, B b, C c, D d, E e, F f, G g )
    {
@@ -2935,7 +3429,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+7, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -2950,6 +3444,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
    R call( A a, B b, C c, D d, E e, F f, G g, H h )
    {
@@ -2975,7 +3470,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+8, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -2991,9 +3486,10 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i )
-   { 
+   {
       if (Con::isMainThread())
       {
          ConsoleStackFrameSaver sav; sav.save();
@@ -3017,7 +3513,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+9, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3034,6 +3530,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j )
    {
@@ -3061,7 +3558,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+10, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3079,6 +3576,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k )
    {
@@ -3107,6 +3605,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+11, NULL, false, &cb);
          evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3125,6 +3624,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l )
    {
@@ -3154,6 +3654,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+12, NULL, false, &cb);
          evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3173,7 +3674,10 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
 };
+
+
 
 // Override for when first parameter is const char*
 template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEngineConsoleCallbackHelper
@@ -3207,6 +3711,8 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
       }
    }
 
+
+   
    template< typename R, typename A >
    R call( A a )
    {
@@ -3217,6 +3723,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
+
          return R( EngineUnmarshallData< R >()( _exec() ) );
       }
       else
@@ -3224,6 +3731,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+1, NULL, false, &cb);
          evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
 
@@ -3232,6 +3740,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B >
    R call( A a, B b )
    {
@@ -3251,6 +3760,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+2, NULL, false, &cb);
          evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3260,6 +3770,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C >
    R call( A a, B b, C c )
    {
@@ -3280,7 +3791,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+3, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3291,6 +3802,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D >
    R call( A a, B b, C c, D d )
    {
@@ -3312,7 +3824,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+4, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3324,6 +3836,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E >
    R call( A a, B b, C c, D d, E e )
    {
@@ -3346,7 +3859,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+5, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3359,6 +3872,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F >
    R call( A a, B b, C c, D d, E e, F f )
    {
@@ -3382,7 +3896,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+6, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3396,6 +3910,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
    R call( A a, B b, C c, D d, E e, F f, G g )
    {
@@ -3420,7 +3935,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+7, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3435,6 +3950,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
    R call( A a, B b, C c, D d, E e, F f, G g, H h )
    {
@@ -3460,7 +3976,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+8, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3476,9 +3992,10 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i )
-   { 
+   {
       if (Con::isMainThread())
       {
          ConsoleStackFrameSaver sav; sav.save();
@@ -3502,7 +4019,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+9, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3519,6 +4036,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j )
    {
@@ -3546,7 +4064,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+10, NULL, false, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3564,6 +4082,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k )
    {
@@ -3592,6 +4111,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+11, NULL, false, &cb);
          evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3610,6 +4130,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l )
    {
@@ -3639,6 +4160,7 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+12, NULL, false, &cb);
          evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(mCallbackName);
 
          EngineMarshallData( a, mArgc, mArgv );
          EngineMarshallData( b, mArgc, mArgv );
@@ -3658,7 +4180,9 @@ template<> struct _EngineConsoleExecCallbackHelper<const char*> : public _BaseEn
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
 };
+
 
 
 // Override for when first parameter is presumably a SimObject*, in which case A will be absorbed as the callback
@@ -3673,29 +4197,35 @@ public:
       mCallbackName = NULL;
    }
 
+   
    template< typename R, typename A >
    R call( A a )
    {
       if (Con::isMainThread())
       {
          ConsoleStackFrameSaver sav; sav.save();
-         CSTK.reserveValues(mArgc, mArgv);
+         CSTK.reserveValues(mArgc+0, mArgv);
          mArgv[ 0 ].value->setStackStringValue(a);
+
+         
 
          return R( EngineUnmarshallData< R >()( _exec() ) );
       }
       else
       {
          SimConsoleThreadExecCallback cb;
-         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc, NULL, true, &cb);
+         SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+0, NULL, true, &cb);
          evt->populateArgs(mArgv);
          mArgv[ 0 ].value->setStackStringValue(a);
+
+         
 
          Sim::postEvent(mThis, evt, Sim::getCurrentTime());
 
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B >
    R call( A a, B b )
    {
@@ -3723,6 +4253,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C >
    R call( A a, B b, C c )
    {
@@ -3742,7 +4273,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+2, NULL, true, &cb);
          evt->populateArgs(mArgv);
-
+         mArgv[ 0 ].value->setStackStringValue(a);
 
          EngineMarshallData( b, mArgc, mArgv );
          EngineMarshallData( c, mArgc, mArgv );
@@ -3752,6 +4283,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D >
    R call( A a, B b, C c, D d )
    {
@@ -3774,7 +4306,6 @@ public:
          evt->populateArgs(mArgv);
          mArgv[ 0 ].value->setStackStringValue(a);
 
-
          EngineMarshallData( b, mArgc, mArgv );
          EngineMarshallData( c, mArgc, mArgv );
          EngineMarshallData( d, mArgc, mArgv );
@@ -3784,6 +4315,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E >
    R call( A a, B b, C c, D d, E e )
    {
@@ -3807,7 +4339,6 @@ public:
          evt->populateArgs(mArgv);
          mArgv[ 0 ].value->setStackStringValue(a);
 
-
          EngineMarshallData( b, mArgc, mArgv );
          EngineMarshallData( c, mArgc, mArgv );
          EngineMarshallData( d, mArgc, mArgv );
@@ -3818,6 +4349,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F >
    R call( A a, B b, C c, D d, E e, F f )
    {
@@ -3842,7 +4374,6 @@ public:
          evt->populateArgs(mArgv);
          mArgv[ 0 ].value->setStackStringValue(a);
 
-
          EngineMarshallData( b, mArgc, mArgv );
          EngineMarshallData( c, mArgc, mArgv );
          EngineMarshallData( d, mArgc, mArgv );
@@ -3854,6 +4385,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G >
    R call( A a, B b, C c, D d, E e, F f, G g )
    {
@@ -3891,6 +4423,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H >
    R call( A a, B b, C c, D d, E e, F f, G g, H h )
    {
@@ -3930,9 +4463,10 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i )
-   { 
+   {
       if (Con::isMainThread())
       {
          ConsoleStackFrameSaver sav; sav.save();
@@ -3971,6 +4505,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j )
    {
@@ -3997,6 +4532,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+9, NULL, true, &cb);
          evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
 
          EngineMarshallData( b, mArgc, mArgv );
          EngineMarshallData( c, mArgc, mArgv );
@@ -4013,6 +4549,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k )
    {
@@ -4040,6 +4577,7 @@ public:
          SimConsoleThreadExecCallback cb;
          SimConsoleThreadExecEvent *evt = new SimConsoleThreadExecEvent(mArgc+10, NULL, true, &cb);
          evt->populateArgs(mArgv);
+         mArgv[ 0 ].value->setStackStringValue(a);
 
          EngineMarshallData( b, mArgc, mArgv );
          EngineMarshallData( c, mArgc, mArgv );
@@ -4057,6 +4595,7 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
    template< typename R, typename A, typename B, typename C, typename D, typename E, typename F, typename G, typename H, typename I, typename J, typename K, typename L >
    R call( A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l )
    {
@@ -4104,8 +4643,8 @@ public:
          return R( EngineUnmarshallData< R >()( cb.waitForResult() ) );
       }
    }
+   
 };
-
 
 // Re-enable some VC warnings we disabled for this file.
 #pragma warning( pop ) // 4510 and 4610

--- a/Engine/source/console/sim.h
+++ b/Engine/source/console/sim.h
@@ -157,13 +157,13 @@ namespace Sim
    SimTime getTargetTime();
 
    /// a target time of 0 on an event means current event
-   U32 postEvent(SimObject*, SimEvent*, U32 targetTime);
+   U32 postEvent(SimObject*, SimEvent*, SimTime targetTime);
 
-   inline U32 postEvent(SimObjectId iD,SimEvent*evt, U32 targetTime)
+   inline U32 postEvent(SimObjectId iD,SimEvent*evt, SimTime targetTime)
    {
       return postEvent(findObject(iD), evt, targetTime);
    }
-   inline U32 postEvent(const char *objectName,SimEvent*evt, U32 targetTime)
+   inline U32 postEvent(const char *objectName,SimEvent*evt, SimTime targetTime)
    {
       return postEvent(findObject(objectName), evt, targetTime);
    }

--- a/Engine/source/console/simEvents.cpp
+++ b/Engine/source/console/simEvents.cpp
@@ -39,7 +39,10 @@ SimConsoleEvent::SimConsoleEvent(S32 argc, ConsoleValueRef *argv, bool onObject)
       mArgv[i].value = new ConsoleValue();
       mArgv[i].value->type = ConsoleValue::TypeInternalString;
       mArgv[i].value->init();
-      mArgv[i].value->setStringValue((const char*)argv[i]);
+	  if (argv)
+	  {
+		mArgv[i].value->setStringValue((const char*)argv[i]);
+	  }
    }
 }
 
@@ -92,10 +95,19 @@ void SimConsoleEvent::process(SimObject* object)
    }
 }
 
+void SimConsoleEvent::populateArgs(ConsoleValueRef *argv)
+{
+   for (U32 i=0; i<mArgc; i++)
+   {
+      argv[i].value = mArgv[i].value;
+   }
+}
+
 //-----------------------------------------------------------------------------
 
-SimConsoleThreadExecCallback::SimConsoleThreadExecCallback() : retVal(NULL)
+SimConsoleThreadExecCallback::SimConsoleThreadExecCallback()
 {
+   retVal.value = NULL;
    sem = new Semaphore(0);
 }
 
@@ -104,13 +116,13 @@ SimConsoleThreadExecCallback::~SimConsoleThreadExecCallback()
    delete sem;
 }
 
-void SimConsoleThreadExecCallback::handleCallback(const char *ret)
+void SimConsoleThreadExecCallback::handleCallback(ConsoleValueRef ret)
 {
    retVal = ret;
    sem->release();
 }
 
-const char *SimConsoleThreadExecCallback::waitForResult()
+ConsoleValueRef SimConsoleThreadExecCallback::waitForResult()
 {
    if(sem->acquire(true))
    {
@@ -129,7 +141,7 @@ SimConsoleThreadExecEvent::SimConsoleThreadExecEvent(S32 argc, ConsoleValueRef *
 
 void SimConsoleThreadExecEvent::process(SimObject* object)
 {
-   const char *retVal;
+   ConsoleValueRef retVal;
    if(mOnObject)
       retVal = Con::execute(object, mArgc, mArgv);
    else

--- a/Engine/source/console/simEvents.h
+++ b/Engine/source/console/simEvents.h
@@ -114,19 +114,22 @@ public:
 
    ~SimConsoleEvent();
    virtual void process(SimObject *object);
+
+   /// Creates a reference to our internal args list in argv
+   void populateArgs(ConsoleValueRef *argv);
 };
 
 /// Used by Con::threadSafeExecute()
 struct SimConsoleThreadExecCallback
 {
    Semaphore   *sem;
-   const char  *retVal;
+   ConsoleValueRef retVal;
 
    SimConsoleThreadExecCallback();
    ~SimConsoleThreadExecCallback();
 
-   void handleCallback(const char *ret);
-   const char *waitForResult();
+   void handleCallback(ConsoleValueRef ret);
+   ConsoleValueRef waitForResult();
 };
 
 class SimConsoleThreadExecEvent : public SimConsoleEvent
@@ -136,6 +139,7 @@ class SimConsoleThreadExecEvent : public SimConsoleEvent
 public:
    SimConsoleThreadExecEvent(S32 argc, ConsoleValueRef *argv, bool onObject, SimConsoleThreadExecCallback *callback);
 
+   SimConsoleThreadExecCallback& getCB() { return *cb; }
    virtual void process(SimObject *object);
 };
 

--- a/Engine/source/console/simEvents.h
+++ b/Engine/source/console/simEvents.h
@@ -119,6 +119,8 @@ public:
    void populateArgs(ConsoleValueRef *argv);
 };
 
+
+// NOTE: SimConsoleThreadExecCallback & SimConsoleThreadExecEvent moved to engineAPI.h
 /// Used by Con::threadSafeExecute()
 struct SimConsoleThreadExecCallback
 {

--- a/Engine/source/console/simObjectList.cpp
+++ b/Engine/source/console/simObjectList.cpp
@@ -23,7 +23,8 @@
 #include "platform/platform.h"
 #include "console/simObjectList.h"
 
-#include "console/console.h"
+#include "console/simBase.h"
+#include "console/engineAPI.h"
 #include "console/sim.h"
 #include "console/simObject.h"
 

--- a/Engine/source/console/stringStack.cpp
+++ b/Engine/source/console/stringStack.cpp
@@ -90,6 +90,8 @@ void ConsoleValueStack::pushValue(ConsoleValue &variable)
       mStack[mStackPos++].setIntValue((S32)variable.getIntValue());
    case ConsoleValue::TypeInternalFloat:
       mStack[mStackPos++].setFloatValue((F32)variable.getFloatValue());
+   case ConsoleValue::TypeInternalStringStackPtr:
+      mStack[mStackPos++].setStringStackPtrValue(variable.getStringStackPtr());
    default:
       mStack[mStackPos++].setStringValue(variable.getStringValue());
    }
@@ -148,6 +150,19 @@ ConsoleValue *ConsoleValueStack::pushStackString(const char *value)
    //Con::printf("[%i]CSTK pushString %s", mStackPos, value);
 
    mStack[mStackPos++].setStackStringValue(value);
+   return &mStack[mStackPos-1];
+}
+
+ConsoleValue *ConsoleValueStack::pushStringStackPtr(StringStackPtr value)
+{
+   if (mStackPos == ConsoleValueStack::MaxStackDepth) {
+      AssertFatal(false, "Console Value Stack is empty");
+      return NULL;
+   }
+
+   //Con::printf("[%i]CSTK pushStringStackPtr %s", mStackPos, StringStackPtrRef(value).getPtr(&STR));
+
+   mStack[mStackPos++].setStringStackPtrValue(value);
    return &mStack[mStackPos-1];
 }
 

--- a/Engine/source/console/stringStack.cpp
+++ b/Engine/source/console/stringStack.cpp
@@ -31,12 +31,11 @@ void ConsoleValueStack::getArgcArgv(StringTableEntry name, U32 *argc, ConsoleVal
    U32 argCount   = getMin(mStackPos - startStack, (U32)MaxArgs - 1);
 
    *in_argv = mArgv;
-   mArgv[0] = name;
+   mArgv[0].value = CSTK.pushStackString(name);
    
    for(U32 i = 0; i < argCount; i++) {
       ConsoleValueRef *ref = &mArgv[i+1];
       ref->value = &mStack[startStack + i];
-      ref->stringStackValue = NULL;
    }
    argCount++;
    
@@ -94,6 +93,36 @@ void ConsoleValueStack::pushValue(ConsoleValue &variable)
    default:
       mStack[mStackPos++].setStringValue(variable.getStringValue());
    }
+}
+
+ConsoleValue* ConsoleValueStack::reserveValues(U32 count)
+{
+   U32 startPos = mStackPos;
+   if (startPos+count >= ConsoleValueStack::MaxStackDepth) {
+      AssertFatal(false, "Console Value Stack is empty");
+      return NULL;
+   }
+
+   //Con::printf("[%i]CSTK reserveValues %i", mStackPos, count);
+   mStackPos += count;
+   return &mStack[startPos];
+}
+
+bool ConsoleValueStack::reserveValues(U32 count, ConsoleValueRef *outValues)
+{
+   U32 startPos = mStackPos;
+   if (startPos+count >= ConsoleValueStack::MaxStackDepth) {
+      AssertFatal(false, "Console Value Stack is empty");
+      return false;
+   }
+
+   //Con::printf("[%i]CSTK reserveValues %i", mStackPos, count);
+   for (U32 i=0; i<count; i++)
+   {
+	   outValues[i].value = &mStack[mStackPos+i];
+   }
+   mStackPos += count;
+   return true;
 }
 
 ConsoleValue *ConsoleValueStack::pushString(const char *value)

--- a/Engine/source/console/stringStack.h
+++ b/Engine/source/console/stringStack.h
@@ -127,6 +127,7 @@ struct StringStack
    /// Return a temporary buffer we can use to return data.
    char* getReturnBuffer(U32 size)
    {
+      AssertFatal(Con::isMainThread(), "Manipulating return buffer from a secondary thread!");
       validateArgBufferSize(size);
       return mArgBuffer;
    }
@@ -136,6 +137,7 @@ struct StringStack
    /// This updates the function offset.
    char *getArgBuffer(U32 size)
    {
+      AssertFatal(Con::isMainThread(), "Manipulating console arg buffer from a secondary thread!");
       validateBufferSize(mStart + mFunctionOffset + size);
       char *ret = mBuffer + mStart + mFunctionOffset;
       mFunctionOffset += size;
@@ -314,6 +316,8 @@ public:
 
    void pushVar(ConsoleValue *variable);
    void pushValue(ConsoleValue &value);
+   ConsoleValue* reserveValues(U32 numValues);
+   bool reserveValues(U32 numValues, ConsoleValueRef *values);
    ConsoleValue* pop();
 
    ConsoleValue *pushString(const char *value);
@@ -337,5 +341,8 @@ public:
 
    ConsoleValueRef mArgv[MaxArgs];
 };
+
+extern StringStack STR;
+extern ConsoleValueStack CSTK;
 
 #endif

--- a/Engine/source/console/stringStack.h
+++ b/Engine/source/console/stringStack.h
@@ -35,8 +35,21 @@
 #include "console/console.h"
 #endif
 
+typedef U32 StringStackPtr;
+struct StringStack;
 
+/// Helper class which stores a relative pointer in the StringStack buffer
+class StringStackPtrRef
+{
+public:
+   StringStackPtrRef() : mOffset(0) {;}
+   StringStackPtrRef(StringStackPtr offset) : mOffset(offset) {;}
 
+   StringStackPtr mOffset;
+
+   /// Get pointer to string in stack stk
+   inline char *getPtr(StringStack *stk);
+};
 
 /// Core stack for interpreter operations.
 ///
@@ -199,6 +212,16 @@ struct StringStack
       return mBuffer + mStartOffsets[mStartStackSize-1];
    }
 
+   inline StringStackPtr getStringValuePtr()
+   {
+      return (getStringValue() - mBuffer);
+   }
+
+   inline StringStackPtr getPreviousStringValuePtr()
+   {
+      return (getPreviousStringValue() - mBuffer);
+   }
+
    /// Advance the start stack, placing a zero length string on the top.
    ///
    /// @note You should use StringStack::push, not this, if you want to
@@ -322,6 +345,7 @@ public:
 
    ConsoleValue *pushString(const char *value);
    ConsoleValue *pushStackString(const char *value);
+   ConsoleValue *pushStringStackPtr(StringStackPtr ptr);
    ConsoleValue *pushUINT(U32 value);
    ConsoleValue *pushFLT(float value);
 
@@ -344,5 +368,7 @@ public:
 
 extern StringStack STR;
 extern ConsoleValueStack CSTK;
+
+inline char* StringStackPtrRef::getPtr(StringStack *stk) { return stk->mBuffer + mOffset; }
 
 #endif

--- a/Engine/source/console/telnetConsole.cpp
+++ b/Engine/source/console/telnetConsole.cpp
@@ -21,9 +21,11 @@
 //-----------------------------------------------------------------------------
 
 #include "platform/platform.h"
+
+#include "console/simBase.h"
+#include "console/engineAPI.h"
 #include "console/telnetConsole.h"
 
-#include "console/engineAPI.h"
 #include "core/strings/stringFunctions.h"
 #include "core/util/journal/process.h"
 #include "core/module.h"

--- a/Engine/source/console/test/consoleTest.cpp
+++ b/Engine/source/console/test/consoleTest.cpp
@@ -1,0 +1,287 @@
+#ifdef TORQUE_TESTS_ENABLED
+#include "testing/unitTesting.h"
+#include "platform/platform.h"
+#include "console/simBase.h"
+#include "console/consoleTypes.h"
+#include "console/simBase.h"
+#include "console/engineAPI.h"
+#include "math/mMath.h"
+#include "console/stringStack.h"
+
+TEST(Con, executef)
+{
+	char buffer[128];
+	Con::evaluate("if (isObject(TestConExec)) {\r\nTestConExec.delete();\r\n}\r\nfunction testExecutef(%a,%b,%c,%d,%e,%f,%g,%h,%i,%j,%k){return %a SPC %b SPC %c SPC %d SPC %e SPC %f SPC %g SPC %h SPC %i SPC %j SPC %k;}\r\nfunction TestConExec::testThisFunction(%this,%a,%b,%c,%d,%e,%f,%g,%h,%i,%j){ return %a SPC %b SPC %c SPC %d SPC %e SPC %f SPC %g SPC %h SPC %i SPC %j;}\r\nnew ScriptObject(TestConExec);\r\n", false, "test");
+	
+	SimObject *testObject = NULL;
+	Sim::findObject("TestConExec", testObject);
+
+	EXPECT_TRUE(testObject != NULL)
+		<< "TestConExec object should exist";
+
+	// Check basic calls with SimObject. We'll do this for every single possible call just to make sure.
+	const char *returnValue = NULL;
+	
+	returnValue = Con::executef(testObject, "testThisFunction");
+	EXPECT_TRUE(dStricmp(returnValue, "         ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef(testObject, "testThisFunction", "a");
+	EXPECT_TRUE(dStricmp(returnValue, "a         ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef(testObject, "testThisFunction", "a", "b");
+	EXPECT_TRUE(dStricmp(returnValue, "a b        ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef(testObject, "testThisFunction", "a", "b", "c");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c       ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef(testObject, "testThisFunction", "a", "b", "c", "d");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d      ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef(testObject, "testThisFunction", "a", "b", "c", "d", "e");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e     ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef(testObject, "testThisFunction", "a", "b", "c", "d", "e", "f");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e f    ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef(testObject, "testThisFunction", "a", "b", "c", "d", "e", "f", "g");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e f g   ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef(testObject, "testThisFunction", "a", "b", "c", "d", "e", "f", "g", "h");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e f g h  ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef(testObject, "testThisFunction", "a", "b", "c", "d", "e", "f", "g", "h", "i");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e f g h i ") == 0) <<
+		"All values should be printed in the correct order";
+
+	// Now test without the object
+	
+	returnValue = Con::executef("testExecutef");
+	EXPECT_TRUE(dStricmp(returnValue, "          ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef("testExecutef", "a");
+	EXPECT_TRUE(dStricmp(returnValue, "a          ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef("testExecutef", "a", "b");
+	EXPECT_TRUE(dStricmp(returnValue, "a b         ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef("testExecutef", "a", "b", "c");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c        ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef("testExecutef", "a", "b", "c", "d");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d       ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef("testExecutef", "a", "b", "c", "d", "e");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e      ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef("testExecutef", "a", "b", "c", "d", "e", "f");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e f     ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef("testExecutef", "a", "b", "c", "d", "e", "f", "g");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e f g    ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef("testExecutef", "a", "b", "c", "d", "e", "f", "g", "h");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e f g h   ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef("testExecutef", "a", "b", "c", "d", "e", "f", "g", "h", "i");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e f g h i  ") == 0) <<
+		"All values should be printed in the correct order";
+	
+	returnValue = Con::executef("testExecutef", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
+	EXPECT_TRUE(dStricmp(returnValue, "a b c d e f g h i j ") == 0) <<
+		"All values should be printed in the correct order";
+
+	// Test type conversions with and without SimObject...
+
+	// Integer
+	returnValue = Con::executef(testObject, "testThisFunction", 123);
+	EXPECT_TRUE(dStricmp(returnValue, "123         ") == 0) <<
+		"Integer should be converted";
+	returnValue = Con::executef("testExecutef", 123);
+	EXPECT_TRUE(dStricmp(returnValue, "123          ") == 0) <<
+		"Integer should be converted";
+
+	// Float
+	returnValue = Con::executef(testObject, "testThisFunction", (F32)123.4);
+	EXPECT_TRUE(dStricmp(returnValue, "123.4         ") == 0) <<
+		"Float should be converted";
+	returnValue = Con::executef("testExecutef", (F32)123.4);
+	EXPECT_TRUE(dStricmp(returnValue, "123.4          ") == 0) <<
+		"Float should be converted";
+
+	// SimObject
+	dSprintf(buffer, sizeof(buffer), "%i         ", testObject->getId());
+	returnValue = Con::executef(testObject, "testThisFunction", testObject);
+	EXPECT_TRUE(dStricmp(returnValue, buffer) == 0) <<
+		"SimObject should be converted";
+	dSprintf(buffer, sizeof(buffer), "%i          ", testObject->getId());
+	returnValue = Con::executef("testExecutef", testObject);
+	EXPECT_TRUE(dStricmp(returnValue, buffer) == 0) <<
+		"SimObject should be converted";
+
+	// Point3F
+	Point3F point(1,2,3);
+	returnValue = Con::executef(testObject, "testThisFunction", point);
+	EXPECT_TRUE(dStricmp(returnValue, "1 2 3         ") == 0) <<
+		"Point3F should be converted";
+	returnValue = Con::executef("testExecutef", point);
+	EXPECT_TRUE(dStricmp(returnValue, "1 2 3          ") == 0) <<
+		"Point3F should be converted";
+
+   // Finally test the function arg offset. This should be consistently 0 after each call
+   
+	EXPECT_TRUE(STR.mFunctionOffset == 0) <<
+		"Function offset should be 0";
+
+   const char *floatArg = Con::getFloatArg(1.23);
+	EXPECT_TRUE(STR.mFunctionOffset > 0) <<
+		"Function offset should not be 0";
+
+   Con::executef("testExecutef", floatArg);
+   
+	EXPECT_TRUE(STR.mFunctionOffset == 0) <<
+		"Function offset should be 0";
+
+   floatArg = Con::getFloatArg(1.23);
+	EXPECT_TRUE(STR.mFunctionOffset > 0) <<
+		"Function offset should not be 0";
+
+   Con::executef("testImaginaryFunction_", floatArg);
+   
+	EXPECT_TRUE(STR.mFunctionOffset == 0) <<
+		"Function offset should be 0";
+}
+
+TEST(Con, execute)
+{
+	Con::evaluate("if (isObject(TestConExec)) {\r\nTestConExec.delete();\r\n}\r\nfunction testScriptExecuteFunction(%a,%b) {return %a SPC %b;}\nfunction TestConExec::testScriptExecuteFunction(%this, %a,%b) {return %a SPC %b;}new ScriptObject(TestConExec);\r\n", false, "testExecute");
+	
+	U32 startStackPos = CSTK.mStackPos;
+	U32 startStringStackPos = STR.mStart;
+	U32 startStackFrame = CSTK.mFrame;
+	
+	SimObject *testObject = NULL;
+	Sim::findObject("TestConExec", testObject);
+
+	EXPECT_TRUE(testObject != NULL)
+		<< "TestConExec object should exist";
+
+	// const char* versions of execute should maintain stack
+	const char *argv[] = {"testScriptExecuteFunction", "1", "2"};
+	const char *argvObject[] = {"testScriptExecuteFunction", "", "1", "2"};
+	const char *returnValue = Con::execute(3, argv);
+
+	EXPECT_TRUE(dStricmp(returnValue, "1 2") == 0) <<
+		"execute should return 1 2";
+	
+	EXPECT_TRUE(CSTK.mStackPos == startStackPos) <<
+		"execute should restore stack";
+
+	returnValue = Con::execute(testObject, 4, argvObject);
+
+	EXPECT_TRUE(dStricmp(returnValue, "1 2") == 0) <<
+		"execute should return 1 2";
+	
+	EXPECT_TRUE(CSTK.mStackPos == startStackPos) <<
+		"execute should restore stack";
+
+	// ConsoleValueRef versions of execute should not restore stack
+	CSTK.pushFrame();
+	STR.pushFrame();
+
+	ConsoleValue valueArg[4];
+	ConsoleValueRef refArg[4];
+	ConsoleValue valueArgObject[4];
+	ConsoleValueRef refArgObject[4];
+	for (U32 i=0; i<4; i++)
+	{
+		refArg[i].value = &valueArg[i];
+		refArgObject[i].value = &valueArgObject[i];
+		valueArgObject[i].init();
+		valueArg[i].init();
+	}
+
+	refArg[0] = "testScriptExecuteFunction";
+	refArg[1] = "1";
+	refArg[2] = "2";
+
+	refArgObject[0] = "testScriptExecuteFunction";
+	refArgObject[2] = "1";
+	refArgObject[3] = "2";
+
+	returnValue = Con::execute(3, refArg);
+
+	EXPECT_TRUE(dStricmp(returnValue, "1 2") == 0) <<
+		"execute should return 1 2";
+	
+	EXPECT_TRUE(CSTK.mStackPos == startStackPos) <<
+		"execute should restore stack";
+
+	CSTK.popFrame();
+	STR.popFrame();
+
+	CSTK.pushFrame();
+	STR.pushFrame();
+
+	returnValue = Con::execute(testObject, 4, refArgObject);
+
+	EXPECT_TRUE(dStricmp(returnValue, "1 2") == 0) <<
+		"execute should return 1 2";
+	
+	EXPECT_TRUE(CSTK.mStackPos == startStackPos) <<
+		"execute should restore stack";
+
+	CSTK.popFrame();
+	STR.popFrame();
+}
+
+static U32 gConsoleStackFrame = 0;
+
+ConsoleFunction(testConsoleStackFrame, S32, 1, 1, "")
+{
+	gConsoleStackFrame = CSTK.mFrame;
+	return (U32)Con::executef("testScriptEvalFunction"); // execute a sub function which manipulates the stack
+}
+
+TEST(Con, evaluate)
+{
+	U32 startStackPos = CSTK.mStackPos;
+	U32 startStringStackPos = STR.mStart;
+	S32 returnValue = Con::evaluate("function testScriptEvalFunction() {return \"1\"@\"2\"@\"3\";}\nreturn testConsoleStackFrame();", false, "testEvaluate");
+	U32 frame = CSTK.mFrame;
+
+	EXPECT_TRUE(returnValue == 123) <<
+		"Evaluate should return 123";
+
+	EXPECT_TRUE(gConsoleStackFrame == (frame+2)) <<
+		"Console stack frame inside function should be +2";
+
+	EXPECT_TRUE(CSTK.mFrame == frame) <<
+		"Console stack frame outside function should be the same as before";
+
+	EXPECT_TRUE(STR.mStart == startStringStackPos) <<
+		"Console string stack should not be changed";
+
+	EXPECT_TRUE(CSTK.mStackPos == startStackPos) <<
+		"Console stack should not be changed";
+
+}
+
+#endif

--- a/Engine/source/console/test/engineAPITest.cpp
+++ b/Engine/source/console/test/engineAPITest.cpp
@@ -1,0 +1,150 @@
+#ifdef TORQUE_TESTS_ENABLED
+#include "testing/unitTesting.h"
+#include "platform/platform.h"
+#include "console/simBase.h"
+#include "console/consoleTypes.h"
+#include "console/simBase.h"
+#include "console/engineAPI.h"
+#include "math/mMath.h"
+
+
+TEST(EngineAPI, EngineMarshallData)
+{
+	// Reserve some values
+	ConsoleValue values[16];
+	ConsoleValueRef refValues[16];
+
+	for (U32 i=0; i<16; i++)
+	{
+		values[i].init();
+		refValues[i].value = &values[i];
+	}
+
+	// Basic string casting...
+	SimObject *foo = new SimObject();
+	foo->registerObject();
+
+	const char *value = EngineMarshallData(foo);
+	EXPECT_TRUE(dStricmp(value, foo->getIdString()) == 0) 
+		<< "SimObject should be casted to its ID";
+
+	U32 unsignedNumber = 123;
+	S32 signedNumber = -123;
+	value = EngineMarshallData(unsignedNumber);
+	EXPECT_TRUE(dStricmp(value, "123") == 0) 
+		<< "Integer should be converted to 123";
+	value = EngineMarshallData(signedNumber);
+	EXPECT_TRUE(dStricmp(value, "-123") == 0) 
+		<< "Integer should be converted to -123";
+
+	bool boolValue = true;
+	value = EngineMarshallData(boolValue);
+	EXPECT_TRUE(dStricmp(value, "1") == 0) 
+		<< "Bool should be converted to 1";
+
+	Point3F point(1,2,3);
+	value = EngineMarshallData(point);
+	EXPECT_TRUE(dStricmp(value, "1 2 3") == 0) 
+		<< "Point3F should be converted to 1 2 3";
+
+	F32 floatValue = 1.23f;
+	value = EngineMarshallData(floatValue);
+	EXPECT_TRUE(dStricmp(value, "1.23") == 0) 
+		<< "F32 should be converted to 1.23";
+
+	// Argv based casting
+	S32 argc = 0;
+	EngineMarshallData(foo, argc, refValues);
+	EngineMarshallData((const SimObject*)foo, argc, refValues);
+	EngineMarshallData(point, argc, refValues);
+	EngineMarshallData(unsignedNumber, argc, refValues);
+	EngineMarshallData(signedNumber, argc, refValues);
+	EngineMarshallData(boolValue, argc, refValues);
+	EngineMarshallData(floatValue, argc, refValues);
+
+	EXPECT_TRUE(argc == 7) 
+		<< "7 args should have been set";
+
+	EXPECT_TRUE(values[0].type == ConsoleValue::TypeInternalInt && values[0].getSignedIntValue() == foo->getId())
+		<< "1st arg should be foo's id";
+
+	EXPECT_TRUE(values[1].type == ConsoleValue::TypeInternalInt && values[1].getSignedIntValue() == foo->getId())
+		<< "2nd arg should be foo's id";
+
+	EXPECT_TRUE(values[2].type == ConsoleValue::TypeInternalString && dStricmp(values[2].getStringValue(), "1 2 3") == 0)
+		<< "3rd arg should be 1 2 3";
+
+	EXPECT_TRUE(values[3].type == ConsoleValue::TypeInternalFloat && values[3].getSignedIntValue() == 123)
+		<< "4th arg should be 123";
+
+	EXPECT_TRUE(values[4].type == ConsoleValue::TypeInternalFloat && values[4].getSignedIntValue() == -123)
+		<< "5th arg should be -123";
+
+	EXPECT_TRUE(values[5].type == ConsoleValue::TypeInternalFloat && values[5].getBoolValue() == true)
+		<< "6th arg should be -123";
+
+	EXPECT_TRUE(values[6].type == ConsoleValue::TypeInternalFloat && mRound(values[6].getFloatValue() * 100) == 123)
+		<< "7th arg should be 1.23";
+
+	foo->deleteObject();
+}
+
+TEST(EngineAPI, EngineUnMarshallData)
+{
+	SimObject *foo = new SimObject();
+	foo->registerObject();
+
+	SimObject *testFoo = EngineUnmarshallData<SimObject*>()(foo->getIdString());
+
+	EXPECT_TRUE(foo == testFoo)
+		<< "Unmarshalling foo's id should return foo";
+
+	testFoo = EngineUnmarshallData<SimObject*>()("ShouldNotExist_Really123");
+	EXPECT_TRUE(testFoo == NULL)
+		<< "Unmarshalling a bad object should return NULL";
+
+	foo->deleteObject();
+}
+
+TEST(EngineAPI, _EngineConsoleCallbackHelper)
+{
+	Con::evaluate("if (isObject(TestConExec)) {\r\nTestConExec.delete();\r\n}\r\nfunction testExecutef(%a,%b,%c,%d,%e,%f,%g,%h,%i,%j,%k){return %a SPC %b SPC %c SPC %d SPC %e SPC %f SPC %g SPC %h SPC %i SPC %j SPC %k;}\r\nfunction TestConExec::testThisFunction(%this,%a,%b,%c,%d,%e,%f,%g,%h,%i,%j){ return %a SPC %b SPC %c SPC %d SPC %e SPC %f SPC %g SPC %h SPC %i SPC %j;}\r\nnew ScriptObject(TestConExec);\r\n", false, "test");
+	
+	SimObject *testObject = NULL;
+	Sim::findObject("TestConExec", testObject);
+
+   _EngineConsoleCallbackHelper helper("testExecutef", NULL);
+   const char *returnValue = helper.call<const char*>("a", "b", "c");
+
+	EXPECT_TRUE(dStricmp(returnValue, "a b c        ") == 0) <<
+		"All values should be printed in the correct order";
+   
+   _EngineConsoleCallbackHelper objectHelper("testThisFunction", testObject);
+   returnValue = helper.call<const char*>("a", "b", "c");
+
+	EXPECT_TRUE(dStricmp(returnValue, "a b c        ") == 0) <<
+		"All values should be printed in the correct order";
+}
+
+// NOTE: this is also indirectly tested by the executef tests
+TEST(EngineAPI, _EngineConsoleExecCallbackHelper)
+{
+	Con::evaluate("if (isObject(TestConExec)) {\r\nTestConExec.delete();\r\n}\r\nfunction testExecutef(%a,%b,%c,%d,%e,%f,%g,%h,%i,%j,%k){return %a SPC %b SPC %c SPC %d SPC %e SPC %f SPC %g SPC %h SPC %i SPC %j SPC %k;}\r\nfunction TestConExec::testThisFunction(%this,%a,%b,%c,%d,%e,%f,%g,%h,%i,%j){ return %a SPC %b SPC %c SPC %d SPC %e SPC %f SPC %g SPC %h SPC %i SPC %j;}\r\nnew ScriptObject(TestConExec);\r\n", false, "test");
+	
+	SimObject *testObject = NULL;
+	Sim::findObject("TestConExec", testObject);
+
+   _EngineConsoleExecCallbackHelper<const char*> helper("testExecutef");
+   const char *returnValue = helper.call<const char*>("a", "b", "c");
+
+	EXPECT_TRUE(dStricmp(returnValue, "a b c        ") == 0) <<
+		"All values should be printed in the correct order";
+   
+   _EngineConsoleExecCallbackHelper<SimObject*> objectHelper(testObject);
+   returnValue = objectHelper.call<const char*>("testThisFunction", "a", "b", "c");
+
+	EXPECT_TRUE(dStricmp(returnValue, "a b c       ") == 0) <<
+		"All values should be printed in the correct order";
+}
+
+#endif

--- a/Engine/source/forest/editor/forestSelectionTool.cpp
+++ b/Engine/source/forest/editor/forestSelectionTool.cpp
@@ -517,7 +517,7 @@ bool ForestSelectionTool::updateGuiInfo()
 
    Con::executef( statusbar, "setInfo", text.c_str() );
 
-   Con::executef( statusbar, "setSelectionObjectsByCount", Con::getIntArg( mSelection.size() ) );
+   Con::executef( statusbar, "setSelectionObjectsByCount", mSelection.size() );
 
    return true;
 }

--- a/Engine/source/gui/controls/guiConsoleTextCtrl.cpp
+++ b/Engine/source/gui/controls/guiConsoleTextCtrl.cpp
@@ -113,7 +113,7 @@ void GuiConsoleTextCtrl::onPreRender()
 {   
    if ( mConsoleExpression.isNotEmpty() )
    {
-      mResult = Con::evaluatef( "$guiConsoleTextCtrlTemp = %s;", mConsoleExpression.c_str() );
+      mResult = (const char*)Con::evaluatef( "$guiConsoleTextCtrlTemp = %s;", mConsoleExpression.c_str() );
       
       // Of the resulting string we will be printing,
       // Find the number of lines and length of each.      

--- a/Engine/source/gui/controls/guiListBoxCtrl.cpp
+++ b/Engine/source/gui/controls/guiListBoxCtrl.cpp
@@ -71,7 +71,7 @@ IMPLEMENT_CALLBACK( GuiListBoxCtrl, onClearSelection, void, (),(),
    "@see GuiControl\n\n"
 );
 
-IMPLEMENT_CALLBACK( GuiListBoxCtrl, onUnSelect, void, ( const char* index, const char* itemText),( index, itemText ),
+IMPLEMENT_CALLBACK( GuiListBoxCtrl, onUnSelect, void, ( S32 index, const char* itemText),( index, itemText ),
    "@brief Called whenever a selected item in the list has been unselected.\n\n"
    "@param index Index id of the item that was unselected\n"
    "@param itemText Text for the list entry at the index id that was unselected\n\n"
@@ -85,7 +85,7 @@ IMPLEMENT_CALLBACK( GuiListBoxCtrl, onUnSelect, void, ( const char* index, const
    "@see GuiControl\n\n"
 );
 
-IMPLEMENT_CALLBACK( GuiListBoxCtrl, onSelect, void, ( const char* index , const char* itemText ),( index, itemText ),
+IMPLEMENT_CALLBACK( GuiListBoxCtrl, onSelect, void, ( S32 index , const char* itemText ),( index, itemText ),
    "@brief Called whenever an item in the list is selected.\n\n"
    "@param index Index id for the item in the list that was selected.\n"
    "@param itemText Text for the list item at the index that was selected.\n\n"
@@ -111,7 +111,7 @@ IMPLEMENT_CALLBACK( GuiListBoxCtrl, onDoubleClick, void, (),(),
    "@see GuiControl\n\n"
 );
 
-IMPLEMENT_CALLBACK( GuiListBoxCtrl, onMouseUp, void, (const char* itemHit, const char* mouseClickCount),( itemHit,mouseClickCount),
+IMPLEMENT_CALLBACK( GuiListBoxCtrl, onMouseUp, void, ( S32 itemHit, S32 mouseClickCount ),( itemHit,mouseClickCount ),
    "@brief Called whenever the mouse has previously been clicked down (onMouseDown) and has now been raised on the control.\n"
    "If an item in the list was hit during the click cycle, then the index id of the clicked object along with how many clicks occured are passed\n"
    "into the callback.\n\n"
@@ -309,7 +309,7 @@ void GuiListBoxCtrl::removeSelection( LBItem *item, S32 index )
       {
          mSelectedItems.erase( &mSelectedItems[i] );
          item->isSelected = false;
-         onUnSelect_callback(Con::getIntArg(index), item->itemText);
+         onUnSelect_callback(index, item->itemText);
          return;
       }
    }
@@ -355,7 +355,7 @@ void GuiListBoxCtrl::addSelection( LBItem *item, S32 index )
    item->isSelected = true;
    mSelectedItems.push_front( item );
 
-   onSelect_callback(Con::getIntArg( index ), item->itemText);
+   onSelect_callback(index, item->itemText);
 }
 
 S32 GuiListBoxCtrl::getItemIndex( LBItem *item )
@@ -1224,7 +1224,7 @@ void GuiListBoxCtrl::onMouseUp( const GuiEvent& event )
 {
    S32 itemHit = -1;
    if( hitTest( event.mousePoint, itemHit ) )
-      onMouseUp_callback(Con::getIntArg( itemHit ), Con::getIntArg( event.mouseClickCount ) );
+      onMouseUp_callback( itemHit, event.mouseClickCount );
 
    // Execute console command
    execConsoleCallback();

--- a/Engine/source/gui/controls/guiListBoxCtrl.h
+++ b/Engine/source/gui/controls/guiListBoxCtrl.h
@@ -57,10 +57,10 @@ public:
 
    DECLARE_CALLBACK( void, onMouseDragged, ());
    DECLARE_CALLBACK( void, onClearSelection, ());
-   DECLARE_CALLBACK( void, onUnSelect, ( const char* index, const char* itemText));
-   DECLARE_CALLBACK( void, onSelect, ( const char* index , const char* itemText ));
+   DECLARE_CALLBACK( void, onUnSelect, ( S32 index, const char* itemText));
+   DECLARE_CALLBACK( void, onSelect, ( S32 index , const char* itemText ));
    DECLARE_CALLBACK( void, onDoubleClick, ());
-   DECLARE_CALLBACK( void, onMouseUp, (const char* itemHit, const char* mouseClickCount));
+   DECLARE_CALLBACK( void, onMouseUp, ( S32 itemHit, S32 mouseClickCount ));
    DECLARE_CALLBACK( void, onDeleteKey, ());
    DECLARE_CALLBACK( bool, isObjectMirrored, ( const char* indexIdString ));
 

--- a/Engine/source/gui/controls/guiMLTextCtrl.cpp
+++ b/Engine/source/gui/controls/guiMLTextCtrl.cpp
@@ -73,7 +73,7 @@ IMPLEMENT_CALLBACK( GuiMLTextCtrl, onURL, void, ( const char* url ),( url ),
    "@see GuiControl\n\n"
 );
 
-IMPLEMENT_CALLBACK( GuiMLTextCtrl, onResize, void, ( const char* width, const char* maxY ),( width, maxY ),
+IMPLEMENT_CALLBACK( GuiMLTextCtrl, onResize, void, ( S32 width, S32 maxY ),( width, maxY ),
    "@brief Called whenever the control size changes.\n\n"
    "@param width The new width value for the control\n"
    "@param maxY The current maximum allowed Y value for the control\n\n"
@@ -2133,7 +2133,7 @@ textemit:
    processEmitAtoms();
    emitNewLine(mScanPos);
    setHeight( mMaxY );
-   onResize_callback(Con::getIntArg( getWidth() ), Con::getIntArg( mMaxY ) );
+   onResize_callback( getWidth(), mMaxY );
 	
    //make sure the cursor is still visible - this handles if we're a child of a scroll ctrl...
    ensureCursorOnScreen();

--- a/Engine/source/gui/controls/guiMLTextCtrl.h
+++ b/Engine/source/gui/controls/guiMLTextCtrl.h
@@ -128,7 +128,7 @@ class GuiMLTextCtrl : public GuiControl
    ~GuiMLTextCtrl();
 
    DECLARE_CALLBACK( void, onURL, (const char* url));
-   DECLARE_CALLBACK( void, onResize, ( const char* width, const char* maxY ));
+   DECLARE_CALLBACK( void, onResize, ( S32 width, S32 maxY ));
 
    // Text retrieval functions
    U32 getNumChars() const;

--- a/Engine/source/gui/controls/guiTextListCtrl.cpp
+++ b/Engine/source/gui/controls/guiTextListCtrl.cpp
@@ -52,7 +52,7 @@ ConsoleDocClass( GuiTextListCtrl,
 );
 
 
-IMPLEMENT_CALLBACK( GuiTextListCtrl, onSelect, void, (const char* cellid, const char* text),( cellid , text ),
+IMPLEMENT_CALLBACK( GuiTextListCtrl, onSelect, void, (S32 cellid, const char* text),( cellid , text ),
    "@brief Called whenever an item in the list is selected.\n\n"
    "@param cellid The ID of the cell that was selected\n"
    "@param text The text in the selected cel\n\n"
@@ -66,7 +66,7 @@ IMPLEMENT_CALLBACK( GuiTextListCtrl, onSelect, void, (const char* cellid, const 
    "@see GuiControl\n\n"
 );
 
-IMPLEMENT_CALLBACK( GuiTextListCtrl, onDeleteKey, void, ( const char* id ),( id ),
+IMPLEMENT_CALLBACK( GuiTextListCtrl, onDeleteKey, void, ( S32 id ),( id ),
    "@brief Called when the delete key has been pressed.\n\n"
    "@param id Id of the selected item in the list\n"
    "@tsexample\n"
@@ -172,7 +172,7 @@ bool GuiTextListCtrl::cellSelected(Point2I cell)
 
 void GuiTextListCtrl::onCellSelected(Point2I cell)
 {
-   onSelect_callback(Con::getIntArg(mList[cell.y].id), mList[cell.y].text);
+   onSelect_callback(mList[cell.y].id, mList[cell.y].text);
    execConsoleCallback();
 }
 
@@ -497,7 +497,7 @@ bool GuiTextListCtrl::onKeyDown( const GuiEvent &event )
       break;
    case KEY_DELETE:
       if ( mSelectedCell.y >= 0 && mSelectedCell.y < mList.size() )
-      onDeleteKey_callback(Con::getIntArg( mList[mSelectedCell.y].id ) );
+      onDeleteKey_callback( mList[mSelectedCell.y].id );
       break;
    default:
    return( Parent::onKeyDown( event ) );

--- a/Engine/source/gui/controls/guiTextListCtrl.h
+++ b/Engine/source/gui/controls/guiTextListCtrl.h
@@ -67,8 +67,8 @@ class GuiTextListCtrl : public GuiArrayCtrl
    DECLARE_CATEGORY( "Gui Lists" );
    DECLARE_DESCRIPTION( "A control that displays text in tabular form." );
    
-   DECLARE_CALLBACK( void, onSelect, (const char* cellid, const char* text));
-   DECLARE_CALLBACK( void, onDeleteKey, ( const char* id ));
+   DECLARE_CALLBACK( void, onSelect, (S32 cellid, const char* text));
+   DECLARE_CALLBACK( void, onDeleteKey, ( S32 id ));
 
    static void initPersistFields();
 

--- a/Engine/source/gui/editor/guiMenuBar.cpp
+++ b/Engine/source/gui/editor/guiMenuBar.cpp
@@ -111,7 +111,7 @@ IMPLEMENT_CALLBACK( GuiMenuBar, onMouseInMenu, void, (bool isInMenu),( isInMenu 
    "@see GuiTickCtrl\n\n"
 );
 
-IMPLEMENT_CALLBACK( GuiMenuBar, onMenuSelect, void, ( const char* menuId, const char* menuText ),( menuId , menuText ),
+IMPLEMENT_CALLBACK( GuiMenuBar, onMenuSelect, void, ( S32 menuId, const char* menuText ),( menuId , menuText ),
    "@brief Called whenever a menu is selected.\n\n"
    "@param menuId Index id of the clicked menu\n"
    "@param menuText Text of the clicked menu\n\n"
@@ -125,7 +125,7 @@ IMPLEMENT_CALLBACK( GuiMenuBar, onMenuSelect, void, ( const char* menuId, const 
    "@see GuiTickCtrl\n\n"
 );
 
-IMPLEMENT_CALLBACK( GuiMenuBar, onMenuItemSelect, void, ( const char* menuId, const char* menuText, const char* menuItemId, const char* menuItemText ),
+IMPLEMENT_CALLBACK( GuiMenuBar, onMenuItemSelect, void, ( S32 menuId, const char* menuText, S32 menuItemId, const char* menuItemText ),
 												   ( menuId, menuText, menuItemId, menuItemText ),
    "@brief Called whenever an item in a menu is selected.\n\n"
    "@param menuId Index id of the menu which contains the selected menu item\n"
@@ -142,7 +142,7 @@ IMPLEMENT_CALLBACK( GuiMenuBar, onMenuItemSelect, void, ( const char* menuId, co
    "@see GuiTickCtrl\n\n"
 );
 
-IMPLEMENT_CALLBACK( GuiMenuBar, onSubmenuSelect, void, ( const char* submenuId, const char* submenuText ),( submenuId, submenuText ),
+IMPLEMENT_CALLBACK( GuiMenuBar, onSubmenuSelect, void, ( S32 submenuId, const char* submenuText ),( submenuId, submenuText ),
    "@brief Called whenever a submenu is selected.\n\n"
    "@param submenuId Id of the selected submenu\n"
    "@param submenuText Text of the selected submenu\n\n"
@@ -1393,7 +1393,7 @@ void GuiMenuBar::acceleratorKeyPress(U32 index)
          if(item->acceleratorIndex == index)
          {
             // first, call the script callback for menu selection:
-            onMenuSelect_callback(Con::getIntArg(menu->id), menu->text);
+            onMenuSelect_callback(menu->id, menu->text);
 			
             if(item->visible)
                menuItemSelected(menu, item);
@@ -1575,7 +1575,7 @@ bool GuiSubmenuBackgroundCtrl::pointInControl(const Point2I& parentCoordPoint)
 void GuiMenuBar::menuItemSelected(GuiMenuBar::Menu *menu, GuiMenuBar::MenuItem *item)
 {
    if(item->enabled)
-      onMenuItemSelect_callback(Con::getIntArg(menu->id), menu->text, Con::getIntArg(item->id), item->text);
+      onMenuItemSelect_callback(menu->id, menu->text, item->id, item->text);
 }
 
 void GuiMenuBar::onSleep()
@@ -1668,7 +1668,7 @@ void GuiMenuBar::onAction()
       return;
 
    // first, call the script callback for menu selection:
-   onMenuSelect_callback(Con::getIntArg(mouseDownMenu->id), mouseDownMenu->text);
+   onMenuSelect_callback(mouseDownMenu->id, mouseDownMenu->text);
 
    MenuItem *visWalk = mouseDownMenu->firstMenuItem;
    while(visWalk)
@@ -1783,7 +1783,7 @@ void GuiMenuBar::onSubmenuAction(S32 selectionIndex, RectI bounds, Point2I cellS
       return;
 
    // first, call the script callback for menu selection:
-   onSubmenuSelect_callback(Con::getIntArg(mouseOverSubmenu->id), mouseOverSubmenu->text);
+   onSubmenuSelect_callback(mouseOverSubmenu->id, mouseOverSubmenu->text);
 
    MenuItem *visWalk = mouseOverSubmenu->submenu->firstMenuItem;
    while(visWalk)

--- a/Engine/source/gui/editor/guiMenuBar.h
+++ b/Engine/source/gui/editor/guiMenuBar.h
@@ -220,10 +220,10 @@ public:
    static void initPersistFields();
 
    DECLARE_CONOBJECT(GuiMenuBar);
-   DECLARE_CALLBACK( void, onMouseInMenu, (bool hasLeftMenu));
-   DECLARE_CALLBACK( void, onMenuSelect, (const char* menuId, const char* menuText));
-   DECLARE_CALLBACK( void, onMenuItemSelect, ( const char* menuId, const char* menuText, const char* menuItemId, const char* menuItemText  ));
-   DECLARE_CALLBACK( void, onSubmenuSelect, ( const char* submenuId, const char* submenuText));
+   DECLARE_CALLBACK( void, onMouseInMenu, ( bool hasLeftMenu ));
+   DECLARE_CALLBACK( void, onMenuSelect, ( S32 menuId, const char* menuText ));
+   DECLARE_CALLBACK( void, onMenuItemSelect, ( S32 menuId, const char* menuText, S32 menuItemId, const char* menuItemText  ));
+   DECLARE_CALLBACK( void, onSubmenuSelect, ( S32 submenuId, const char* submenuText ));
 };
 
 #endif

--- a/Engine/source/gui/editor/inspector/customField.cpp
+++ b/Engine/source/gui/editor/inspector/customField.cpp
@@ -20,6 +20,8 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
+#include "console/simBase.h"
+#include "console/engineAPI.h"
 #include "gui/editor/inspector/customField.h"
 #include "gui/editor/guiInspector.h"
 

--- a/Engine/source/gui/editor/inspector/field.cpp
+++ b/Engine/source/gui/editor/inspector/field.cpp
@@ -269,7 +269,7 @@ void GuiInspectorField::setData( const char* data, bool callbacks )
          {
             char buffer[ 2048 ];
             expandEscape( buffer, newValue );
-            newValue = Con::evaluatef( "%%f = \"%s\"; return ( %s );", oldValue.c_str(), buffer );
+            newValue = (const char*)Con::evaluatef( "%%f = \"%s\"; return ( %s );", oldValue.c_str(), buffer );
          }
          else if(    type == TypeS32Vector
                   || type == TypeF32Vector

--- a/Engine/source/lighting/common/sceneLighting.cpp
+++ b/Engine/source/lighting/common/sceneLighting.cpp
@@ -24,6 +24,7 @@
 #include "lighting/common/sceneLighting.h"
 
 #include "T3D/gameBase/gameConnection.h"
+#include "console/engineAPI.h"
 #include "console/consoleTypes.h"
 #include "scene/sceneManager.h"
 #include "lighting/common/shadowVolumeBSP.h"
@@ -605,7 +606,7 @@ void SceneLighting::completed(bool success)
    }
 
    if(gCompleteCallback && gCompleteCallback[0])
-      Con::executef(gCompleteCallback);
+      Con::executef((const char*)gCompleteCallback);
 
    dFree(gCompleteCallback);
    gCompleteCallback = NULL;

--- a/Engine/source/platform/platformRedBook.cpp
+++ b/Engine/source/platform/platformRedBook.cpp
@@ -22,6 +22,7 @@
 
 #include "core/strings/stringFunctions.h"
 #include "console/console.h"
+#include "console/simBase.h"
 #include "console/engineAPI.h"
 #include "platform/platformRedBook.h"
 

--- a/Engine/source/platformSDL/menus/popupMenuSDL.cpp
+++ b/Engine/source/platformSDL/menus/popupMenuSDL.cpp
@@ -35,6 +35,7 @@
 #include "gui/editor/guiMenuBar.h"
 
 #include "platformSDL/menus/PlatformSDLPopupMenuData.h"
+#include "console/engineAPI.h"
 
 //////////////////////////////////////////////////////////////////////////
 // Platform Menu Data

--- a/Engine/source/platformWin32/menus/popupMenuWin32.cpp
+++ b/Engine/source/platformWin32/menus/popupMenuWin32.cpp
@@ -24,6 +24,7 @@
 
 #include "platform/menus/popupMenu.h"
 #include "platformWin32/platformWin32.h"
+#include "console/engineAPI.h"
 #include "console/consoleTypes.h"
 #include "gui/core/guiCanvas.h"
 #include "windowManager/platformWindowMgr.h"

--- a/Engine/source/sfx/sfxModifier.cpp
+++ b/Engine/source/sfx/sfxModifier.cpp
@@ -20,6 +20,8 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
+#include "console/simBase.h"
+#include "console/engineAPI.h"
 #include "sfx/sfxModifier.h"
 #include "sfx/sfxSource.h"
 

--- a/Engine/source/sfx/sfxParameter.cpp
+++ b/Engine/source/sfx/sfxParameter.cpp
@@ -22,6 +22,7 @@
 
 #include "sfx/sfxParameter.h"
 #include "console/consoleTypes.h"
+#include "console/simBase.h"
 #include "console/engineAPI.h"
 #include "console/simSet.h"
 #include "math/mMathFn.h"

--- a/Engine/source/sim/netDownload.cpp
+++ b/Engine/source/sim/netDownload.cpp
@@ -23,6 +23,7 @@
 #include "platform/platform.h"
 #include "core/dnet.h"
 #include "console/simBase.h"
+#include "console/engineAPI.h"
 #include "sim/netConnection.h"
 #include "core/stream/bitStream.h"
 #include "core/stream/fileStream.h"

--- a/Engine/source/util/undo.h
+++ b/Engine/source/util/undo.h
@@ -29,6 +29,12 @@
 #ifndef _TVECTOR_H_
 #include "core/util/tVector.h"
 #endif
+#ifndef _SIMBASE_H_
+#include "console/simBase.h"
+#endif
+#ifndef _ENGINEAPI_H_
+#include "console/engineAPI.h"
+#endif
 
 class UndoManager;
 


### PR DESCRIPTION
Refactors console execution in order to resolve issue #1134. It does this by changing executef calls to templates which internally manage the stack, similar to how most modern C++ script binding libraries work. The templates also automatically perform type conversion, meaning you don't even need to bother converting your parameters to TorqueScript types - this is all done for you.

Along with this, all public execution calls (such as execute* and evaluate*) now save and restore the stack upon returning. They are also now thread safe, meaning they can be called from other threads (as long as get*Arg functions aren't used).

I've also added some basic tests for the core marshalling functionality in addition to the execution calls. This should hopefully trap any expected future regressions with this functionality.

In addition some callbacks have been corrected to use the correct types instead of strings which was causing a few problems.