### PR TITLE
+proper buffer size for udp socket

### DIFF
--- a/Engine/source/platform/platformNet.cpp
+++ b/Engine/source/platform/platformNet.cpp
@@ -503,7 +503,7 @@ bool Net::openPort(S32 port, bool doBind)
 	  }
 
       if(error == NoError)
-         error = setBufferSize(udpSocket, 32768);
+         error = setBufferSize(udpSocket, 32768*8);
 
       if(error == NoError && !useVDP)
          error = setBroadcast(udpSocket, true);


### PR DESCRIPTION
SkypeLog: 28.02.2015
[17:18:32] Dušan Jocic: when creating user datagram protocol or UDP, old
implementation was limiting lan utalization to 1% of our modern 1000Mbps
hardwar
[17:19:15] Dušan Jocic: that add proper buffer size for udp socket
[17:19:43] Dušan Jocic: and lift off limitation what was present there
for 10/100 mbps lan