### PR TITLE
feedback for *which* namespace is already linked. 

### DIFF
--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -1407,11 +1407,11 @@ void SimObject::linkNamespaces()
    // while still having the class namespace fields matching the current
    // setup.
 
-   if (mNameSpace != NULL)
+   if (mNameSpace)
+   {
       Con::warnf("SimObject::linkNamespaces -- Namespace linkage already in place %s", mNameSpace->getName());
-   if( mNameSpace )
       return;
-
+   }
    // Get the namespace for the C++ class.
 
    Namespace* cppNamespace = getClassRep()->getNameSpace();

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -1407,7 +1407,8 @@ void SimObject::linkNamespaces()
    // while still having the class namespace fields matching the current
    // setup.
 
-   AssertWarn( mNameSpace == NULL, "SimObject::linkNamespaces -- Namespace linkage already in place" );
+   if (mNameSpace != NULL)
+      Con::warnf("SimObject::linkNamespaces -- Namespace linkage already in place %s", mNameSpace->getName());
    if( mNameSpace )
       return;
 


### PR DESCRIPTION
should probably look into enhancing assertwarn to be able to take a formatted string at some point...