### PR TITLE
return the result value of scrollVisible

### DIFF
--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -4924,7 +4924,7 @@ DefineEngineMethod( GuiTreeViewCtrl, scrollVisible, bool, ( S32 itemID), ,
    "@param itemID TreeItemId of item to scroll to/make visible.\n"
    "@return True if it was successful, false if not.")
 {
-   object->scrollVisible(itemID);
+   return object->scrollVisible(itemID);
 }
 
 DefineEngineMethod( GuiTreeViewCtrl, buildIconTable, bool, ( const char* icons), ,


### PR DESCRIPTION
The console function changed from void to bool, so we
should actually return the value.

Also, the missing return is an error in VS2013.