### PR TITLE
Fix for minidump support

### DIFF
--- a/Engine/source/platformWin32/minidump/winStackWalker.h
+++ b/Engine/source/platformWin32/minidump/winStackWalker.h
@@ -28,6 +28,8 @@
 #include <windows.h>
 #include <dbghelp.h>
 
+#include "platform/types.h"
+
 class StackWalker
 {
 public:

--- a/Tools/projectGenerator/templates/vc2010_lib_proj.tpl
+++ b/Tools/projectGenerator/templates/vc2010_lib_proj.tpl
@@ -135,7 +135,7 @@
       <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>{foreach item=def from=$projIncludes}{$def};{/foreach}%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>{foreach item=def from=$projDefines}{$def};{/foreach}UNICODE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>{foreach item=def from=$projDefines}{$def};{/foreach}UNICODE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;TORQUE_RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>
       </ExceptionHandling>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>

--- a/Tools/projectGenerator/templates/vc2k8_lib_proj.tpl
+++ b/Tools/projectGenerator/templates/vc2k8_lib_proj.tpl
@@ -206,7 +206,7 @@
 				Optimization="3"
 				InlineFunctionExpansion="2"
 				AdditionalIncludeDirectories="{foreach item=def from=$projIncludes}{$def};{/foreach}"
-				PreprocessorDefinitions="{foreach item=def from=$projDefines}{$def};{/foreach}UNICODE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="{foreach item=def from=$projDefines}{$def};{/foreach}UNICODE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;TORQUE_RELEASE"
 				ExceptionHandling="0"
 				BasicRuntimeChecks="0"
 				StringPooling="true"


### PR DESCRIPTION
This allows minidump support to compile and be setup correctly when the checkbox is checked. The VS lib templates were missing TORQUE_RELEASE in the preprocessor definitions which caused minidump support to not be enabled regardless of a checkbox or not.