### PR TITLE
Remove default web deployment

### DIFF
--- a/Templates/Empty/buildFiles/config/project.conf
+++ b/Templates/Empty/buildFiles/config/project.conf
@@ -13,9 +13,6 @@ $TORQUE_EXTENDED_MOVE = false;
 
 // Configure Torque 3D
 Torque3D::beginConfig( "win32", "Empty" );
-
-    // Include Web Deployment module
-    includeModule( 'webDeploy' );
         
     // Enable for optional minidump debugging support
     // addProjectDefine( 'TORQUE_MINIDUMP' );

--- a/Templates/Full/buildFiles/config/project.conf
+++ b/Templates/Full/buildFiles/config/project.conf
@@ -13,9 +13,6 @@ $TORQUE_EXTENDED_MOVE = false;
 
 // Configure Torque 3D
 Torque3D::beginConfig( "win32", "Full" );
-
-    // Include Web Deployment module
-    includeModule( 'webDeploy' );
         
     // Enable for optional minidump debugging support
     // addProjectDefine( 'TORQUE_MINIDUMP' );


### PR DESCRIPTION
It can still be added in the project manager module list as normal, but since it seems deprecated, let's not include it by default.