### PR TITLE
DiffuseMapFeatGLSL::setTexData validation

### DIFF
--- a/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
@@ -986,8 +986,11 @@ void DiffuseMapFeatGLSL::setTexData(   Material::StageData &stageDat,
                                        U32 &texIndex )
 {
    GFXTextureObject *tex = stageDat.getTex( MFT_DiffuseMap );
-   passData.mSamplerNames[ texIndex ] = "diffuseMap";
-   passData.mTexSlot[ texIndex++ ].texObject = tex;
+   if (tex)
+   {
+      passData.mSamplerNames[texIndex] = "diffuseMap";
+      passData.mTexSlot[texIndex++].texObject = tex;
+   }
 }
 
 


### PR DESCRIPTION
this shouldn't ever trigger, but for paranoias sake, best check it.