### PR TITLE
Fixed SDL related header includes for linux

### DIFF
--- a/Engine/source/platformX86UNIX/threads/semaphore.cpp
+++ b/Engine/source/platformX86UNIX/threads/semaphore.cpp
@@ -25,8 +25,8 @@
 // Instead of that mess that was here before, lets use the SDL lib to deal
 // with the semaphores.
 
-#include <SDL.h>
-#include <SDL_thread.h>
+#include <SDL/SDL.h>
+#include <SDL/SDL_thread.h>
 
 struct PlatformSemaphore
 {

--- a/Engine/source/platformX86UNIX/x86UNIXProcessControl.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXProcessControl.cpp
@@ -31,7 +31,7 @@
 #include <signal.h>
 
 #ifndef TORQUE_DEDICATED
-#include <SDL.h>
+#include <SDL/SDL.h>
 #endif
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/platformX86UNIX/x86UNIXRedbook.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXRedbook.cpp
@@ -32,7 +32,7 @@
 #include <string.h>
 #endif
 
-#include <SDL.h>
+#include <SDL/SDL.h>
 
 class SDL_CD; // TODO SDL remove
 


### PR DESCRIPTION
When trying to compile the development branch on Fedora 21 (x86_64) I ran into the following error:
- *fatal error: SDL.h: No such file or directory*

This micro contribution fixes the the SDL related header includes, so that the previously mentioned fatal error is resolved. This way the inclusion of SDL related headers is consistent with the the includes of these headers in other classes of this directory as well.