### PR TITLE
Smart vsync

### DIFF
--- a/Engine/source/gfx/D3D9/pc/gfxPCD3D9Target.cpp
+++ b/Engine/source/gfx/D3D9/pc/gfxPCD3D9Target.cpp
@@ -474,7 +474,8 @@ void GFXPCD3D9WindowTarget::resetMode()
       // have changed.      
       if ( backbufferSize == getSize() && 
            ppFullscreen == mode.fullScreen &&
-           ppAntiAliaseLevel == mode.antialiasLevel )
+           ppAntiAliaseLevel == mode.antialiasLevel &&
+           ((pp.PresentationInterval == D3DPRESENT_INTERVAL_IMMEDIATE) == mDevice->smDisableVSync) )
          return;   
    }
 

--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -50,6 +50,7 @@
 GFXDevice * GFXDevice::smGFXDevice = NULL;
 bool GFXDevice::smWireframe = false;
 bool GFXDevice::smDisableVSync = true;
+bool GFXDevice::smPrevDisableVSync = GFXDevice::smDisableVSync;
 F32 GFXDevice::smForcedPixVersion = -1.0f;
 bool GFXDevice::smDisableOcclusionQuery = false;
 bool gDisassembleAllShaders = false;
@@ -206,6 +207,9 @@ GFXDevice::GFXDevice()
 
 void GFXDevice::vsyncChanged()
 {
+   if (smDisableVSync == smPrevDisableVSync)
+      return;
+
    static bool sHaveWarned;
    if (smDisableVSync && !sHaveWarned)
    {
@@ -222,6 +226,7 @@ void GFXDevice::vsyncChanged()
          sHaveWarned = true;
       }
    }
+   smPrevDisableVSync = smDisableVSync;
 }
 
 GFXDrawUtil* GFXDevice::getDrawUtil()

--- a/Engine/source/gfx/gfxDevice.h
+++ b/Engine/source/gfx/gfxDevice.h
@@ -563,6 +563,7 @@ protected:
    //-----------------------------------------------------------------------------
 protected:
 
+   void vsyncChanged();
 
    /// @name Buffer Allocation 
    /// These methods are implemented per-device and are called by the GFX layer

--- a/Engine/source/gfx/gfxDevice.h
+++ b/Engine/source/gfx/gfxDevice.h
@@ -401,6 +401,15 @@ public:
 
    /// @}
 
+   enum VSyncMode
+   {
+      VS_Disabled = 0,
+      VS_Enabled  = 1,
+      VS_Auto     = 2 // Try to choose a good vsync based on video mode and whether desktop
+                      // composition is running, preferring to disable vsync when appropriate.
+                      // TODO: support adaptive vsync
+   };
+
    //-----------------------------------------------------------------------------
 protected:
 
@@ -442,6 +451,9 @@ protected:
    /// The global vsync state.
    static bool smDisableVSync;
    static bool smPrevDisableVSync;
+
+   static S32 smFullscreenVSyncMode;
+   static S32 smWindowedVSyncMode;
 
    /// The forced shader model version if non-zero.
    static F32 smForcedPixVersion;
@@ -564,6 +576,7 @@ protected:
    //-----------------------------------------------------------------------------
 protected:
 
+   void videoModeChanged();
    void vsyncChanged();
 
    /// @name Buffer Allocation 

--- a/Engine/source/gfx/gfxDevice.h
+++ b/Engine/source/gfx/gfxDevice.h
@@ -441,6 +441,7 @@ protected:
 
    /// The global vsync state.
    static bool smDisableVSync;
+   static bool smPrevDisableVSync;
 
    /// The forced shader model version if non-zero.
    static F32 smForcedPixVersion;

--- a/Engine/source/platformX86UNIX/x86UNIXOGLVideo.client.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXOGLVideo.client.cpp
@@ -197,7 +197,7 @@ bool OpenGLDevice::activate( U32 width, U32 height, U32 bpp, bool fullScreen )
    // Do this here because we now know about the extensions:
    if ( gGLState.suppSwapInterval )
       setVerticalSync(
-         !Con::getBoolVariable( "$pref::Video::disableVerticalSync" ) );
+         !Con::getBoolVariable( "$video::disableVerticalSync" ) );
    Con::setBoolVariable("$pref::OpenGL::allowTexGen", true);
 
    return true;
@@ -362,7 +362,7 @@ bool OpenGLDevice::setScreenMode( U32 width, U32 height, U32 bpp,
    }
 
    if ( gGLState.suppSwapInterval )
-      setVerticalSync( !Con::getBoolVariable( "$pref::Video::disableVerticalSync" ) );
+      setVerticalSync( !Con::getBoolVariable( "$video::disableVerticalSync" ) );
 
    // reset the window in platform state
    SDL_SysWMinfo sysinfo;

--- a/Engine/source/windowManager/platformWindowMgr.h
+++ b/Engine/source/windowManager/platformWindowMgr.h
@@ -136,6 +136,10 @@ public:
    /// This method indicates to created windows to show as normal.
    virtual void setDisplayWindow(bool set){}
 
+   /// Checks if DWM is running (Windows only)
+   virtual bool isDesktopCompositionEnabled() { return false; }
+   virtual void updateDesktopCompositionState() {}
+
 private:
    /// Process command line arguments from StandardMainLoop. This is done to
    /// allow web plugin functionality, where we are passed platform-specific

--- a/Engine/source/windowManager/win32/win32Window.cpp
+++ b/Engine/source/windowManager/win32/win32Window.cpp
@@ -937,6 +937,11 @@ LRESULT PASCAL Win32Window::WindowProc( HWND hWnd, UINT message, WPARAM wParam, 
 			}
 		}
 		break;
+
+   case WM_DWMCOMPOSITIONCHANGED:
+      WindowManager->updateDesktopCompositionState();
+      break;
+
 		// Some events need to be consumed as well as queued up
 		// for later dispatch.
 	case WM_CLOSE:

--- a/Engine/source/windowManager/win32/win32WindowMgr.h
+++ b/Engine/source/windowManager/win32/win32WindowMgr.h
@@ -123,6 +123,9 @@ public:
    virtual void raiseCurtain();
 
    virtual void setDisplayWindow(bool set) { mDisplayWindow = set; }
+
+   virtual bool isDesktopCompositionEnabled();
+   virtual void updateDesktopCompositionState();
 };
 
 #endif

--- a/Templates/Empty/game/art/gui/optionsDlg.gui
+++ b/Templates/Empty/game/art/gui/optionsDlg.gui
@@ -674,7 +674,7 @@
             profile = "GuiCheckBoxProfile";
             visible = "1";
             active = "1";
-            command = "OptionsDlg._updateApplyState();";
+            command = "OptionsDlg._fullscreenChanged();";
             tooltipProfile = "GuiToolTipProfile";
             hovertime = "1000";
             isContainer = "0";

--- a/Templates/Empty/game/core/scripts/client/defaults.cs
+++ b/Templates/Empty/game/core/scripts/client/defaults.cs
@@ -47,7 +47,8 @@ $sceneLighting::purgeMethod = "lastCreated";
 $sceneLighting::cacheLighting = 1;
 
 $pref::Video::displayDevice = "D3D9";
-$pref::Video::disableVerticalSync = 1;
+$pref::Video::vsyncFullscreen = 2;
+$pref::Video::vsyncWindowed = 2;
 $pref::Video::mode = "1024 768 false 32 60 4";
 $pref::Video::defaultFenceCount = 0;
 $pref::Video::screenShotSession = 0;

--- a/Templates/Empty/game/scripts/gui/optionsDlg.cs
+++ b/Templates/Empty/game/scripts/gui/optionsDlg.cs
@@ -140,7 +140,7 @@ function OptionsDlg::onWake(%this)
    {
       %this-->OptGraphicsFullscreenToggle.setStateOn( Canvas.isFullScreen() );
    }
-   %this-->OptGraphicsVSyncToggle.setStateOn( !$pref::Video::disableVerticalSync );
+   %this-->OptGraphicsVSyncToggle.setStateOn( !$video::disableVerticalSync );
    
    OptionsDlg.initResMenu();
    %resSelId = OptionsDlg-->OptGraphicsResolutionMenu.findText( _makePrettyResString( $pref::Video::mode ) );
@@ -355,7 +355,7 @@ function OptionsDlg::applyGraphics( %this, %testNeedApply )
 	%newBpp        = 32; // ... its not 1997 anymore.
 	%newFullScreen = %this-->OptGraphicsFullscreenToggle.getValue() ? "true" : "false";
 	%newRefresh    = %this-->OptRefreshSelectMenu.getSelected();
-	%newVsync = !%this-->OptGraphicsVSyncToggle.getValue();	
+	%newVsync = !%this-->OptGraphicsVSyncToggle.getValue();
 	%newFSAA = %this-->OptAAQualityPopup.getSelected();
 
    // Under web deployment we can't be full screen.
@@ -383,13 +383,13 @@ function OptionsDlg::applyGraphics( %this, %testNeedApply )
 	
    // Change the video mode.   
    if (  %newMode !$= $pref::Video::mode || 
-         %newVsync != $pref::Video::disableVerticalSync )
+         %newVsync != $video::disableVerticalSync )
    {
       if ( %testNeedApply )
          return true;
 
       $pref::Video::mode = %newMode;
-      $pref::Video::disableVerticalSync = %newVsync;      
+      $video::disableVerticalSync = %newVsync;
       configureCanvas();
    }
    
@@ -426,6 +426,22 @@ function OptionsDlg::_updateApplyState( %this )
    assert( isObject( %graphicsPane ) );
 
    %applyCtrl.active = %graphicsPane.isVisible() && %this.applyGraphics( true );   
+}
+
+function OptionsDlg::_fullscreenChanged( %this )
+{
+    // Switching between fullscreen and windowed can trigger the vsync mode to change,
+    // so temporarily set the new mode string to see what vsync we will get and
+    // update the UI appropriately.
+    // TODO: This is hacky, write a dedicated function for this instead.
+    %newFullScreen = %this-->OptGraphicsFullscreenToggle.getValue() ? "true" : "false";
+
+    %oldMode = $pref::Video::mode;
+    $pref::Video::mode = setWord(%oldMode, $WORD::FULLSCREEN, %newFullScreen);
+    %this-->OptGraphicsVSyncToggle.setStateOn( !$video::disableVerticalSync );
+    $pref::Video::mode = %oldMode;
+
+    %this._updateApplyState();
 }
 
 function OptionsDlg::_autoDetectQuality( %this )

--- a/Templates/Full/game/art/gui/optionsDlg.gui
+++ b/Templates/Full/game/art/gui/optionsDlg.gui
@@ -674,7 +674,7 @@
             profile = "GuiCheckBoxProfile";
             visible = "1";
             active = "1";
-            command = "OptionsDlg._updateApplyState();";
+            command = "OptionsDlg._fullscreenChanged();";
             tooltipProfile = "GuiToolTipProfile";
             hovertime = "1000";
             isContainer = "0";

--- a/Templates/Full/game/core/scripts/client/defaults.cs
+++ b/Templates/Full/game/core/scripts/client/defaults.cs
@@ -47,7 +47,8 @@ $sceneLighting::purgeMethod = "lastCreated";
 $sceneLighting::cacheLighting = 1;
 
 $pref::Video::displayDevice = "D3D9";
-$pref::Video::disableVerticalSync = 1;
+$pref::Video::vsyncFullscreen = 2;
+$pref::Video::vsyncWindowed = 2;
 $pref::Video::mode = "1024 768 false 32 60 4";
 $pref::Video::defaultFenceCount = 0;
 $pref::Video::screenShotSession = 0;

--- a/Templates/Full/game/scripts/gui/optionsDlg.cs
+++ b/Templates/Full/game/scripts/gui/optionsDlg.cs
@@ -140,7 +140,7 @@ function OptionsDlg::onWake(%this)
    {
       %this-->OptGraphicsFullscreenToggle.setStateOn( Canvas.isFullScreen() );
    }
-   %this-->OptGraphicsVSyncToggle.setStateOn( !$pref::Video::disableVerticalSync );
+   %this-->OptGraphicsVSyncToggle.setStateOn( !$video::disableVerticalSync );
    
    OptionsDlg.initResMenu();
    %resSelId = OptionsDlg-->OptGraphicsResolutionMenu.findText( _makePrettyResString( $pref::Video::mode ) );
@@ -355,7 +355,7 @@ function OptionsDlg::applyGraphics( %this, %testNeedApply )
 	%newBpp        = 32; // ... its not 1997 anymore.
 	%newFullScreen = %this-->OptGraphicsFullscreenToggle.getValue() ? "true" : "false";
 	%newRefresh    = %this-->OptRefreshSelectMenu.getSelected();
-	%newVsync = !%this-->OptGraphicsVSyncToggle.getValue();	
+	%newVsync = !%this-->OptGraphicsVSyncToggle.getValue();
 	%newFSAA = %this-->OptAAQualityPopup.getSelected();
 
    // Under web deployment we can't be full screen.
@@ -383,13 +383,13 @@ function OptionsDlg::applyGraphics( %this, %testNeedApply )
 	
    // Change the video mode.   
    if (  %newMode !$= $pref::Video::mode || 
-         %newVsync != $pref::Video::disableVerticalSync )
+         %newVsync != $video::disableVerticalSync )
    {
       if ( %testNeedApply )
          return true;
 
       $pref::Video::mode = %newMode;
-      $pref::Video::disableVerticalSync = %newVsync;      
+      $video::disableVerticalSync = %newVsync;
       configureCanvas();
    }
    
@@ -426,6 +426,22 @@ function OptionsDlg::_updateApplyState( %this )
    assert( isObject( %graphicsPane ) );
 
    %applyCtrl.active = %graphicsPane.isVisible() && %this.applyGraphics( true );   
+}
+
+function OptionsDlg::_fullscreenChanged( %this )
+{
+    // Switching between fullscreen and windowed can trigger the vsync mode to change,
+    // so temporarily set the new mode string to see what vsync we will get and
+    // update the UI appropriately.
+    // TODO: This is hacky, write a dedicated function for this instead.
+    %newFullScreen = %this-->OptGraphicsFullscreenToggle.getValue() ? "true" : "false";
+
+    %oldMode = $pref::Video::mode;
+    $pref::Video::mode = setWord(%oldMode, $WORD::FULLSCREEN, %newFullScreen);
+    %this-->OptGraphicsVSyncToggle.setStateOn( !$video::disableVerticalSync );
+    $pref::Video::mode = %oldMode;
+
+    %this._updateApplyState();
 }
 
 function OptionsDlg::_autoDetectQuality( %this )


### PR DESCRIPTION
Previously we were defaulting to vsync=off, but in recent versions
of windows this is often a bad idea because desktop compositing ("aero")
effectively enforces a vsync in windowed modes, regardless of our
presentation interval. So turning on vsync in those cases is beneficial
because we won't waste CPU effort rendering frames that are just going to
be discarded by the OS anyways, and frame rate displays will more
accurately represent what the user is actually seeing on the monitor.

To solve this, the engine now tracks separate fullscreen and windowed
vsync modes. Fullscreen defaults to vsync=off. Windowed modes default to
vsync=on if desktop composition is detected, and off otherwise. These
settings are stored in the vsyncFullscreen and vsyncWindowed config
variables. The settings are:

0 : vsync disabled
1 : vsync enabled
2 : auto vsync (default)

These variables aren't intended to be changed directly, and they don't
appear in the graphic options. Any changes to the vsync setting via the
graphics options will removed the "auto" behavior, and this can only be
restored by resetting or editing the config by hand.

The old vsync config variable now only acts as an abstraction to minimize the amount of code that needs to know about the two different vsyncs, and it's been renamed to $video::disableVerticalSync so it won't be persisted.