### PR TITLE
Added NULL check in function findItemByName.

### DIFF
--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -4624,6 +4624,8 @@ S32 GuiTreeViewCtrl::findItemByName(const char *name)
 {
    for (S32 i = 0; i < mItems.size(); i++) 
    {
+      if ( !mItems[i] )
+         continue;
 	   if( mItems[i]->mState.test( Item::InspectorData ) )
 		   continue;
       if (mItems[i] && dStrcmp(mItems[i]->getText(),name) == 0) 


### PR DESCRIPTION
(cherry picked from commit adb2513a2461092486e00b5550bf57fb83d0ccac)

When items in the gui tree control are removed it does  not resize the array because it can create a problem with the tree item id's. So it just NULL's out the element. This causes an access violation. 