### PR TITLE
nvidia nsight debugger support.

### DIFF
--- a/Engine/source/gfx/gl/gfxGLDevice.cpp
+++ b/Engine/source/gfx/gl/gfxGLDevice.cpp
@@ -152,10 +152,10 @@ void GFXGLDevice::initGLState()
       glBindFramebuffer = &_t3d_glBindFramebuffer;
    }
 
-#if TORQUE_DEBUG
 #ifdef TORQUE_NSIGHT_WORKAROUND
    __GLEW_ARB_buffer_storage = false;
 #endif
+#if TORQUE_DEBUG
    if( gglHasExtension(ARB_debug_output) )
    {
       glEnable(GL_DEBUG_OUTPUT);

--- a/Engine/source/gfx/gl/gfxGLDevice.cpp
+++ b/Engine/source/gfx/gl/gfxGLDevice.cpp
@@ -153,6 +153,9 @@ void GFXGLDevice::initGLState()
    }
 
 #if TORQUE_DEBUG
+#ifdef TORQUE_NSIGHT_WORKAROUND
+   __GLEW_ARB_buffer_storage = false;
+#endif
    if( gglHasExtension(ARB_debug_output) )
    {
       glEnable(GL_DEBUG_OUTPUT);


### PR DESCRIPTION
requires defining the TORQUE_NSIGHT_WORKAROUND preprocessor macro