### PR TITLE
Revert recent style cleanup changes

### DIFF
--- a/Engine/source/T3D/debris.cpp
+++ b/Engine/source/T3D/debris.cpp
@@ -573,7 +573,7 @@ bool Debris::onAdd()
    // Setup our bounding box
    if( mDataBlock->shape )
    {
-      mObjBox = mDataBlock->shape->mBounds;
+      mObjBox = mDataBlock->shape->bounds;
    }
    else
    {

--- a/Engine/source/T3D/examples/renderShapeExample.cpp
+++ b/Engine/source/T3D/examples/renderShapeExample.cpp
@@ -213,7 +213,7 @@ void RenderShapeExample::createShape()
    }
 
    // Update the bounding box
-   mObjBox = mShape->mBounds;
+   mObjBox = mShape->bounds;
    resetWorldBox();
    setRenderTransform(mObjToWorld);
 

--- a/Engine/source/T3D/fx/explosion.cpp
+++ b/Engine/source/T3D/fx/explosion.cpp
@@ -1252,7 +1252,7 @@ bool Explosion::explode()
       mEndingMS = U32(mExplosionInstance->getScaledDuration(mExplosionThread) * 1000.0f);
 
       mObjScale.convolve(mDataBlock->explosionScale);
-      mObjBox = mDataBlock->explosionShape->mBounds;
+      mObjBox = mDataBlock->explosionShape->bounds;
       resetWorldBox();
    }
 

--- a/Engine/source/T3D/fx/groundCover.cpp
+++ b/Engine/source/T3D/fx/groundCover.cpp
@@ -1142,7 +1142,7 @@ GroundCoverCell* GroundCover::_generateCell( const Point2I& index,
       const F32 typeMaxElevation = mMaxElevation[type];
       const F32 typeMinElevation = mMinElevation[type];
       const bool typeIsShape = mShapeInstances[ type ] != NULL;
-      const Box3F typeShapeBounds = typeIsShape ? mShapeInstances[ type ]->getShape()->mBounds : Box3F();
+      const Box3F typeShapeBounds = typeIsShape ? mShapeInstances[ type ]->getShape()->bounds : Box3F();
       const F32 typeWindScale = mWindScale[type];
       StringTableEntry typeLayer = mLayer[type];
       const bool typeInvertLayer = mInvertLayer[type];

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -268,8 +268,8 @@ void GuiMaterialPreview::setObjectModel(const char* modelName)
    AssertFatal(mModel, avar("GuiMaterialPreview: Failed to load model %s. Please check your model name and load a valid model.", modelName));
 
    // Initialize camera values:
-   mOrbitPos = mModel->getShape()->mCenter;
-   mMinOrbitDist = mModel->getShape()->mRadius;
+   mOrbitPos = mModel->getShape()->center;
+   mMinOrbitDist = mModel->getShape()->radius;
 
    lastRenderTime = Platform::getVirtualMilliseconds();
 }
@@ -434,7 +434,7 @@ void GuiMaterialPreview::resetViewport()
    mCameraRot.set( mDegToRad(30.0f), 0, mDegToRad(-30.0f) );
    mCameraPos.set(0.0f, 1.75f, 1.25f);
    mOrbitDist = 5.0f;
-   mOrbitPos = mModel->getShape()->mCenter;
+   mOrbitPos = mModel->getShape()->center;
 
    // Reset the viewport's lighting.
    GuiMaterialPreview::mFakeSun->setColor( ColorF( 1.0f, 1.0f, 1.0f ) );

--- a/Engine/source/T3D/guiObjectView.cpp
+++ b/Engine/source/T3D/guiObjectView.cpp
@@ -366,8 +366,8 @@ void GuiObjectView::setObjectModel( const String& modelName )
 
    // Initialize camera values.
    
-   mOrbitPos = mModel->getShape()->mCenter;
-   mMinOrbitDist = mModel->getShape()->mRadius;
+   mOrbitPos = mModel->getShape()->center;
+   mMinOrbitDist = mModel->getShape()->radius;
 
    // Initialize animation.
    
@@ -645,7 +645,7 @@ void GuiObjectView::_initAnimation()
       
    if( mAnimationSeq != -1 )
    {
-      if( mAnimationSeq >= mModel->getShape()->mSequences.size() )
+      if( mAnimationSeq >= mModel->getShape()->sequences.size() )
       {
          Con::errorf( "GuiObjectView::_initAnimation - Sequence '%i' out of range for model '%s'",
             mAnimationSeq,
@@ -694,7 +694,7 @@ void GuiObjectView::_initMount()
    
    // Make sure mount node is valid.
    
-   if( mMountNode != -1 && mMountNode >= mModel->getShape()->mNodes.size() )
+   if( mMountNode != -1 && mMountNode >= mModel->getShape()->nodes.size() )
    {
       Con::errorf( "GuiObjectView::_initMount - Mount node index '%i' out of range for '%s'",
          mMountNode,

--- a/Engine/source/T3D/physics/physicsDebris.cpp
+++ b/Engine/source/T3D/physics/physicsDebris.cpp
@@ -358,7 +358,7 @@ bool PhysicsDebris::onAdd()
    }
 
    // Setup our bounding box
-   mObjBox = mDataBlock->shape->mBounds;   
+   mObjBox = mDataBlock->shape->bounds;   
    resetWorldBox();
 
    // Add it to the client scene.
@@ -696,20 +696,20 @@ void PhysicsDebris::_findNodes( U32 colNode, Vector<U32> &nodeIds )
    // 2. Collision node is a child of its visible mesh node
 
    TSShape *shape = mDataBlock->shape;
-   S32 itr = shape->mNodes[colNode].parentIndex;
-   itr = shape->mNodes[itr].firstChild;
+   S32 itr = shape->nodes[colNode].parentIndex;
+   itr = shape->nodes[itr].firstChild;
 
    while ( itr != -1 )
    {
       if ( itr != colNode )
          nodeIds.push_back(itr);
-      itr = shape->mNodes[itr].nextSibling;
+      itr = shape->nodes[itr].nextSibling;
    }
 
    // If we didn't find any siblings of the collision node we assume
    // it is case #2 and the collision nodes direct parent is the visible mesh.
-   if ( nodeIds.size() == 0 && shape->mNodes[colNode].parentIndex != -1 )
-      nodeIds.push_back( shape->mNodes[colNode].parentIndex );
+   if ( nodeIds.size() == 0 && shape->nodes[colNode].parentIndex != -1 )
+      nodeIds.push_back( shape->nodes[colNode].parentIndex );
 }
 
 extern bool gEditingMission;

--- a/Engine/source/T3D/physics/physicsShape.cpp
+++ b/Engine/source/T3D/physics/physicsShape.cpp
@@ -698,7 +698,7 @@ bool PhysicsShape::_createShape()
       return false;
 
    // Set the world box.
-   mObjBox = db->shape->mBounds;
+   mObjBox = db->shape->bounds;
    resetWorldBox();
 
    // If this is the server and its a client only simulation

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -489,12 +489,12 @@ bool PlayerData::preload(bool server, String &errorStr)
          if (dp->sequence != -1)
             getGroundInfo(si,thread,dp);
       }
-      for (S32 b = 0; b < mShape->mSequences.size(); b++)
+      for (S32 b = 0; b < mShape->sequences.size(); b++)
       {
          if (!isTableSequence(b))
          {
             dp->sequence      = b;
-            dp->name          = mShape->getName(mShape->mSequences[b].nameIndex);
+            dp->name          = mShape->getName(mShape->sequences[b].nameIndex);
             dp->velocityScale = false;
             getGroundInfo(si,thread,dp++);
          }
@@ -614,7 +614,7 @@ void PlayerData::getGroundInfo(TSShapeInstance* si, TSThread* thread,ActionAnima
       dp->dir.set(0.0f, 0.0f, 0.0f);
 
       // Death animations MUST define ground transforms, so add dummy ones if required
-      if (si->getShape()->mSequences[dp->sequence].numGroundFrames == 0)
+      if (si->getShape()->sequences[dp->sequence].numGroundFrames == 0)
          si->getShape()->setSequenceGroundSpeed(dp->name, Point3F(0, 0, 0), Point3F(0, 0, 0));
    }
    else

--- a/Engine/source/T3D/projectile.cpp
+++ b/Engine/source/T3D/projectile.cpp
@@ -771,7 +771,7 @@ bool Projectile::onAdd()
 
    // Setup our bounding box
    if (bool(mDataBlock->projectileShape) == true)
-      mObjBox = mDataBlock->projectileShape->mBounds;
+      mObjBox = mDataBlock->projectileShape->bounds;
    else
       mObjBox = Box3F(Point3F(0, 0, 0), Point3F(0, 0, 0));
 

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -323,9 +323,9 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
       // Resolve details and camera node indexes.
       static const String sCollisionStr( "collision-" );
 
-      for (i = 0; i < mShape->mDetails.size(); i++)
+      for (i = 0; i < mShape->details.size(); i++)
       {
-         const String &name = mShape->mNames[mShape->mDetails[i].nameIndex];
+         const String &name = mShape->names[mShape->details[i].nameIndex];
 
          if (name.compare( sCollisionStr, sCollisionStr.length(), String::NoCase ) == 0)
          {
@@ -335,15 +335,15 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
             mShape->computeBounds(collisionDetails.last(), collisionBounds.last());
             mShape->getAccelerator(collisionDetails.last());
 
-            if (!mShape->mBounds.isContained(collisionBounds.last()))
+            if (!mShape->bounds.isContained(collisionBounds.last()))
             {
                Con::warnf("Warning: shape %s collision detail %d (Collision-%d) bounds exceed that of shape.", shapeName, collisionDetails.size() - 1, collisionDetails.last());
-               collisionBounds.last() = mShape->mBounds;
+               collisionBounds.last() = mShape->bounds;
             }
             else if (collisionBounds.last().isValidBox() == false)
             {
                Con::errorf("Error: shape %s-collision detail %d (Collision-%d) bounds box invalid!", shapeName, collisionDetails.size() - 1, collisionDetails.last());
-               collisionBounds.last() = mShape->mBounds;
+               collisionBounds.last() = mShape->bounds;
             }
 
             // The way LOS works is that it will check to see if there is a LOS detail that matches
@@ -364,9 +364,9 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
       // Snag any "unmatched" LOS details
       static const String sLOSStr( "LOS-" );
 
-      for (i = 0; i < mShape->mDetails.size(); i++)
+      for (i = 0; i < mShape->details.size(); i++)
       {
-         const String &name = mShape->mNames[mShape->mDetails[i].nameIndex];
+         const String &name = mShape->names[mShape->details[i].nameIndex];
 
          if (name.compare( sLOSStr, sLOSStr.length(), String::NoCase ) == 0)
          {
@@ -410,7 +410,7 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
       damageSequence = mShape->findSequence("Damage");
 
       //
-      F32 w = mShape->mBounds.len_y() / 2;
+      F32 w = mShape->bounds.len_y() / 2;
       if (cameraMaxDist < w)
          cameraMaxDist = w;
    }
@@ -606,7 +606,7 @@ DefineEngineMethod( ShapeBaseData, checkDeployPos, bool, ( TransformF txfm ),,
 
    MatrixF mat = txfm.getMatrix();
 
-   Box3F objBox = object->mShape->mBounds;
+   Box3F objBox = object->mShape->bounds;
    Point3F boxCenter = (objBox.minExtents + objBox.maxExtents) * 0.5f;
    objBox.minExtents = boxCenter + (objBox.minExtents - boxCenter) * 0.9f;
    objBox.maxExtents = boxCenter + (objBox.maxExtents - boxCenter) * 0.9f;
@@ -1097,11 +1097,11 @@ bool ShapeBase::onNewDataBlock( GameBaseData *dptr, bool reload )
       if (isClientObject())
          mShapeInstance->cloneMaterialList();
 
-      mObjBox = mDataBlock->mShape->mBounds;
+      mObjBox = mDataBlock->mShape->bounds;
       resetWorldBox();
 
       // Set the initial mesh hidden state.
-      mMeshHidden.setSize( mDataBlock->mShape->mObjects.size() );
+      mMeshHidden.setSize( mDataBlock->mShape->objects.size() );
       mMeshHidden.clear();
 
       // Initialize the threads
@@ -1126,8 +1126,8 @@ bool ShapeBase::onNewDataBlock( GameBaseData *dptr, bool reload )
             AssertFatal( prevDB != NULL, "ShapeBase::onNewDataBlock - how did you have a sequence playing without a prior datablock?" );
    
             const TSShape *prevShape = prevDB->mShape;
-            const TSShape::Sequence &prevSeq = prevShape->mSequences[st.sequence];
-            const String &prevSeqName = prevShape->mNames[prevSeq.nameIndex];
+            const TSShape::Sequence &prevSeq = prevShape->sequences[st.sequence];
+            const String &prevSeqName = prevShape->names[prevSeq.nameIndex];
 
             st.sequence = mDataBlock->mShape->findSequence( prevSeqName );
 
@@ -2123,7 +2123,7 @@ const char *ShapeBase::getThreadSequenceName( U32 slot )
 	}
 
 	// Name Index
-	const U32 nameIndex = getShape()->mSequences[st.sequence].nameIndex;
+	const U32 nameIndex = getShape()->sequences[st.sequence].nameIndex;
 
 	// Return Name.
 	return getShape()->getName( nameIndex );
@@ -2309,7 +2309,7 @@ void ShapeBase::advanceThreads(F32 dt)
    for (U32 i = 0; i < MaxScriptThreads; i++) {
       Thread& st = mScriptThread[i];
       if (st.thread) {
-         if (!mShapeInstance->getShape()->mSequences[st.sequence].isCyclic() && !st.atEnd &&
+         if (!mShapeInstance->getShape()->sequences[st.sequence].isCyclic() && !st.atEnd &&
 			 ( ( st.timescale > 0.f )? mShapeInstance->getPos(st.thread) >= 1.0:
               mShapeInstance->getPos(st.thread) <= 0)) {
             st.atEnd = true;
@@ -2589,7 +2589,7 @@ void ShapeBase::_renderBoundingBox( ObjectRenderInst *ri, SceneRenderState *stat
          MatrixF mat;
          getRenderImageTransform( ri->objectIndex, &mat );         
 
-         const Box3F &objBox = image.shapeInstance[getImageShapeIndex(image)]->getShape()->mBounds;
+         const Box3F &objBox = image.shapeInstance[getImageShapeIndex(image)]->getShape()->bounds;
 
          drawer->drawCube( desc, objBox, ColorI( 255, 255, 255 ), &mat );
       }
@@ -3277,17 +3277,17 @@ void ShapeBaseConvex::findNodeTransform()
    TSShapeInstance* si = pShapeBase->getShapeInstance();
    TSShape* shape = si->getShape();
 
-   const TSShape::Detail* detail = &shape->mDetails[dl];
+   const TSShape::Detail* detail = &shape->details[dl];
    const S32 subs = detail->subShapeNum;
-   const S32 start = shape->mSubShapeFirstObject[subs];
-   const S32 end = start + shape->mSubShapeNumObjects[subs];
+   const S32 start = shape->subShapeFirstObject[subs];
+   const S32 end = start + shape->subShapeNumObjects[subs];
 
    // Find the first object that contains a mesh for this
    // detail level. There should only be one mesh per
    // collision detail level.
    for (S32 i = start; i < end; i++) 
    {
-      const TSShape::Object* obj = &shape->mObjects[i];
+      const TSShape::Object* obj = &shape->objects[i];
       if (obj->numMeshes && detail->objectDetailNum < obj->numMeshes) 
       {
          nodeTransform = &si->mNodeTransforms[obj->nodeIndex];
@@ -4857,7 +4857,7 @@ DefineEngineMethod( ShapeBase, changeMaterial, void, ( const char* mapTo, Materi
    ShapeBase *clientObj = dynamic_cast< ShapeBase* > ( object->getClientObject() );
 
    // Check the mapTo name exists for this shape
-   S32 matIndex = serverObj->getShape()->mMaterialList->getMaterialNameList().find_next(String(mapTo));
+   S32 matIndex = serverObj->getShape()->materialList->getMaterialNameList().find_next(String(mapTo));
    if (matIndex < 0)
    {
       Con::errorf("ShapeBase::changeMaterial failed: Invalid mapTo name '%s'", mapTo);
@@ -4876,19 +4876,19 @@ DefineEngineMethod( ShapeBase, changeMaterial, void, ( const char* mapTo, Materi
    // Replace instances with the new material being traded in. For ShapeBase
    // class we have to update the server/client objects separately so both
    // represent our changes
-   delete serverObj->getShape()->mMaterialList->mMatInstList[matIndex];
-   serverObj->getShape()->mMaterialList->mMatInstList[matIndex] = newMat->createMatInstance();
+   delete serverObj->getShape()->materialList->mMatInstList[matIndex];
+   serverObj->getShape()->materialList->mMatInstList[matIndex] = newMat->createMatInstance();
    if (clientObj)
    {
-      delete clientObj->getShape()->mMaterialList->mMatInstList[matIndex];
-      clientObj->getShape()->mMaterialList->mMatInstList[matIndex] = newMat->createMatInstance();
+      delete clientObj->getShape()->materialList->mMatInstList[matIndex];
+      clientObj->getShape()->materialList->mMatInstList[matIndex] = newMat->createMatInstance();
    }
 
    // Finish up preparing the material instances for rendering
    const GFXVertexFormat *flags = getGFXVertexFormat<GFXVertexPNTTB>();
    FeatureSet features = MATMGR->getDefaultFeatures();
 
-   serverObj->getShape()->mMaterialList->getMaterialInst(matIndex)->init( features, flags );
+   serverObj->getShape()->materialList->getMaterialInst(matIndex)->init( features, flags );
    if (clientObj)
       clientObj->getShapeInstance()->mMaterialList->getMaterialInst(matIndex)->init( features, flags );
 }

--- a/Engine/source/T3D/shapeImage.cpp
+++ b/Engine/source/T3D/shapeImage.cpp
@@ -497,9 +497,9 @@ bool ShapeBaseImageData::preload(bool server, String &errorStr)
             do {
                MatrixF nmat;
                QuatF q;
-               TSTransform::setMatrix(shape[i]->mDefaultRotations[node].getQuatF(&q),shape[i]->mDefaultTranslations[node],&nmat);
+               TSTransform::setMatrix(shape[i]->defaultRotations[node].getQuatF(&q),shape[i]->defaultTranslations[node],&nmat);
                total.mul(nmat);
-               node = shape[i]->mNodes[node].parentIndex;
+               node = shape[i]->nodes[node].parentIndex;
             }
             while(node != -1);
             total.inverse();

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -334,7 +334,7 @@ bool TSStatic::_createShape()
          NetConnection::filesWereDownloaded() )
       return false;
 
-   mObjBox = mShape->mBounds;
+   mObjBox = mShape->bounds;
    resetWorldBox();
 
    mShapeInstance = new TSShapeInstance( mShape, isClientObject() );
@@ -391,7 +391,7 @@ void TSStatic::_updatePhysics()
    if ( mCollisionType == Bounds )
    {
       MatrixF offset( true );
-      offset.setPosition( mShape->mCenter );
+      offset.setPosition( mShape->center );
       colShape = PHYSICSMGR->createCollision();
       colShape->addBox( getObjBox().getExtents() * 0.5f * mObjScale, offset );         
    }
@@ -960,31 +960,31 @@ void TSStatic::buildConvex(const Box3F& box, Convex* convex)
 SceneObject* TSStaticPolysoupConvex::smCurObject = NULL;
 
 TSStaticPolysoupConvex::TSStaticPolysoupConvex()
-:  mBox( 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f ),
-   mNormal( 0.0f, 0.0f, 0.0f, 0.0f ),
-   mIdx( 0 ),
-   mMesh( NULL )
+:  box( 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f ),
+   normal( 0.0f, 0.0f, 0.0f, 0.0f ),
+   idx( 0 ),
+   mesh( NULL )
 {
    mType = TSPolysoupConvexType;
 
    for ( U32 i = 0; i < 4; ++i )
    {
-      mVerts[i].set( 0.0f, 0.0f, 0.0f );
+      verts[i].set( 0.0f, 0.0f, 0.0f );
    }
 }
 
 Point3F TSStaticPolysoupConvex::support(const VectorF& vec) const
 {
-   F32 bestDot = mDot( mVerts[0], vec );
+   F32 bestDot = mDot( verts[0], vec );
 
-   const Point3F *bestP = &mVerts[0];
+   const Point3F *bestP = &verts[0];
    for(S32 i=1; i<4; i++)
    {
-      F32 newD = mDot(mVerts[i], vec);
+      F32 newD = mDot(verts[i], vec);
       if(newD > bestDot)
       {
          bestDot = newD;
-         bestP = &mVerts[i];
+         bestP = &verts[i];
       }
    }
 
@@ -993,7 +993,7 @@ Point3F TSStaticPolysoupConvex::support(const VectorF& vec) const
 
 Box3F TSStaticPolysoupConvex::getBoundingBox() const
 {
-   Box3F wbox = mBox;
+   Box3F wbox = box;
    wbox.minExtents.convolve( mObject->getScale() );
    wbox.maxExtents.convolve( mObject->getScale() );
    mObject->getTransform().mul(wbox);
@@ -1003,7 +1003,7 @@ Box3F TSStaticPolysoupConvex::getBoundingBox() const
 Box3F TSStaticPolysoupConvex::getBoundingBox(const MatrixF& mat, const Point3F& scale) const
 {
    AssertISV(false, "TSStaticPolysoupConvex::getBoundingBox(m,p) - Not implemented. -- XEA");
-   return mBox;
+   return box;
 }
 
 void TSStaticPolysoupConvex::getPolyList(AbstractPolyList *list)
@@ -1015,11 +1015,11 @@ void TSStaticPolysoupConvex::getPolyList(AbstractPolyList *list)
    list->setObject(mObject);
 
    // Add only the original collision triangle
-   S32 base =  list->addPoint(mVerts[0]);
-               list->addPoint(mVerts[2]);
-               list->addPoint(mVerts[1]);
+   S32 base =  list->addPoint(verts[0]);
+               list->addPoint(verts[2]);
+               list->addPoint(verts[1]);
 
-   list->begin(0, (U32)mIdx ^ (uintptr_t)mMesh);
+   list->begin(0, (U32)idx ^ (uintptr_t)mesh);
    list->vertex(base + 2);
    list->vertex(base + 1);
    list->vertex(base + 0);
@@ -1035,10 +1035,10 @@ void TSStaticPolysoupConvex::getFeatures(const MatrixF& mat,const VectorF& n, Co
    // For a tetrahedron this is pretty easy... first
    // convert everything into world space.
    Point3F tverts[4];
-   mat.mulP(mVerts[0], &tverts[0]);
-   mat.mulP(mVerts[1], &tverts[1]);
-   mat.mulP(mVerts[2], &tverts[2]);
-   mat.mulP(mVerts[3], &tverts[3]);
+   mat.mulP(verts[0], &tverts[0]);
+   mat.mulP(verts[1], &tverts[1]);
+   mat.mulP(verts[2], &tverts[2]);
+   mat.mulP(verts[3], &tverts[3]);
 
    // points...
    S32 firstVert = cf->mVertexList.size();
@@ -1172,7 +1172,7 @@ DefineEngineMethod( TSStatic, changeMaterial, void, ( const char* mapTo, Materia
    }
 
    // Check the mapTo name exists for this shape
-   S32 matIndex = object->getShape()->mMaterialList->getMaterialNameList().find_next(String(mapTo));
+   S32 matIndex = object->getShape()->materialList->getMaterialNameList().find_next(String(mapTo));
    if (matIndex < 0)
    {
       Con::errorf("TSShape::changeMaterial failed: Invalid mapTo name '%s'", mapTo);
@@ -1190,13 +1190,13 @@ DefineEngineMethod( TSStatic, changeMaterial, void, ( const char* mapTo, Materia
 
    // Replace instances with the new material being traded in. Lets make sure that we only
    // target the specific targets per inst, this is actually doing more than we thought
-   delete object->getShape()->mMaterialList->mMatInstList[matIndex];
-   object->getShape()->mMaterialList->mMatInstList[matIndex] = newMat->createMatInstance();
+   delete object->getShape()->materialList->mMatInstList[matIndex];
+   object->getShape()->materialList->mMatInstList[matIndex] = newMat->createMatInstance();
 
    // Finish up preparing the material instances for rendering
    const GFXVertexFormat *flags = getGFXVertexFormat<GFXVertexPNTTB>();
    FeatureSet features = MATMGR->getDefaultFeatures();
-   object->getShape()->mMaterialList->getMaterialInst(matIndex)->init( features, flags );
+   object->getShape()->materialList->getMaterialInst(matIndex)->init( features, flags );
 }
 
 DefineEngineMethod( TSStatic, getModelFile, const char *, (),,

--- a/Engine/source/T3D/tsStatic.h
+++ b/Engine/source/T3D/tsStatic.h
@@ -56,11 +56,11 @@ public:
    ~TSStaticPolysoupConvex() {};
 
 public:
-   Box3F                mBox;
-   Point3F              mVerts[4];
-   PlaneF               mNormal;
-   S32                  mIdx;
-   TSMesh               *mMesh;
+   Box3F                box;
+   Point3F              verts[4];
+   PlaneF               normal;
+   S32                  idx;
+   TSMesh               *mesh;
 
    static SceneObject* smCurObject;
 

--- a/Engine/source/T3D/turret/turretShape.cpp
+++ b/Engine/source/T3D/turret/turretShape.cpp
@@ -823,8 +823,8 @@ void TurretShape::_updateNodes(const Point3F& rot)
    if (node != -1)
    {
       MatrixF* mat = &mShapeInstance->mNodeTransforms[node];
-      Point3F defaultPos = mShapeInstance->getShape()->mDefaultTranslations[node];
-      Quat16 defaultRot = mShapeInstance->getShape()->mDefaultRotations[node];
+      Point3F defaultPos = mShapeInstance->getShape()->defaultTranslations[node];
+      Quat16 defaultRot = mShapeInstance->getShape()->defaultRotations[node];
 
       QuatF qrot(zRot);
       qrot *= defaultRot.getQuatF();
@@ -837,8 +837,8 @@ void TurretShape::_updateNodes(const Point3F& rot)
    if (node != -1)
    {
       MatrixF* mat = &mShapeInstance->mNodeTransforms[node];
-      Point3F defaultPos = mShapeInstance->getShape()->mDefaultTranslations[node];
-      Quat16 defaultRot = mShapeInstance->getShape()->mDefaultRotations[node];
+      Point3F defaultPos = mShapeInstance->getShape()->defaultTranslations[node];
+      Quat16 defaultRot = mShapeInstance->getShape()->defaultRotations[node];
 
       QuatF qrot(xRot);
       qrot *= defaultRot.getQuatF();
@@ -853,8 +853,8 @@ void TurretShape::_updateNodes(const Point3F& rot)
       if (node != -1)
       {
          MatrixF* mat = &mShapeInstance->mNodeTransforms[node];
-         Point3F defaultPos = mShapeInstance->getShape()->mDefaultTranslations[node];
-         Quat16 defaultRot = mShapeInstance->getShape()->mDefaultRotations[node];         
+         Point3F defaultPos = mShapeInstance->getShape()->defaultTranslations[node];
+         Quat16 defaultRot = mShapeInstance->getShape()->defaultRotations[node];         
 
          QuatF qrot(xRot);
          qrot *= defaultRot.getQuatF();
@@ -866,8 +866,8 @@ void TurretShape::_updateNodes(const Point3F& rot)
       if (node != -1)
       {
          MatrixF* mat = &mShapeInstance->mNodeTransforms[node];
-         Point3F defaultPos = mShapeInstance->getShape()->mDefaultTranslations[node];
-         Quat16 defaultRot = mShapeInstance->getShape()->mDefaultRotations[node];
+         Point3F defaultPos = mShapeInstance->getShape()->defaultTranslations[node];
+         Quat16 defaultRot = mShapeInstance->getShape()->defaultRotations[node];
 
          QuatF qrot(zRot);
          qrot *= defaultRot.getQuatF();

--- a/Engine/source/T3D/vehicles/wheeledVehicle.cpp
+++ b/Engine/source/T3D/vehicles/wheeledVehicle.cpp
@@ -111,7 +111,7 @@ bool WheeledVehicleTire::preload(bool server, String &errorStr)
       // Determinw wheel radius from the shape's bounding box.
       // The tire should be built with it's hub axis along the
       // object's Y axis.
-      radius = shape->mBounds.len_z() / 2;
+      radius = shape->bounds.len_z() / 2;
    }
 
    return true;
@@ -399,8 +399,8 @@ bool WheeledVehicleData::preload(bool server, String &errorStr)
    if (collisionDetails[0] != -1) {
       MatrixF imat(1);
       SphereF sphere;
-      sphere.center = mShape->mCenter;
-      sphere.radius = mShape->mRadius;
+      sphere.center = mShape->center;
+      sphere.radius = mShape->radius;
       PlaneExtractorPolyList polyList;
       polyList.mPlaneList = &rigidBody.mPlaneList;
       polyList.setTransform(&imat, Point3F(1,1,1));

--- a/Engine/source/console/codeBlock.cpp
+++ b/Engine/source/console/codeBlock.cpp
@@ -41,21 +41,21 @@ ConsoleParser *CodeBlock::smCurrentParser = NULL;
 
 CodeBlock::CodeBlock()
 {
-   mGlobalStrings = NULL;
-   mFunctionStrings = NULL;
-   mFunctionStringsMaxLen = 0;
-   mGlobalStringsMaxLen = 0;
-   mGlobalFloats = NULL;
-   mFunctionFloats = NULL;
-   mLineBreakPairs = NULL;
-   mBreakList = NULL;
-   mBreakListSize = 0;
+   globalStrings = NULL;
+   functionStrings = NULL;
+   functionStringsMaxLen = 0;
+   globalStringsMaxLen = 0;
+   globalFloats = NULL;
+   functionFloats = NULL;
+   lineBreakPairs = NULL;
+   breakList = NULL;
+   breakListSize = 0;
 
-   mRefCount = 0;
-   mCode = NULL;
-   mName = NULL;
-   mFullPath = NULL;
-   mModPath = NULL;
+   refCount = 0;
+   code = NULL;
+   name = NULL;
+   fullPath = NULL;
+   modPath = NULL;
 }
 
 CodeBlock::~CodeBlock()
@@ -63,18 +63,18 @@ CodeBlock::~CodeBlock()
    // Make sure we aren't lingering in the current code block...
    AssertFatal(smCurrentCodeBlock != this, "CodeBlock::~CodeBlock - Caught lingering in smCurrentCodeBlock!")
 
-   if(mName)
+   if(name)
       removeFromCodeList();
-   delete[] const_cast<char*>(mGlobalStrings);
-   delete[] const_cast<char*>(mFunctionStrings);
+   delete[] const_cast<char*>(globalStrings);
+   delete[] const_cast<char*>(functionStrings);
    
-   mFunctionStringsMaxLen = 0;
-   mGlobalStringsMaxLen = 0;
+   functionStringsMaxLen = 0;
+   globalStringsMaxLen = 0;
 
-   delete[] mGlobalFloats;
-   delete[] mFunctionFloats;
-   delete[] mCode;
-   delete[] mBreakList;
+   delete[] globalFloats;
+   delete[] functionFloats;
+   delete[] code;
+   delete[] breakList;
 }
 
 //-------------------------------------------------------------------------
@@ -82,7 +82,7 @@ CodeBlock::~CodeBlock()
 StringTableEntry CodeBlock::getCurrentCodeBlockName()
 {
    if (CodeBlock::getCurrentBlock())
-      return CodeBlock::getCurrentBlock()->mName;
+      return CodeBlock::getCurrentBlock()->name;
    else
       return NULL;
 }   
@@ -90,7 +90,7 @@ StringTableEntry CodeBlock::getCurrentCodeBlockName()
 StringTableEntry CodeBlock::getCurrentCodeBlockFullPath()
 {
    if (CodeBlock::getCurrentBlock())
-      return CodeBlock::getCurrentBlock()->mFullPath;
+      return CodeBlock::getCurrentBlock()->fullPath;
    else
       return NULL;
 }
@@ -98,15 +98,15 @@ StringTableEntry CodeBlock::getCurrentCodeBlockFullPath()
 StringTableEntry CodeBlock::getCurrentCodeBlockModName()
 {
    if (CodeBlock::getCurrentBlock())
-      return CodeBlock::getCurrentBlock()->mModPath;
+      return CodeBlock::getCurrentBlock()->modPath;
    else
       return NULL;
 }
 
 CodeBlock *CodeBlock::find(StringTableEntry name)
 {
-   for(CodeBlock *walk = CodeBlock::getCodeBlockList(); walk; walk = walk->mNextFile)
-      if(walk->mName == name)
+   for(CodeBlock *walk = CodeBlock::getCodeBlockList(); walk; walk = walk->nextFile)
+      if(walk->name == name)
          return walk;
    return NULL;
 }
@@ -116,39 +116,39 @@ CodeBlock *CodeBlock::find(StringTableEntry name)
 void CodeBlock::addToCodeList()
 {
    // remove any code blocks with my name
-   for(CodeBlock **walk = &smCodeBlockList; *walk;walk = &((*walk)->mNextFile))
+   for(CodeBlock **walk = &smCodeBlockList; *walk;walk = &((*walk)->nextFile))
    {
-      if((*walk)->mName == mName)
+      if((*walk)->name == name)
       {
-         *walk = (*walk)->mNextFile;
+         *walk = (*walk)->nextFile;
          break;
       }
    }
-   mNextFile = smCodeBlockList;
+   nextFile = smCodeBlockList;
    smCodeBlockList = this;
 }
 
 void CodeBlock::clearAllBreaks()
 {
-   if(!mLineBreakPairs)
+   if(!lineBreakPairs)
       return;
-   for(U32 i = 0; i < mLineBreakPairCount; i++)
+   for(U32 i = 0; i < lineBreakPairCount; i++)
    {
-      U32 *p = mLineBreakPairs + i * 2;
-      mCode[p[1]] = p[0] & 0xFF;
+      U32 *p = lineBreakPairs + i * 2;
+      code[p[1]] = p[0] & 0xFF;
    }
 }
 
 void CodeBlock::clearBreakpoint(U32 lineNumber)
 {
-   if(!mLineBreakPairs)
+   if(!lineBreakPairs)
       return;
-   for(U32 i = 0; i < mLineBreakPairCount; i++)
+   for(U32 i = 0; i < lineBreakPairCount; i++)
    {
-      U32 *p = mLineBreakPairs + i * 2;
+      U32 *p = lineBreakPairs + i * 2;
       if((p[0] >> 8) == lineNumber)
       {
-         mCode[p[1]] = p[0] & 0xFF;
+         code[p[1]] = p[0] & 0xFF;
          return;
       }
    }
@@ -156,26 +156,26 @@ void CodeBlock::clearBreakpoint(U32 lineNumber)
 
 void CodeBlock::setAllBreaks()
 {
-   if(!mLineBreakPairs)
+   if(!lineBreakPairs)
       return;
-   for(U32 i = 0; i < mLineBreakPairCount; i++)
+   for(U32 i = 0; i < lineBreakPairCount; i++)
    {
-      U32 *p = mLineBreakPairs + i * 2;
-      mCode[p[1]] = OP_BREAK;
+      U32 *p = lineBreakPairs + i * 2;
+      code[p[1]] = OP_BREAK;
    }
 }
 
 bool CodeBlock::setBreakpoint(U32 lineNumber)
 {
-   if(!mLineBreakPairs)
+   if(!lineBreakPairs)
       return false;
 
-   for(U32 i = 0; i < mLineBreakPairCount; i++)
+   for(U32 i = 0; i < lineBreakPairCount; i++)
    {
-      U32 *p = mLineBreakPairs + i * 2;
+      U32 *p = lineBreakPairs + i * 2;
       if((p[0] >> 8) == lineNumber)
       {
-         mCode[p[1]] = OP_BREAK;
+         code[p[1]] = OP_BREAK;
          return true;
       }
    }
@@ -185,12 +185,12 @@ bool CodeBlock::setBreakpoint(U32 lineNumber)
 
 U32 CodeBlock::findFirstBreakLine(U32 lineNumber)
 {
-   if(!mLineBreakPairs)
+   if(!lineBreakPairs)
       return 0;
 
-   for(U32 i = 0; i < mLineBreakPairCount; i++)
+   for(U32 i = 0; i < lineBreakPairCount; i++)
    {
-      U32 *p = mLineBreakPairs + i * 2;
+      U32 *p = lineBreakPairs + i * 2;
       U32 line = (p[0] >> 8);
 
       if( lineNumber <= line )
@@ -209,11 +209,11 @@ struct LinePair
 void CodeBlock::findBreakLine(U32 ip, U32 &line, U32 &instruction)
 {
    U32 min = 0;
-   U32 max = mLineBreakPairCount - 1;
-   LinePair *p = (LinePair *) mLineBreakPairs;
+   U32 max = lineBreakPairCount - 1;
+   LinePair *p = (LinePair *) lineBreakPairs;
 
    U32 found;
-   if(!mLineBreakPairCount || p[min].ip > ip || p[max].ip < ip)
+   if(!lineBreakPairCount || p[min].ip > ip || p[max].ip < ip)
    {
       line = 0;
       instruction = OP_INVALID;
@@ -254,17 +254,17 @@ const char *CodeBlock::getFileLine(U32 ip)
    U32 line, inst;
    findBreakLine(ip, line, inst);
 
-   dSprintf(nameBuffer, sizeof(nameBuffer), "%s (%d)", mName ? mName : "<input>", line);
+   dSprintf(nameBuffer, sizeof(nameBuffer), "%s (%d)", name ? name : "<input>", line);
    return nameBuffer;
 }
 
 void CodeBlock::removeFromCodeList()
 {
-   for(CodeBlock **walk = &smCodeBlockList; *walk; walk = &((*walk)->mNextFile))
+   for(CodeBlock **walk = &smCodeBlockList; *walk; walk = &((*walk)->nextFile))
    {
       if(*walk == this)
       {
-         *walk = mNextFile;
+         *walk = nextFile;
 
          // clear out all breakpoints
          clearAllBreaks();
@@ -285,9 +285,9 @@ void CodeBlock::calcBreakList()
    S32 line = -1;
    U32 seqCount = 0;
    U32 i;
-   for(i = 0; i < mLineBreakPairCount; i++)
+   for(i = 0; i < lineBreakPairCount; i++)
    {
-      U32 lineNumber = mLineBreakPairs[i * 2];
+      U32 lineNumber = lineBreakPairs[i * 2];
       if(lineNumber == U32(line + 1))
          seqCount++;
       else
@@ -302,23 +302,23 @@ void CodeBlock::calcBreakList()
    if(seqCount)
       size++;
 
-   mBreakList = new U32[size];
-   mBreakListSize = size;
+   breakList = new U32[size];
+   breakListSize = size;
    line = -1;
    seqCount = 0;
    size = 0;
 
-   for(i = 0; i < mLineBreakPairCount; i++)
+   for(i = 0; i < lineBreakPairCount; i++)
    {
-      U32 lineNumber = mLineBreakPairs[i * 2];
+      U32 lineNumber = lineBreakPairs[i * 2];
 
       if(lineNumber == U32(line + 1))
          seqCount++;
       else
       {
          if(seqCount)
-            mBreakList[size++] = seqCount;
-         mBreakList[size++] = lineNumber - getMax(0, line) - 1;
+            breakList[size++] = seqCount;
+         breakList[size++] = lineNumber - getMax(0, line) - 1;
          seqCount = 1;
       }
 
@@ -326,12 +326,12 @@ void CodeBlock::calcBreakList()
    }
 
    if(seqCount)
-      mBreakList[size++] = seqCount;
+      breakList[size++] = seqCount;
 
-   for(i = 0; i < mLineBreakPairCount; i++)
+   for(i = 0; i < lineBreakPairCount; i++)
    {
-      U32 *p = mLineBreakPairs + i * 2;
-      p[0] = (p[0] << 8) | mCode[p[1]];
+      U32 *p = lineBreakPairs + i * 2;
+      p[0] = (p[0] << 8) | code[p[1]];
    }
 
    // Let the telnet debugger know that this code
@@ -346,27 +346,27 @@ bool CodeBlock::read(StringTableEntry fileName, Stream &st)
    const StringTableEntry exePath = Platform::getMainDotCsDir();
    const StringTableEntry cwd = Platform::getCurrentDirectory();
 
-   mName = fileName;
+   name = fileName;
 
    if(fileName)
    {
-      mFullPath = NULL;
+      fullPath = NULL;
 
       if(Platform::isFullPath(fileName))
-         mFullPath = fileName;
+         fullPath = fileName;
 
       if(dStrnicmp(exePath, fileName, dStrlen(exePath)) == 0)
-         mName = StringTable->insert(fileName + dStrlen(exePath) + 1, true);
+         name = StringTable->insert(fileName + dStrlen(exePath) + 1, true);
       else if(dStrnicmp(cwd, fileName, dStrlen(cwd)) == 0)
-         mName = StringTable->insert(fileName + dStrlen(cwd) + 1, true);
+         name = StringTable->insert(fileName + dStrlen(cwd) + 1, true);
 
-      if(mFullPath == NULL)
+      if(fullPath == NULL)
       {
          char buf[1024];
-         mFullPath = StringTable->insert(Platform::makeFullPathName(fileName, buf, sizeof(buf)), true);
+         fullPath = StringTable->insert(Platform::makeFullPathName(fileName, buf, sizeof(buf)), true);
       }
 
-      mModPath = Con::getModNameFromPath(fileName);
+      modPath = Con::getModNameFromPath(fileName);
    }
    
    //
@@ -376,53 +376,53 @@ bool CodeBlock::read(StringTableEntry fileName, Stream &st)
    st.read(&size);
    if(size)
    {
-      mGlobalStrings = new char[size];
-      mGlobalStringsMaxLen = size;
-      st.read(size, mGlobalStrings);
+      globalStrings = new char[size];
+      globalStringsMaxLen = size;
+      st.read(size, globalStrings);
    }
    globalSize = size;
    st.read(&size);
    if(size)
    {
-      mFunctionStrings = new char[size];
-      mFunctionStringsMaxLen = size;
-      st.read(size, mFunctionStrings);
+      functionStrings = new char[size];
+      functionStringsMaxLen = size;
+      st.read(size, functionStrings);
    }
    st.read(&size);
    if(size)
    {
-      mGlobalFloats = new F64[size];
+      globalFloats = new F64[size];
       for(U32 i = 0; i < size; i++)
-         st.read(&mGlobalFloats[i]);
+         st.read(&globalFloats[i]);
    }
    st.read(&size);
    if(size)
    {
-      mFunctionFloats = new F64[size];
+      functionFloats = new F64[size];
       for(U32 i = 0; i < size; i++)
-         st.read(&mFunctionFloats[i]);
+         st.read(&functionFloats[i]);
    }
    U32 codeLength;
    st.read(&codeLength);
-   st.read(&mLineBreakPairCount);
+   st.read(&lineBreakPairCount);
 
-   U32 totSize = codeLength + mLineBreakPairCount * 2;
-   mCode = new U32[totSize];
+   U32 totSize = codeLength + lineBreakPairCount * 2;
+   code = new U32[totSize];
 
    for(i = 0; i < codeLength; i++)
    {
       U8 b;
       st.read(&b);
       if(b == 0xFF)
-         st.read(&mCode[i]);
+         st.read(&code[i]);
       else
-         mCode[i] = b;
+         code[i] = b;
    }
 
    for(i = codeLength; i < totSize; i++)
-      st.read(&mCode[i]);
+      st.read(&code[i]);
 
-   mLineBreakPairs = mCode + codeLength;
+   lineBreakPairs = code + codeLength;
 
    // StringTable-ize our identifiers.
    U32 identCount;
@@ -433,7 +433,7 @@ bool CodeBlock::read(StringTableEntry fileName, Stream &st)
       st.read(&offset);
       StringTableEntry ste;
       if(offset < globalSize)
-         ste = StringTable->insert(mGlobalStrings + offset);
+         ste = StringTable->insert(globalStrings + offset);
       else
          ste = StringTable->insert("");
       U32 count;
@@ -442,11 +442,11 @@ bool CodeBlock::read(StringTableEntry fileName, Stream &st)
       {
          U32 ip;
          st.read(&ip);
-         mCode[ip] = *((U32 *) &ste);
+         code[ip] = *((U32 *) &ste);
       }
    }
 
-   if(mLineBreakPairCount)
+   if(lineBreakPairCount)
       calcBreakList();
 
    return true;
@@ -519,14 +519,14 @@ bool CodeBlock::compile(const char *codeFileName, StringTableEntry fileName, con
    }
    else
    {
-      mCodeSize = 1;
+      codeSize = 1;
       lastIp = 0;
    }
    
    codeStream.emit(OP_RETURN);
-   codeStream.emitCodeStream(&mCodeSize, &mCode, &mLineBreakPairs);
+   codeStream.emitCodeStream(&codeSize, &code, &lineBreakPairs);
    
-   mLineBreakPairCount = codeStream.getNumLineBreaks();
+   lineBreakPairCount = codeStream.getNumLineBreaks();
 
    // Write string table data...
    getGlobalStringTable().write(st);
@@ -536,29 +536,29 @@ bool CodeBlock::compile(const char *codeFileName, StringTableEntry fileName, con
    getGlobalFloatTable().write(st);
    getFunctionFloatTable().write(st);
 
-   if(lastIp != mCodeSize)
+   if(lastIp != codeSize)
       Con::errorf(ConsoleLogEntry::General, "CodeBlock::compile - precompile size mismatch, a precompile/compile function pair is probably mismatched.");
    
-   U32 totSize = mCodeSize + codeStream.getNumLineBreaks() * 2;
-   st.write(mCodeSize);
-   st.write(mLineBreakPairCount);
+   U32 totSize = codeSize + codeStream.getNumLineBreaks() * 2;
+   st.write(codeSize);
+   st.write(lineBreakPairCount);
 
    // Write out our bytecode, doing a bit of compression for low numbers.
    U32 i;   
-   for(i = 0; i < mCodeSize; i++)
+   for(i = 0; i < codeSize; i++)
    {
-      if(mCode[i] < 0xFF)
-         st.write(U8(mCode[i]));
+      if(code[i] < 0xFF)
+         st.write(U8(code[i]));
       else
       {
          st.write(U8(0xFF));
-         st.write(mCode[i]);
+         st.write(code[i]);
       }
    }
 
    // Write the break info...
-   for(i = mCodeSize; i < totSize; i++)
-      st.write(mCode[i]);
+   for(i = codeSize; i < totSize; i++)
+      st.write(code[i]);
 
    getIdentTable().write(st);
 
@@ -581,33 +581,33 @@ ConsoleValueRef CodeBlock::compileExec(StringTableEntry fileName, const char *in
    STEtoCode = evalSTEtoCode;
    consoleAllocReset();
 
-   mName = fileName;
+   name = fileName;
 
    if(fileName)
    {
       const StringTableEntry exePath = Platform::getMainDotCsDir();
       const StringTableEntry cwd = Platform::getCurrentDirectory();
 
-      mFullPath = NULL;
+      fullPath = NULL;
       
       if(Platform::isFullPath(fileName))
-         mFullPath = fileName;
+         fullPath = fileName;
 
       if(dStrnicmp(exePath, fileName, dStrlen(exePath)) == 0)
-         mName = StringTable->insert(fileName + dStrlen(exePath) + 1, true);
+         name = StringTable->insert(fileName + dStrlen(exePath) + 1, true);
       else if(dStrnicmp(cwd, fileName, dStrlen(cwd)) == 0)
-         mName = StringTable->insert(fileName + dStrlen(cwd) + 1, true);
+         name = StringTable->insert(fileName + dStrlen(cwd) + 1, true);
 
-      if(mFullPath == NULL)
+      if(fullPath == NULL)
       {
          char buf[1024];
-         mFullPath = StringTable->insert(Platform::makeFullPathName(fileName, buf, sizeof(buf)), true);
+         fullPath = StringTable->insert(Platform::makeFullPathName(fileName, buf, sizeof(buf)), true);
       }
 
-      mModPath = Con::getModNameFromPath(fileName);
+      modPath = Con::getModNameFromPath(fileName);
    }
 
-   if(mName)
+   if(name)
       addToCodeList();
    
    gStatementList = NULL;
@@ -645,29 +645,29 @@ ConsoleValueRef CodeBlock::compileExec(StringTableEntry fileName, const char *in
    CodeStream codeStream;
    U32 lastIp = compileBlock(gStatementList, codeStream, 0);
 
-   mLineBreakPairCount = codeStream.getNumLineBreaks();
+   lineBreakPairCount = codeStream.getNumLineBreaks();
 
-   mGlobalStrings   = getGlobalStringTable().build();
-   mGlobalStringsMaxLen = getGlobalStringTable().totalLen;
+   globalStrings   = getGlobalStringTable().build();
+   globalStringsMaxLen = getGlobalStringTable().totalLen;
 
-   mFunctionStrings = getFunctionStringTable().build();
-   mFunctionStringsMaxLen = getFunctionStringTable().totalLen;
+   functionStrings = getFunctionStringTable().build();
+   functionStringsMaxLen = getFunctionStringTable().totalLen;
 
-   mGlobalFloats    = getGlobalFloatTable().build();
-   mFunctionFloats  = getFunctionFloatTable().build();
+   globalFloats    = getGlobalFloatTable().build();
+   functionFloats  = getFunctionFloatTable().build();
    
    codeStream.emit(OP_RETURN);
-   codeStream.emitCodeStream(&mCodeSize, &mCode, &mLineBreakPairs);
+   codeStream.emitCodeStream(&codeSize, &code, &lineBreakPairs);
    
    //dumpInstructions(0, false);
    
    consoleAllocReset();
 
-   if(mLineBreakPairCount && fileName)
+   if(lineBreakPairCount && fileName)
       calcBreakList();
 
-   if(lastIp+1 != mCodeSize)
-      Con::warnf(ConsoleLogEntry::General, "precompile size mismatch, precompile: %d compile: %d", mCodeSize, lastIp);
+   if(lastIp+1 != codeSize)
+      Con::warnf(ConsoleLogEntry::General, "precompile size mismatch, precompile: %d compile: %d", codeSize, lastIp);
 
    return exec(0, fileName, NULL, 0, 0, noCalls, NULL, setFrame);
 }
@@ -676,13 +676,13 @@ ConsoleValueRef CodeBlock::compileExec(StringTableEntry fileName, const char *in
 
 void CodeBlock::incRefCount()
 {
-   mRefCount++;
+   refCount++;
 }
 
 void CodeBlock::decRefCount()
 {
-   mRefCount--;
-   if(!mRefCount)
+   refCount--;
+   if(!refCount)
       delete this;
 }
 
@@ -692,10 +692,10 @@ String CodeBlock::getFunctionArgs( U32 ip )
 {
    StringBuilder str;
    
-   U32 fnArgc = mCode[ ip + 5 ];
+   U32 fnArgc = code[ ip + 5 ];
    for( U32 i = 0; i < fnArgc; ++ i )
    {
-      StringTableEntry var = CodeToSTE(mCode, ip + (i*2) + 6);
+      StringTableEntry var = CodeToSTE(code, ip + (i*2) + 6);
       
       if( i != 0 )
          str.append( ", " );
@@ -720,24 +720,24 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
    smInFunction = false;
    U32 endFuncIp = 0;
    
-   while( ip < mCodeSize )
+   while( ip < codeSize )
    {
       if (ip > endFuncIp)
       {
          smInFunction = false;
       }
       
-      switch( mCode[ ip ++ ] )
+      switch( code[ ip ++ ] )
       {
             
          case OP_FUNC_DECL:
          {
-            StringTableEntry fnName       = CodeToSTE(mCode, ip);
-            StringTableEntry fnNamespace  = CodeToSTE(mCode, ip+2);
-            StringTableEntry fnPackage    = CodeToSTE(mCode, ip+4);
-            bool hasBody = bool(mCode[ip+6]);
-            U32 newIp = mCode[ ip + 7 ];
-            U32 argc = mCode[ ip + 8 ];
+            StringTableEntry fnName       = CodeToSTE(code, ip);
+            StringTableEntry fnNamespace  = CodeToSTE(code, ip+2);
+            StringTableEntry fnPackage    = CodeToSTE(code, ip+4);
+            bool hasBody = bool(code[ip+6]);
+            U32 newIp = code[ ip + 7 ];
+            U32 argc = code[ ip + 8 ];
             endFuncIp = newIp;
             
             Con::printf( "%i: OP_FUNC_DECL name=%s nspace=%s package=%s hasbody=%i newip=%i argc=%i",
@@ -752,12 +752,12 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
             
          case OP_CREATE_OBJECT:
          {
-            StringTableEntry objParent = CodeToSTE(mCode, ip);
-            bool isDataBlock =          mCode[ip + 2];
-            bool isInternal  =          mCode[ip + 3];
-            bool isSingleton =          mCode[ip + 4];
-            U32  lineNumber  =          mCode[ip + 5];
-            U32 failJump     =          mCode[ip + 6];
+            StringTableEntry objParent = CodeToSTE(code, ip);
+            bool isDataBlock =          code[ip + 2];
+            bool isInternal  =          code[ip + 3];
+            bool isSingleton =          code[ip + 4];
+            U32  lineNumber  =          code[ip + 5];
+            U32 failJump     =          code[ip + 6];
             
             Con::printf( "%i: OP_CREATE_OBJECT objParent=%s isDataBlock=%i isInternal=%i isSingleton=%i lineNumber=%i failJump=%i",
                ip - 1, objParent, isDataBlock, isInternal, isSingleton, lineNumber, failJump );
@@ -768,14 +768,14 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_ADD_OBJECT:
          {
-            bool placeAtRoot = mCode[ip++];
+            bool placeAtRoot = code[ip++];
             Con::printf( "%i: OP_ADD_OBJECT placeAtRoot=%i", ip - 1, placeAtRoot );
             break;
          }
          
          case OP_END_OBJECT:
          {
-            bool placeAtRoot = mCode[ip++];
+            bool placeAtRoot = code[ip++];
             Con::printf( "%i: OP_END_OBJECT placeAtRoot=%i", ip - 1, placeAtRoot );
             break;
          }
@@ -788,49 +788,49 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
          
          case OP_JMPIFFNOT:
          {
-            Con::printf( "%i: OP_JMPIFFNOT ip=%i", ip - 1, mCode[ ip ] );
+            Con::printf( "%i: OP_JMPIFFNOT ip=%i", ip - 1, code[ ip ] );
             ++ ip;
             break;
          }
          
          case OP_JMPIFNOT:
          {
-            Con::printf( "%i: OP_JMPIFNOT ip=%i", ip - 1, mCode[ ip ] );
+            Con::printf( "%i: OP_JMPIFNOT ip=%i", ip - 1, code[ ip ] );
             ++ ip;
             break;
          }
          
          case OP_JMPIFF:
          {
-            Con::printf( "%i: OP_JMPIFF ip=%i", ip - 1, mCode[ ip ] );
+            Con::printf( "%i: OP_JMPIFF ip=%i", ip - 1, code[ ip ] );
             ++ ip;
             break;
          }
 
          case OP_JMPIF:
          {
-            Con::printf( "%i: OP_JMPIF ip=%i", ip - 1, mCode[ ip ] );
+            Con::printf( "%i: OP_JMPIF ip=%i", ip - 1, code[ ip ] );
             ++ ip;
             break;
          }
 
          case OP_JMPIFNOT_NP:
          {
-            Con::printf( "%i: OP_JMPIFNOT_NP ip=%i", ip - 1, mCode[ ip ] );
+            Con::printf( "%i: OP_JMPIFNOT_NP ip=%i", ip - 1, code[ ip ] );
             ++ ip;
             break;
          }
 
          case OP_JMPIF_NP:
          {
-            Con::printf( "%i: OP_JMPIF_NP ip=%i", ip - 1, mCode[ ip ] );
+            Con::printf( "%i: OP_JMPIF_NP ip=%i", ip - 1, code[ ip ] );
             ++ ip;
             break;
          }
 
          case OP_JMP:
          {
-            Con::printf( "%i: OP_JMP ip=%i", ip - 1, mCode[ ip ] );
+            Con::printf( "%i: OP_JMP ip=%i", ip - 1, code[ ip ] );
             ++ ip;
             break;
          }
@@ -1009,7 +1009,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_SETCURVAR:
          {
-            StringTableEntry var = CodeToSTE(mCode, ip);
+            StringTableEntry var = CodeToSTE(code, ip);
             
             Con::printf( "%i: OP_SETCURVAR var=%s", ip - 1, var );
             ip += 2;
@@ -1018,7 +1018,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
          
          case OP_SETCURVAR_CREATE:
          {
-            StringTableEntry var = CodeToSTE(mCode, ip);
+            StringTableEntry var = CodeToSTE(code, ip);
             
             Con::printf( "%i: OP_SETCURVAR_CREATE var=%s", ip - 1, var );
             ip += 2;
@@ -1106,7 +1106,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
          
          case OP_SETCURFIELD:
          {
-            StringTableEntry curField = CodeToSTE(mCode, ip);
+            StringTableEntry curField = CodeToSTE(code, ip);
             Con::printf( "%i: OP_SETCURFIELD field=%s", ip - 1, curField );
             ip += 2;
             break;
@@ -1120,7 +1120,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_SETCURFIELD_TYPE:
          {
-            U32 type = mCode[ ip ];
+            U32 type = code[ ip ];
             Con::printf( "%i: OP_SETCURFIELD_TYPE type=%i", ip - 1, type );
             ++ ip;
             break;
@@ -1224,7 +1224,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_LOADIMMED_UINT:
          {
-            U32 val = mCode[ ip ];
+            U32 val = code[ ip ];
             Con::printf( "%i: OP_LOADIMMED_UINT val=%i", ip - 1, val );
             ++ ip;
             break;
@@ -1232,7 +1232,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_LOADIMMED_FLT:
          {
-            F64 val = (smInFunction ? mFunctionFloats : mGlobalFloats)[ mCode[ ip ] ];
+            F64 val = (smInFunction ? functionFloats : globalFloats)[ code[ ip ] ];
             Con::printf( "%i: OP_LOADIMMED_FLT val=%f", ip - 1, val );
             ++ ip;
             break;
@@ -1240,7 +1240,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_TAG_TO_STR:
          {
-            const char* str = (smInFunction ? mFunctionStrings : mGlobalStrings) + mCode[ ip ];
+            const char* str = (smInFunction ? functionStrings : globalStrings) + code[ ip ];
             Con::printf( "%i: OP_TAG_TO_STR str=%s", ip - 1, str );
             ++ ip;
             break;
@@ -1248,7 +1248,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
          
          case OP_LOADIMMED_STR:
          {
-            const char* str = (smInFunction ? mFunctionStrings : mGlobalStrings) + mCode[ ip ];
+            const char* str = (smInFunction ? functionStrings : globalStrings) + code[ ip ];
             Con::printf( "%i: OP_LOADIMMED_STR str=%s", ip - 1, str );
             ++ ip;
             break;
@@ -1256,7 +1256,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_DOCBLOCK_STR:
          {
-            const char* str = (smInFunction ? mFunctionStrings : mGlobalStrings) + mCode[ ip ];
+            const char* str = (smInFunction ? functionStrings : globalStrings) + code[ ip ];
             Con::printf( "%i: OP_DOCBLOCK_STR str=%s", ip - 1, str );
             ++ ip;
             break;
@@ -1264,7 +1264,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
          
          case OP_LOADIMMED_IDENT:
          {
-            StringTableEntry str = CodeToSTE(mCode, ip);
+            StringTableEntry str = CodeToSTE(code, ip);
             Con::printf( "%i: OP_LOADIMMED_IDENT str=%s", ip - 1, str );
             ip += 2;
             break;
@@ -1272,9 +1272,9 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_CALLFUNC_RESOLVE:
          {
-            StringTableEntry fnNamespace = CodeToSTE(mCode, ip+2);
-            StringTableEntry fnName      = CodeToSTE(mCode, ip);
-            U32 callType = mCode[ip+2];
+            StringTableEntry fnNamespace = CodeToSTE(code, ip+2);
+            StringTableEntry fnName      = CodeToSTE(code, ip);
+            U32 callType = code[ip+2];
 
             Con::printf( "%i: OP_CALLFUNC_RESOLVE name=%s nspace=%s callType=%s", ip - 1, fnName, fnNamespace,
                callType == FuncCallExprNode::FunctionCall ? "FunctionCall"
@@ -1286,9 +1286,9 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
          
          case OP_CALLFUNC:
          {
-            StringTableEntry fnNamespace = CodeToSTE(mCode, ip+2);
-            StringTableEntry fnName      = CodeToSTE(mCode, ip);
-            U32 callType = mCode[ip+4];
+            StringTableEntry fnNamespace = CodeToSTE(code, ip+2);
+            StringTableEntry fnName      = CodeToSTE(code, ip);
+            U32 callType = code[ip+4];
 
             Con::printf( "%i: OP_CALLFUNC name=%s nspace=%s callType=%s", ip - 1, fnName, fnNamespace,
                callType == FuncCallExprNode::FunctionCall ? "FunctionCall"
@@ -1306,7 +1306,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_ADVANCE_STR_APPENDCHAR:
          {
-            char ch = mCode[ ip ];
+            char ch = code[ ip ];
             Con::printf( "%i: OP_ADVANCE_STR_APPENDCHAR char=%c", ip - 1, ch );
             ++ ip;
             break;
@@ -1374,7 +1374,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_ASSERT:
          {
-            const char* message = (smInFunction ? mFunctionStrings : mGlobalStrings) + mCode[ ip ];
+            const char* message = (smInFunction ? functionStrings : globalStrings) + code[ ip ];
             Con::printf( "%i: OP_ASSERT message=%s", ip - 1, message );
             ++ ip;
             break;
@@ -1388,8 +1388,8 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
          
          case OP_ITER_BEGIN:
          {
-            StringTableEntry varName = CodeToSTE(mCode, ip);
-            U32 failIp = mCode[ ip + 2 ];
+            StringTableEntry varName = CodeToSTE(code, ip);
+            U32 failIp = code[ ip + 2 ];
             
             Con::printf( "%i: OP_ITER_BEGIN varName=%s failIp=%i", ip - 1, varName, failIp );
 
@@ -1399,8 +1399,8 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
 
          case OP_ITER_BEGIN_STR:
          {
-            StringTableEntry varName = CodeToSTE(mCode, ip);
-            U32 failIp = mCode[ ip + 2 ];
+            StringTableEntry varName = CodeToSTE(code, ip);
+            U32 failIp = code[ ip + 2 ];
             
             Con::printf( "%i: OP_ITER_BEGIN varName=%s failIp=%i", ip - 1, varName, failIp );
 
@@ -1410,7 +1410,7 @@ void CodeBlock::dumpInstructions( U32 startIp, bool upToReturn )
          
          case OP_ITER:
          {
-            U32 breakIp = mCode[ ip ];
+            U32 breakIp = code[ ip ];
             
             Con::printf( "%i: OP_ITER breakIp=%i", ip - 1, breakIp );
 

--- a/Engine/source/console/codeBlock.h
+++ b/Engine/source/console/codeBlock.h
@@ -61,28 +61,28 @@ public:
    CodeBlock();
    ~CodeBlock();
 
-   StringTableEntry mName;
-   StringTableEntry mFullPath;
-   StringTableEntry mModPath;
+   StringTableEntry name;
+   StringTableEntry fullPath;
+   StringTableEntry modPath;
 
-   char *mGlobalStrings;
-   char *mFunctionStrings;
+   char *globalStrings;
+   char *functionStrings;
 
-   U32 mFunctionStringsMaxLen;
-   U32 mGlobalStringsMaxLen;
+   U32 functionStringsMaxLen;
+   U32 globalStringsMaxLen;
 
-   F64 *mGlobalFloats;
-   F64 *mFunctionFloats;
+   F64 *globalFloats;
+   F64 *functionFloats;
 
-   U32 mCodeSize;
-   U32 *mCode;
+   U32 codeSize;
+   U32 *code;
 
-   U32 mRefCount;
-   U32 mLineBreakPairCount;
-   U32 *mLineBreakPairs;
-   U32 mBreakListSize;
-   U32 *mBreakList;
-   CodeBlock *mNextFile;
+   U32 refCount;
+   U32 lineBreakPairCount;
+   U32 *lineBreakPairs;
+   U32 breakListSize;
+   U32 *breakList;
+   CodeBlock *nextFile;
 
    void addToCodeList();
    void removeFromCodeList();

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -2159,8 +2159,8 @@ DefineConsoleMethod( SimObject, dumpMethods, ArrayObject*, (),,
       str.append( e->getPrototypeString() );
 
       str.append( '\n' );
-      if( e->mCode && e->mCode->mFullPath )
-         str.append( e->mCode->mFullPath );
+      if( e->mCode && e->mCode->fullPath )
+         str.append( e->mCode->fullPath );
       str.append( '\n' );
       if( e->mCode )
          str.append( String::ToString( e->mFunctionLineNumber ) );

--- a/Engine/source/console/telnetDebugger.cpp
+++ b/Engine/source/console/telnetDebugger.cpp
@@ -384,7 +384,7 @@ void TelnetDebugger::executionStopped(CodeBlock *code, U32 lineNumber)
       return;
    }
 
-   Breakpoint **bp = findBreakpoint(code->mName, lineNumber);
+   Breakpoint **bp = findBreakpoint(code->name, lineNumber);
    if(!bp)
       return;
    
@@ -398,7 +398,7 @@ void TelnetDebugger::executionStopped(CodeBlock *code, U32 lineNumber)
       {
          brk->curCount = 0;
          if(brk->clearOnHit)
-            removeBreakpoint(code->mName, lineNumber);
+            removeBreakpoint(code->name, lineNumber);
          breakProcess();
       }
    }
@@ -457,8 +457,8 @@ void TelnetDebugger::sendBreak()
    {
       CodeBlock *code = gEvalState.stack[i]->code;
       const char *file = "<none>";
-      if (code && code->mName && code->mName[0])
-         file = code->mName;
+      if (code && code->name && code->name[0])
+         file = code->name;
 
       Namespace *ns = gEvalState.stack[i]->scopeNamespace;
       scope[0] = 0;
@@ -582,7 +582,7 @@ void TelnetDebugger::addAllBreakpoints(CodeBlock *code)
    {
       // TODO: This assumes that the OS file names are case 
       // insensitive... Torque needs a dFilenameCmp() function.
-      if( dStricmp( cur->fileName, code->mName ) == 0 )
+      if( dStricmp( cur->fileName, code->name ) == 0 )
 	   {
          cur->code = code;
 
@@ -776,7 +776,7 @@ void TelnetDebugger::setBreakOnNextStatement( bool enabled )
    if ( enabled )
    {
       // Apply breaks on all the code blocks.
-      for(CodeBlock *walk = CodeBlock::getCodeBlockList(); walk; walk = walk->mNextFile)
+      for(CodeBlock *walk = CodeBlock::getCodeBlockList(); walk; walk = walk->nextFile)
          walk->setAllBreaks();
       mBreakOnNextStatement = true;
    } 
@@ -784,7 +784,7 @@ void TelnetDebugger::setBreakOnNextStatement( bool enabled )
    {
       // Clear all the breaks on the codeblocks 
       // then go reapply the breakpoints.
-      for(CodeBlock *walk = CodeBlock::getCodeBlockList(); walk; walk = walk->mNextFile)
+      for(CodeBlock *walk = CodeBlock::getCodeBlockList(); walk; walk = walk->nextFile)
          walk->clearAllBreaks();
       for(Breakpoint *w = mBreakpoints; w; w = w->next)
 	  {
@@ -880,10 +880,10 @@ void TelnetDebugger::evaluateExpression(const char *tag, S32 frame, const char *
 void TelnetDebugger::dumpFileList()
 {
    send("FILELISTOUT ");
-   for(CodeBlock *walk = CodeBlock::getCodeBlockList(); walk; walk = walk->mNextFile)
+   for(CodeBlock *walk = CodeBlock::getCodeBlockList(); walk; walk = walk->nextFile)
    {
-      send(walk->mName);
-      if(walk->mNextFile)
+      send(walk->name);
+      if(walk->nextFile)
          send(" ");
    }
    send("\r\n");
@@ -896,11 +896,11 @@ void TelnetDebugger::dumpBreakableList(const char *fileName)
    char buffer[MaxCommandSize];
    if(file)
    {
-      dSprintf(buffer, MaxCommandSize, "BREAKLISTOUT %s %d", fileName, file->mBreakListSize >> 1);
+      dSprintf(buffer, MaxCommandSize, "BREAKLISTOUT %s %d", fileName, file->breakListSize >> 1);
       send(buffer);
-      for(U32 i = 0; i < file->mBreakListSize; i += 2)
+      for(U32 i = 0; i < file->breakListSize; i += 2)
       {
-         dSprintf(buffer, MaxCommandSize, " %d %d", file->mBreakList[i], file->mBreakList[i+1]);
+         dSprintf(buffer, MaxCommandSize, " %d %d", file->breakList[i], file->breakList[i+1]);
          send(buffer);
       }
       send("\r\n");

--- a/Engine/source/core/stream/bitStream.h
+++ b/Engine/source/core/stream/bitStream.h
@@ -48,13 +48,13 @@ class QuatF;
 class BitStream : public Stream
 {
 protected:
-   U8 *mDataPtr;
-   S32  mBitNum;
-   S32  mBufSize;
-   bool mError;
-   S32  mMaxReadBitNum;
-   S32  mMaxWriteBitNum;
-   char *mStringBuffer;
+   U8 *dataPtr;
+   S32  bitNum;
+   S32  bufSize;
+   bool error;
+   S32  maxReadBitNum;
+   S32  maxWriteBitNum;
+   char *stringBuffer;
    Point3F mCompressPoint;
 
    friend class HuffmanProcessor;
@@ -63,7 +63,7 @@ public:
    static void sendPacketStream(const NetAddress *addr);
 
    void setBuffer(void *bufPtr, S32 bufSize, S32 maxSize = 0);
-   U8*  getBuffer() { return mDataPtr; }
+   U8*  getBuffer() { return dataPtr; }
    U8*  getBytePtr();
 
    U32 getReadByteSize();
@@ -83,7 +83,7 @@ public:
    S32 getBitPosition() const { return getCurPos(); }
    void clearStringBuffer();
 
-   BitStream(void *bufPtr, S32 bufSize, S32 maxWriteSize = -1) { setBuffer(bufPtr, bufSize,maxWriteSize); mStringBuffer = NULL; }
+   BitStream(void *bufPtr, S32 bufSize, S32 maxWriteSize = -1) { setBuffer(bufPtr, bufSize,maxWriteSize); stringBuffer = NULL; }
    void clear();
 
    void setStringBuffer(char buffer[256]);
@@ -241,8 +241,8 @@ public:
    void setBit(S32 bitCount, bool set);
    bool testBit(S32 bitCount);
 
-   bool isFull() { return mBitNum > (mBufSize << 3); }
-   bool isValid() { return !mError; }
+   bool isFull() { return bitNum > (bufSize << 3); }
+   bool isValid() { return !error; }
 
    bool _read (const U32 size,void* d);
    bool _write(const U32 size,const void* d);
@@ -313,26 +313,26 @@ public:
 //
 inline S32 BitStream::getCurPos() const
 {
-   return mBitNum;
+   return bitNum;
 }
 
 inline void BitStream::setCurPos(const U32 in_position)
 {
-   AssertFatal(in_position < (U32)(mBufSize << 3), "Out of range bitposition");
-   mBitNum = S32(in_position);
+   AssertFatal(in_position < (U32)(bufSize << 3), "Out of range bitposition");
+   bitNum = S32(in_position);
 }
 
 inline bool BitStream::readFlag()
 {
-   if(mBitNum > mMaxReadBitNum)
+   if(bitNum > maxReadBitNum)
    {
-      mError = true;
+      error = true;
       AssertFatal(false, "Out of range read");
       return false;
    }
-   S32 mask = 1 << (mBitNum & 0x7);
-   bool ret = (*(mDataPtr + (mBitNum >> 3)) & mask) != 0;
-   mBitNum++;
+   S32 mask = 1 << (bitNum & 0x7);
+   bool ret = (*(dataPtr + (bitNum >> 3)) & mask) != 0;
+   bitNum++;
    return ret;
 }
 

--- a/Engine/source/forest/ts/tsForestItemData.cpp
+++ b/Engine/source/forest/ts/tsForestItemData.cpp
@@ -154,7 +154,7 @@ TSShapeInstance* TSForestItemData::_getShapeInstance() const
 void TSForestItemData::_checkLastDetail()
 {
    const S32 dl = mShape->mSmallestVisibleDL;
-   const TSDetail *detail = &mShape->mDetails[dl];
+   const TSDetail *detail = &mShape->details[dl];
 
    // TODO: Expose some real parameters to the datablock maybe?
    if ( detail->subShapeNum != -1 )
@@ -162,8 +162,8 @@ void TSForestItemData::_checkLastDetail()
       mShape->addImposter( mShapeFile, 10, 4, 0, 0, 256, 0, 0 );
 
       // HACK: If i don't do this it crashes!
-      while ( mShape->mDetailCollisionAccelerators.size() < mShape->mDetails.size() )
-         mShape->mDetailCollisionAccelerators.push_back( NULL );
+      while ( mShape->detailCollisionAccelerators.size() < mShape->details.size() )
+         mShape->detailCollisionAccelerators.push_back( NULL );
    }
 }
 
@@ -174,12 +174,12 @@ TSLastDetail* TSForestItemData::getLastDetail() const
       return NULL;
 
    const S32 dl = mShape->mSmallestVisibleDL;
-   const TSDetail* detail = &mShape->mDetails[dl];
+   const TSDetail* detail = &mShape->details[dl];
    if (  detail->subShapeNum >= 0 ||
-         mShape->mBillboardDetails.size() <= dl )
+         mShape->billboardDetails.size() <= dl )
       return NULL;
 
-   return mShape->mBillboardDetails[dl];
+   return mShape->billboardDetails[dl];
 }
 
 ForestCellBatch* TSForestItemData::allocateBatch() const
@@ -207,8 +207,8 @@ bool TSForestItemData::canBillboard( const SceneRenderState *state, const Forest
    if ( dl < 0 )
       return true;
 
-   const TSDetail *detail = &mShape->mDetails[dl];
-   if ( detail->subShapeNum < 0 && dl < mShape->mBillboardDetails.size() )
+   const TSDetail *detail = &mShape->details[dl];
+   if ( detail->subShapeNum < 0 && dl < mShape->billboardDetails.size() )
       return true;
 
    return false;

--- a/Engine/source/forest/ts/tsForestItemData.h
+++ b/Engine/source/forest/ts/tsForestItemData.h
@@ -88,7 +88,7 @@ public:
    const Vector<S32>& getLOSDetails() const { return mLOSDetails; }
 
    // ForestItemData
-   const Box3F& getObjBox() const { return mShape ? mShape->mBounds : Box3F::Invalid; }
+   const Box3F& getObjBox() const { return mShape ? mShape->bounds : Box3F::Invalid; }
    bool render( TSRenderState *rdata, const ForestItem& item ) const;
    ForestCellBatch* allocateBatch() const;
    bool canBillboard( const SceneRenderState *state, const ForestItem &item, F32 distToCamera ) const;

--- a/Engine/source/gui/editor/guiShapeEdPreview.cpp
+++ b/Engine/source/gui/editor/guiShapeEdPreview.cpp
@@ -331,7 +331,7 @@ void GuiShapeEdPreview::setCurrentDetail(S32 dl)
    if ( mModel )
    {
       S32 smallest = mModel->getShape()->mSmallestVisibleDL;
-      mModel->getShape()->mSmallestVisibleDL = mModel->getShape()->mDetails.size()-1;
+      mModel->getShape()->mSmallestVisibleDL = mModel->getShape()->details.size()-1;
       mModel->setCurrentDetail( dl );
       mModel->getShape()->mSmallestVisibleDL = smallest;
 
@@ -360,18 +360,18 @@ bool GuiShapeEdPreview::setObjectModel(const char* modelName)
       AssertFatal( mModel, avar("GuiShapeEdPreview: Failed to load model %s. Please check your model name and load a valid model.", modelName ));
 
       // Initialize camera values:
-      mOrbitPos = mModel->getShape()->mCenter;
+      mOrbitPos = mModel->getShape()->center;
 
       // Set camera move and zoom speed according to model size
-      mMoveSpeed = mModel->getShape()->mRadius / sMoveScaler;
-      mZoomSpeed = mModel->getShape()->mRadius / sZoomScaler;
+      mMoveSpeed = mModel->getShape()->radius / sMoveScaler;
+      mZoomSpeed = mModel->getShape()->radius / sZoomScaler;
 
       // Reset node selection
       mHoverNode = -1;
       mSelectedNode = -1;
       mSelectedObject = -1;
       mSelectedObjDetail = 0;
-      mProjectedNodes.setSize( mModel->getShape()->mNodes.size() );
+      mProjectedNodes.setSize( mModel->getShape()->nodes.size() );
 
       // Reset detail stats
       mCurrentDL = 0;
@@ -683,9 +683,9 @@ void GuiShapeEdPreview::refreshShape()
       mModel->initNodeTransforms();
       mModel->initMeshObjects();
 
-      mProjectedNodes.setSize( mModel->getShape()->mNodes.size() );
+      mProjectedNodes.setSize( mModel->getShape()->nodes.size() );
 
-      if ( mSelectedObject >= mModel->getShape()->mObjects.size() )
+      if ( mSelectedObject >= mModel->getShape()->objects.size() )
       {
          mSelectedObject = -1;
          mSelectedObjDetail = 0;
@@ -694,9 +694,9 @@ void GuiShapeEdPreview::refreshShape()
       // Re-compute the collision mesh stats
       mColMeshes = 0;
       mColPolys = 0;
-      for ( S32 i = 0; i < mModel->getShape()->mDetails.size(); i++ )
+      for ( S32 i = 0; i < mModel->getShape()->details.size(); i++ )
       {
-         const TSShape::Detail& det = mModel->getShape()->mDetails[i];
+         const TSShape::Detail& det = mModel->getShape()->details[i];
          const String& detName = mModel->getShape()->getName( det.nameIndex );
          if ( ( det.subShapeNum < 0 ) || !detName.startsWith( "collision-" ) )
             continue;
@@ -704,12 +704,12 @@ void GuiShapeEdPreview::refreshShape()
          mColPolys += det.polyCount;
 
          S32 od = det.objectDetailNum;
-         S32 start = mModel->getShape()->mSubShapeFirstObject[det.subShapeNum];
-         S32 end   = start + mModel->getShape()->mSubShapeNumObjects[det.subShapeNum];
+         S32 start = mModel->getShape()->subShapeFirstObject[det.subShapeNum];
+         S32 end   = start + mModel->getShape()->subShapeNumObjects[det.subShapeNum];
          for ( S32 j = start; j < end; j++ )
          {
-            const TSShape::Object &obj = mModel->getShape()->mObjects[j];
-            const TSMesh* mesh = ( od < obj.numMeshes ) ? mModel->getShape()->mMeshes[obj.startMeshIndex + od] : NULL;
+            const TSShape::Object &obj = mModel->getShape()->objects[j];
+            const TSMesh* mesh = ( od < obj.numMeshes ) ? mModel->getShape()->meshes[obj.startMeshIndex + od] : NULL;
             if ( mesh )
                mColMeshes++;
          }
@@ -850,7 +850,7 @@ void GuiShapeEdPreview::exportToCollada( const String& path )
    if ( mModel )
    {
       MatrixF orientation( true );
-      orientation.setPosition( mModel->getShape()->mBounds.getCenter() );
+      orientation.setPosition( mModel->getShape()->bounds.getCenter() );
       orientation.inverse();
 
       OptimizedPolyList polyList;
@@ -1135,8 +1135,8 @@ bool GuiShapeEdPreview::getCameraTransform(MatrixF* cameraMatrix)
       cameraMatrix->identity();
       if ( mModel )
       {
-         Point3F camPos = mModel->getShape()->mBounds.getCenter();
-         F32 offset = mModel->getShape()->mBounds.len();
+         Point3F camPos = mModel->getShape()->bounds.getCenter();
+         F32 offset = mModel->getShape()->bounds.len();
 
          switch (mDisplayType)
          {
@@ -1166,11 +1166,11 @@ void GuiShapeEdPreview::computeSceneBounds(Box3F& bounds)
 void GuiShapeEdPreview::updateDetailLevel(const SceneRenderState* state)
 {
    // Make sure current detail is valid
-   if ( !mModel->getShape()->mDetails.size() )
+   if ( !mModel->getShape()->details.size() )
       return;
 
-   if ( mModel->getCurrentDetail() >= mModel->getShape()->mDetails.size() )
-      setCurrentDetail( mModel->getShape()->mDetails.size() - 1 );
+   if ( mModel->getCurrentDetail() >= mModel->getShape()->details.size() )
+      setCurrentDetail( mModel->getShape()->details.size() - 1 );
 
    // Convert between FOV and distance so zoom is consistent between Perspective
    // and Orthographic views (conversion factor found by trial and error)
@@ -1193,7 +1193,7 @@ void GuiShapeEdPreview::updateDetailLevel(const SceneRenderState* state)
       setCurrentDetail( 0 );
 
    currentDetail = mModel->getCurrentDetail();
-   const TSShape::Detail& det = mModel->getShape()->mDetails[ currentDetail ];
+   const TSShape::Detail& det = mModel->getShape()->details[ currentDetail ];
 
    mDetailPolys = det.polyCount;
    mDetailSize = det.size;
@@ -1213,31 +1213,31 @@ void GuiShapeEdPreview::updateDetailLevel(const SceneRenderState* state)
    {
       Vector<U32> usedMaterials;
 
-      S32 start = mModel->getShape()->mSubShapeFirstObject[det.subShapeNum];
-      S32 end = start + mModel->getShape()->mSubShapeNumObjects[det.subShapeNum];
+      S32 start = mModel->getShape()->subShapeFirstObject[det.subShapeNum];
+      S32 end = start + mModel->getShape()->subShapeNumObjects[det.subShapeNum];
 
       for ( S32 iObj = start; iObj < end; iObj++ )
       {
-         const TSShape::Object& obj = mModel->getShape()->mObjects[iObj];
+         const TSShape::Object& obj = mModel->getShape()->objects[iObj];
 
          if ( obj.numMeshes <= currentDetail )
             continue;
 
-         const TSMesh* mesh = mModel->getShape()->mMeshes[ obj.startMeshIndex + currentDetail ];
+         const TSMesh* mesh = mModel->getShape()->meshes[ obj.startMeshIndex + currentDetail ];
          if ( !mesh )
             continue;
 
          // Count the number of draw calls and materials
-         mNumDrawCalls += mesh->mPrimitives.size();
-         for ( S32 iPrim = 0; iPrim < mesh->mPrimitives.size(); iPrim++ )
-            usedMaterials.push_back_unique( mesh->mPrimitives[iPrim].matIndex & TSDrawPrimitive::MaterialMask );
+         mNumDrawCalls += mesh->primitives.size();
+         for ( S32 iPrim = 0; iPrim < mesh->primitives.size(); iPrim++ )
+            usedMaterials.push_back_unique( mesh->primitives[iPrim].matIndex & TSDrawPrimitive::MaterialMask );
 
          // For skinned meshes, count the number of bones and weights
          if ( mesh->getMeshType() == TSMesh::SkinMeshType )
          {
             const TSSkinMesh* skin = dynamic_cast<const TSSkinMesh*>(mesh);
-            mNumBones += skin->mBatchData.initialTransforms.size();
-            mNumWeights += skin->mWeight.size();
+            mNumBones += skin->batchData.initialTransforms.size();
+            mNumWeights += skin->weight.size();
          }
       }
 
@@ -1262,7 +1262,7 @@ void GuiShapeEdPreview::updateThreads(F32 delta)
          continue;
 
       // Make sure thread priority matches sequence priority (which may have changed)
-      mModel->setPriority( thread.key, mModel->getShape()->mSequences[mModel->getSequence( thread.key )].priority );
+      mModel->setPriority( thread.key, mModel->getShape()->sequences[mModel->getSequence( thread.key )].priority );
 
       // Handle ping-pong
       if ( thread.pingpong && !mModel->isInTransition( thread.key ) )
@@ -1426,18 +1426,18 @@ void GuiShapeEdPreview::renderWorld(const RectI &updateRect)
       // Render the shape bounding box
       if ( mRenderBounds )
       {
-         Point3F boxSize = mModel->getShape()->mBounds.maxExtents - mModel->getShape()->mBounds.minExtents;
+         Point3F boxSize = mModel->getShape()->bounds.maxExtents - mModel->getShape()->bounds.minExtents;
 
          GFXStateBlockDesc desc;
          desc.fillMode = GFXFillWireframe;
-         GFX->getDrawUtil()->drawCube( desc, boxSize, mModel->getShape()->mCenter, ColorF::WHITE );
+         GFX->getDrawUtil()->drawCube( desc, boxSize, mModel->getShape()->center, ColorF::WHITE );
       }
 
       // Render the selected object bounding box
       if ( mRenderObjBox && ( mSelectedObject != -1 ) )
       {
-         const TSShape::Object& obj = mModel->getShape()->mObjects[mSelectedObject];
-         const TSMesh* mesh = ( mCurrentDL < obj.numMeshes ) ? mModel->getShape()->mMeshes[obj.startMeshIndex + mSelectedObjDetail] : NULL;
+         const TSShape::Object& obj = mModel->getShape()->objects[mSelectedObject];
+         const TSMesh* mesh = ( mCurrentDL < obj.numMeshes ) ? mModel->getShape()->meshes[obj.startMeshIndex + mSelectedObjDetail] : NULL;
          if ( mesh )
          {
             GFX->pushWorldMatrix();
@@ -1528,7 +1528,7 @@ void GuiShapeEdPreview::renderSunDirection() const
    {
       // Render four arrows aiming in the direction of the sun's light
       ColorI color( mFakeSun->getColor() );
-      F32 length = mModel->getShape()->mBounds.len() * 0.8f;
+      F32 length = mModel->getShape()->bounds.len() * 0.8f;
 
       // Get the sun's vectors
       Point3F fwd = mFakeSun->getTransform().getForwardVector();
@@ -1536,8 +1536,8 @@ void GuiShapeEdPreview::renderSunDirection() const
       Point3F right = mFakeSun->getTransform().getRightVector() * length / 8;
 
       // Calculate the start and end points of the first arrow (bottom left)
-      Point3F start = mModel->getShape()->mCenter - fwd * length - up/2 - right/2;
-      Point3F end = mModel->getShape()->mCenter - fwd * length / 3 - up/2 - right/2;
+      Point3F start = mModel->getShape()->center - fwd * length - up/2 - right/2;
+      Point3F end = mModel->getShape()->center - fwd * length / 3 - up/2 - right/2;
 
       GFXStateBlockDesc desc;
       desc.setZReadWrite( true, true );
@@ -1560,10 +1560,10 @@ void GuiShapeEdPreview::renderNodes() const
       GFX->setStateBlockByDesc( desc );
 
       PrimBuild::color( ColorI::WHITE );
-      PrimBuild::begin( GFXLineList, mModel->getShape()->mNodes.size() * 2 );
-      for ( S32 i = 0; i < mModel->getShape()->mNodes.size(); i++)
+      PrimBuild::begin( GFXLineList, mModel->getShape()->nodes.size() * 2 );
+      for ( S32 i = 0; i < mModel->getShape()->nodes.size(); i++)
       {
-         const TSShape::Node& node = mModel->getShape()->mNodes[i];
+         const TSShape::Node& node = mModel->getShape()->nodes[i];
          if (node.parentIndex >= 0)
          {
             Point3F start(mModel->mNodeTransforms[i].getPosition());
@@ -1576,7 +1576,7 @@ void GuiShapeEdPreview::renderNodes() const
       PrimBuild::end();
 
       // Render the node axes
-      for ( S32 i = 0; i < mModel->getShape()->mNodes.size(); i++)
+      for ( S32 i = 0; i < mModel->getShape()->nodes.size(); i++)
       {
          // Render the selected and hover nodes last (so they are on top)
          if ( ( i == mSelectedNode ) || ( i == mHoverNode ) )
@@ -1626,7 +1626,7 @@ void GuiShapeEdPreview::renderNodeAxes(S32 index, const ColorF& nodeColor) const
 
 void GuiShapeEdPreview::renderNodeName(S32 index, const ColorF& textColor) const
 {
-   const TSShape::Node& node = mModel->getShape()->mNodes[index];
+   const TSShape::Node& node = mModel->getShape()->nodes[index];
    const String& nodeName = mModel->getShape()->getName( node.nameIndex );
 
    Point2I pos( mProjectedNodes[index].x, mProjectedNodes[index].y + sNodeRectSize + 6 );
@@ -1641,9 +1641,9 @@ void GuiShapeEdPreview::renderCollisionMeshes() const
    {
       ConcretePolyList polylist;
       polylist.setTransform( &MatrixF::Identity, Point3F::One );
-      for ( S32 iDet = 0; iDet < mModel->getShape()->mDetails.size(); iDet++ )
+      for ( S32 iDet = 0; iDet < mModel->getShape()->details.size(); iDet++ )
       {
-         const TSShape::Detail& det = mModel->getShape()->mDetails[iDet];
+         const TSShape::Detail& det = mModel->getShape()->details[iDet];
          const String& detName = mModel->getShape()->getName( det.nameIndex );
 
          // Ignore non-collision details

--- a/Engine/source/lighting/common/blobShadow.cpp
+++ b/Engine/source/lighting/common/blobShadow.cpp
@@ -95,8 +95,8 @@ bool BlobShadow::shouldRender(F32 camDist)
    if (mShapeBase && mShapeBase->getFadeVal() < TSMesh::VISIBILITY_EPSILON)
       return false;
 
-   F32 shadowLen = 10.0f * mShapeInstance->getShape()->mRadius;
-   Point3F pos = mShapeInstance->getShape()->mCenter;
+   F32 shadowLen = 10.0f * mShapeInstance->getShape()->radius;
+   Point3F pos = mShapeInstance->getShape()->center;
 
    // this is a bit of a hack...move generic shadows towards feet/base of shape
    pos *= 0.5f;
@@ -182,7 +182,7 @@ void BlobShadow::setRadius(F32 radius)
 
 void BlobShadow::setRadius(TSShapeInstance * shapeInstance, const Point3F & scale)
 {
-   const Box3F & bounds = shapeInstance->getShape()->mBounds;
+   const Box3F & bounds = shapeInstance->getShape()->bounds;
    F32 dx = 0.5f * (bounds.maxExtents.x-bounds.minExtents.x) * scale.x;
    F32 dy = 0.5f * (bounds.maxExtents.y-bounds.minExtents.y) * scale.y;
    F32 dz = 0.5f * (bounds.maxExtents.z-bounds.minExtents.z) * scale.z;

--- a/Engine/source/sim/netStringTable.cpp
+++ b/Engine/source/sim/netStringTable.cpp
@@ -31,79 +31,79 @@ NetStringTable *gNetStringTable = NULL;
 
 NetStringTable::NetStringTable()
 {
-   mFirstFree = 1;
-   mFirstValid = 1;
+   firstFree = 1;
+   firstValid = 1;
 
-   mTable = (Entry *) dMalloc(sizeof(Entry) * InitialSize);
-   mSize = InitialSize;
+   table = (Entry *) dMalloc(sizeof(Entry) * InitialSize);
+   size = InitialSize;
    for(U32 i = 0; i < InitialSize; i++)
    {
-      mTable[i].next = i + 1;
-      mTable[i].refCount = 0;
-      mTable[i].scriptRefCount = 0;
+      table[i].next = i + 1;
+      table[i].refCount = 0;
+      table[i].scriptRefCount = 0;
    }
-   mTable[InitialSize-1].next = InvalidEntry;
+   table[InitialSize-1].next = InvalidEntry;
    for(U32 j = 0; j < HashTableSize; j++)
-      mHashTable[j] = 0;
-   mAllocator = new DataChunker(DataChunkerSize);
+      hashTable[j] = 0;
+   allocator = new DataChunker(DataChunkerSize);
 }
 
 NetStringTable::~NetStringTable()
 {
-   delete mAllocator;
-   dFree( mTable );
+   delete allocator;
+   dFree( table );
 }
 
 void NetStringTable::incStringRef(U32 id)
 {
-   AssertFatal(mTable[id].refCount != 0 || mTable[id].scriptRefCount != 0 , "Cannot inc ref count from zero.");
-   mTable[id].refCount++;
+   AssertFatal(table[id].refCount != 0 || table[id].scriptRefCount != 0 , "Cannot inc ref count from zero.");
+   table[id].refCount++;
 }
 
 void NetStringTable::incStringRefScript(U32 id)
 {
-   AssertFatal(mTable[id].refCount != 0 || mTable[id].scriptRefCount != 0 , "Cannot inc ref count from zero.");
-   mTable[id].scriptRefCount++;
+   AssertFatal(table[id].refCount != 0 || table[id].scriptRefCount != 0 , "Cannot inc ref count from zero.");
+   table[id].scriptRefCount++;
 }
 
 U32 NetStringTable::addString(const char *string)
 {
    U32 hash = _StringTable::hashString(string);
    U32 bucket = hash % HashTableSize;
-   for(U32 walk = mHashTable[bucket];walk; walk = mTable[walk].next)
+   for(U32 walk = hashTable[bucket];walk; walk = table[walk].next)
    {
-      if(!dStrcmp(mTable[walk].string, string))
+      if(!dStrcmp(table[walk].string, string))
       {
-         mTable[walk].refCount++;
+         table[walk].refCount++;
          return walk;
       }
    }
-   U32 e = mFirstFree;
-   mFirstFree = mTable[e].next;
-   if(mFirstFree == InvalidEntry)
+   U32 e = firstFree;
+   firstFree = table[e].next;
+   if(firstFree == InvalidEntry)
    {
       // in this case, we should expand the table for next time...
-      U32 newSize = mSize * 2;
-      mTable = (Entry *) dRealloc(mTable, newSize * sizeof(Entry));
-      for(U32 i = mSize; i < newSize; i++)
+      U32 newSize = size * 2;
+      table = (Entry *) dRealloc(table, newSize * sizeof(Entry));
+      for(U32 i = size; i < newSize; i++)
       {
-         mTable[i].next = i + 1;
-         mTable[i].refCount = 0;
-         mTable[i].scriptRefCount = 0;
+         table[i].next = i + 1;
+         table[i].refCount = 0;
+         table[i].scriptRefCount = 0;
       }
-      mFirstFree = mSize;
-      mTable[newSize - 1].next = InvalidEntry;
-      mSize = newSize;
+      firstFree = size;
+      table[newSize - 1].next = InvalidEntry;
+      size = newSize;
    }
-   mTable[e].refCount++;
-   mTable[e].string = (char *) mAllocator->alloc(dStrlen(string) + 1);
-   dStrcpy(mTable[e].string, string);
-   mTable[e].next = mHashTable[bucket];
-   mHashTable[bucket] = e;
-   mTable[e].link = mFirstValid;
-   mTable[mFirstValid].prevLink = e;
-   mFirstValid = e;
-   mTable[e].prevLink = 0;
+   table[e].refCount++;
+   table[e].string = (char *) allocator->alloc(dStrlen(string) + 1);
+   dStrcpy(table[e].string, string);
+   table[e].next = hashTable[bucket];
+   hashTable[bucket] = e;
+   table[e].link = firstValid;
+   table[firstValid].prevLink = e;
+   firstValid = e;
+   table[e].prevLink = 0;
    return e;
 }
 
@@ -114,75 +114,75 @@ U32 GameAddTaggedString(const char *string)
 
 const char *NetStringTable::lookupString(U32 id)
 {
-   if(mTable[id].refCount == 0 && mTable[id].scriptRefCount == 0)
+   if(table[id].refCount == 0 && table[id].scriptRefCount == 0)
       return NULL;
-   return mTable[id].string;
+   return table[id].string;
 }
 
 void NetStringTable::removeString(U32 id, bool script)
 {
    if(!script)
    {
-      AssertFatal(mTable[id].refCount != 0, "Error, ref count is already 0!!");
-      if(--mTable[id].refCount)
+      AssertFatal(table[id].refCount != 0, "Error, ref count is already 0!!");
+      if(--table[id].refCount)
          return;
-      if(mTable[id].scriptRefCount)
+      if(table[id].scriptRefCount)
          return;
    }
    else
    {
       // If both ref counts are already 0, this id is not valid. Ignore
       // the remove
-      if (mTable[id].scriptRefCount == 0 && mTable[id].refCount == 0)
+      if (table[id].scriptRefCount == 0 && table[id].refCount == 0)
          return;
 
-      if(mTable[id].scriptRefCount == 0 && mTable[id].refCount)
+      if(table[id].scriptRefCount == 0 && table[id].refCount)
       {
-         Con::errorf("removeTaggedString failed!  Ref count is already 0 for string: %s", mTable[id].string);
+         Con::errorf("removeTaggedString failed!  Ref count is already 0 for string: %s", table[id].string);
          return;
       }
-      if(--mTable[id].scriptRefCount)
+      if(--table[id].scriptRefCount)
          return;
-      if(mTable[id].refCount)
+      if(table[id].refCount)
          return;
    }
    // unlink first:
-   U32 prev = mTable[id].prevLink;
-   U32 next = mTable[id].link;
+   U32 prev = table[id].prevLink;
+   U32 next = table[id].link;
    if(next)
-      mTable[next].prevLink = prev;
+      table[next].prevLink = prev;
    if(prev)
-      mTable[prev].link = next;
+      table[prev].link = next;
    else
-      mFirstValid = next;
+      firstValid = next;
    // remove it from the hash table
-   U32 hash = _StringTable::hashString(mTable[id].string);
+   U32 hash = _StringTable::hashString(table[id].string);
    U32 bucket = hash % HashTableSize;
-   for(U32 *walk = &mHashTable[bucket];*walk; walk = &mTable[*walk].next)
+   for(U32 *walk = &hashTable[bucket];*walk; walk = &table[*walk].next)
    {
       if(*walk == id)
       {
-         *walk = mTable[id].next;
+         *walk = table[id].next;
          break;
       }
    }
-   mTable[id].next = mFirstFree;
-   mFirstFree = id;
+   table[id].next = firstFree;
+   firstFree = id;
 }
 
 void NetStringTable::repack()
 {
    DataChunker *newAllocator = new DataChunker(DataChunkerSize);
-   for(U32 walk = mFirstValid; walk; walk = mTable[walk].link)
+   for(U32 walk = firstValid; walk; walk = table[walk].link)
    {
-      const char *prevStr = mTable[walk].string;
+      const char *prevStr = table[walk].string;
 
 
-      mTable[walk].string = (char *) newAllocator->alloc(dStrlen(prevStr) + 1);
-      dStrcpy(mTable[walk].string, prevStr);
+      table[walk].string = (char *) newAllocator->alloc(dStrlen(prevStr) + 1);
+      dStrcpy(table[walk].string, prevStr);
    }
-   delete mAllocator;
-   mAllocator = newAllocator;
+   delete allocator;
+   allocator = newAllocator;
 }
 
 void NetStringTable::create()
@@ -249,21 +249,21 @@ void NetStringTable::dumpToConsole()
 {
    U32 count = 0;
    S32 maxIndex = -1;
-   for ( U32 i = 0; i < mSize; i++ )
+   for ( U32 i = 0; i < size; i++ )
    {
-      if ( mTable[i].refCount > 0 || mTable[i].scriptRefCount > 0)
+      if ( table[i].refCount > 0 || table[i].scriptRefCount > 0)
       {
-         Con::printf( "%d: \"%c%s%c\" REF: %d", i, 0x10, mTable[i].string, 0x11, mTable[i].refCount );
-         if ( maxIndex == -1 || mTable[i].refCount > mTable[maxIndex].refCount )
+         Con::printf( "%d: \"%c%s%c\" REF: %d", i, 0x10, table[i].string, 0x11, table[i].refCount );
+         if ( maxIndex == -1 || table[i].refCount > table[maxIndex].refCount )
             maxIndex = i;
          count++;
       }
    }
    Con::printf( ">> STRINGS: %d MAX REF COUNT: %d \"%c%s%c\" <<",
          count,
-         ( maxIndex == -1 ) ? 0 : mTable[maxIndex].refCount,
+         ( maxIndex == -1 ) ? 0 : table[maxIndex].refCount,
          0x10,
-         ( maxIndex == -1 ) ? "" : mTable[maxIndex].string,
+         ( maxIndex == -1 ) ? "" : table[maxIndex].string,
          0x11 );
 }
 

--- a/Engine/source/sim/netStringTable.h
+++ b/Engine/source/sim/netStringTable.h
@@ -60,14 +60,14 @@ class NetStringTable
       U32 prevLink;
       U32 seq;
    };
-   U32 mSize;
-   U32 mFirstFree;
-   U32 mFirstValid;
-   U32 mSequenceCount;
+   U32 size;
+   U32 firstFree;
+   U32 firstValid;
+   U32 sequenceCount;
 
-   Entry *mTable;
-   U32 mHashTable[HashTableSize];
-   DataChunker *mAllocator;
+   Entry *table;
+   U32 hashTable[HashTableSize];
+   DataChunker *allocator;
 
     NetStringTable();
    ~NetStringTable();

--- a/Engine/source/ts/collada/colladaAppMaterial.cpp
+++ b/Engine/source/ts/collada/colladaAppMaterial.cpp
@@ -82,9 +82,9 @@ ColladaAppMaterial::ColladaAppMaterial(const domMaterial *pMat)
    const domCommon_color_or_texture_type_complexType* domSpecular = findEffectSpecular(effect);
 
    // Wrap flags
-   if (effectExt->mWrapU)
+   if (effectExt->wrapU)
       flags |= TSMaterialList::S_Wrap;
-   if (effectExt->mWrapV)
+   if (effectExt->wrapV)
       flags |= TSMaterialList::T_Wrap;
 
    // Set material attributes
@@ -146,17 +146,17 @@ ColladaAppMaterial::ColladaAppMaterial(const domMaterial *pMat)
    }
 
    // Double-sided flag
-   doubleSided = effectExt->mDoubleSided;
+   doubleSided = effectExt->double_sided;
 
    // Get the paths for the various textures => Collada indirection at its finest!
    // <texture>.<newparam>.<sampler2D>.<source>.<newparam>.<surface>.<init_from>.<image>.<init_from>
    diffuseMap = getSamplerImagePath(effect, getTextureSampler(effect, domDiffuse));
    specularMap = getSamplerImagePath(effect, getTextureSampler(effect, domSpecular));
-   normalMap = getSamplerImagePath(effect, effectExt->mBumpSampler);
+   normalMap = getSamplerImagePath(effect, effectExt->bumpSampler);
 
    // Set the material name
-   name = ColladaUtils::getOptions().mMatNamePrefix;
-   if ( ColladaUtils::getOptions().mUseDiffuseNames )
+   name = ColladaUtils::getOptions().matNamePrefix;
+   if ( ColladaUtils::getOptions().useDiffuseNames )
    {
       Torque::Path diffusePath( diffuseMap );
       name += diffusePath.getFileName();

--- a/Engine/source/ts/collada/colladaAppMesh.cpp
+++ b/Engine/source/ts/collada/colladaAppMesh.cpp
@@ -40,8 +40,8 @@ namespace DictHash
 
 using namespace ColladaUtils;
 
-bool ColladaAppMesh::mFixedSizeEnabled = false;
-S32 ColladaAppMesh::mFixedSize = 2;
+bool ColladaAppMesh::fixedSizeEnabled = false;
+S32 ColladaAppMesh::fixedSize = 2;
 
 //-----------------------------------------------------------------------------
 // Define a VertTuple dictionary to allow fast tuple lookups
@@ -49,7 +49,7 @@ namespace DictHash
 {
    inline U32 hash(const VertTuple& data)
    {
-      return (U32)data.mVertex;
+      return (U32)data.vertex;
    }
 }
 
@@ -197,27 +197,27 @@ private:
 
 public:
 
-   _SourceReader     mPoints;
-   _SourceReader     mNormals;
-   _SourceReader     mColors;
-   _SourceReader     mUVs;
-   _SourceReader     mUV2s;
+   _SourceReader     points;
+   _SourceReader     normals;
+   _SourceReader     colors;
+   _SourceReader     uvs;
+   _SourceReader     uv2s;
 
-   _SourceReader     mJoints;
-   _SourceReader     mWeights;
-   _SourceReader     mInvBindMatrices;
+   _SourceReader     joints;
+   _SourceReader     weights;
+   _SourceReader     invBindMatrices;
 
    /// Clear the mesh streams
    void reset()
    {
-      mPoints.reset();
-      mNormals.reset();
-      mColors.reset();
-      mUVs.reset();
-      mUV2s.reset();
-      mJoints.reset();
-      mWeights.reset();
-      mInvBindMatrices.reset();
+      points.reset();
+      normals.reset();
+      colors.reset();
+      uvs.reset();
+      uv2s.reset();
+      joints.reset();
+      weights.reset();
+      invBindMatrices.reset();
    }
 
    /// Classify a set of inputs by type and set number (needs to be a template
@@ -283,32 +283,32 @@ public:
 
       // Attempt to initialise the SourceReaders
       const char* vertex_params[] = { "X", "Y", "Z", "" };
-      initSourceReader(sortedInputs[Points], Points, mPoints, vertex_params);
+      initSourceReader(sortedInputs[Points], Points, points, vertex_params);
 
       const char* normal_params[] = { "X", "Y", "Z", "" };
-      initSourceReader(sortedInputs[Normals], Normals, mNormals, normal_params);
+      initSourceReader(sortedInputs[Normals], Normals, normals, normal_params);
 
       const char* color_params[] = { "R", "G", "B", "A", "" };
-      initSourceReader(sortedInputs[Colors], Colors, mColors, color_params);
+      initSourceReader(sortedInputs[Colors], Colors, colors, color_params);
 
       const char* uv_params[] = { "S", "T", "" };
       const char* uv_params2[] = { "U", "V", "" }; // some files use the nonstandard U,V or X,Y param names
       const char* uv_params3[] = { "X", "Y", "" };
-      if (!initSourceReader(sortedInputs[UVs], UVs, mUVs, uv_params))
-         if (!initSourceReader(sortedInputs[UVs], UVs, mUVs, uv_params2))
-            initSourceReader(sortedInputs[UVs], UVs, mUVs, uv_params3);
-      if (!initSourceReader(sortedInputs[UV2s], UV2s, mUV2s, uv_params))
-         if (!initSourceReader(sortedInputs[UV2s], UV2s, mUV2s, uv_params2))
-            initSourceReader(sortedInputs[UV2s], UV2s, mUV2s, uv_params3);
+      if (!initSourceReader(sortedInputs[UVs], UVs, uvs, uv_params))
+         if (!initSourceReader(sortedInputs[UVs], UVs, uvs, uv_params2))
+            initSourceReader(sortedInputs[UVs], UVs, uvs, uv_params3);
+      if (!initSourceReader(sortedInputs[UV2s], UV2s, uv2s, uv_params))
+         if (!initSourceReader(sortedInputs[UV2s], UV2s, uv2s, uv_params2))
+            initSourceReader(sortedInputs[UV2s], UV2s, uv2s, uv_params3);
 
       const char* joint_params[] = { "JOINT", "" };
-      initSourceReader(sortedInputs[Joints], Joints, mJoints, joint_params);
+      initSourceReader(sortedInputs[Joints], Joints, joints, joint_params);
 
       const char* weight_params[] = { "WEIGHT", "" };
-      initSourceReader(sortedInputs[Weights], Weights, mWeights, weight_params);
+      initSourceReader(sortedInputs[Weights], Weights, weights, weight_params);
 
       const char* matrix_params[] = { "TRANSFORM", "" };
-      initSourceReader(sortedInputs[InvBindMatrices], InvBindMatrices, mInvBindMatrices, matrix_params);
+      initSourceReader(sortedInputs[InvBindMatrices], InvBindMatrices, invBindMatrices, matrix_params);
 
       return true;
    }
@@ -317,19 +317,19 @@ public:
 //------------------------------------------------------------------------------
 
 ColladaAppMesh::ColladaAppMesh(const domInstance_geometry* instance, ColladaAppNode* node)
-   : mInstanceGeom(instance), mInstanceCtrl(0), mAppNode(node), mGeomExt(0)
+   : instanceGeom(instance), instanceCtrl(0), appNode(node), geomExt(0)
 {
-   mFlags = 0;
-   mNumFrames = 0;
-   mNumMatFrames = 0;
+   flags = 0;
+   numFrames = 0;
+   numMatFrames = 0;
 }
 
 ColladaAppMesh::ColladaAppMesh(const domInstance_controller* instance, ColladaAppNode* node)
-   : mInstanceGeom(0), mInstanceCtrl(instance), mAppNode(node), mGeomExt(0)
+   : instanceGeom(0), instanceCtrl(instance), appNode(node), geomExt(0)
 {
-   mFlags = 0;
-   mNumFrames = 0;
-   mNumMatFrames = 0;
+   flags = 0;
+   numFrames = 0;
+   numMatFrames = 0;
 }
 
 const char* ColladaAppMesh::getName(bool allowFixed)
@@ -337,27 +337,27 @@ const char* ColladaAppMesh::getName(bool allowFixed)
    // Some exporters add a 'PIVOT' or unnamed node between the mesh and the
    // actual object node. Detect this and return the object node name instead
    // of the pivot node.
-   const char* nodeName = mAppNode->getName();
+   const char* nodeName = appNode->getName();
    if ( dStrEqual(nodeName, "null") || dStrEndsWith(nodeName, "PIVOT") )
-      nodeName = mAppNode->getParentName();
+      nodeName = appNode->getParentName();
 
    // If all geometry is being fixed to the same size, append the size
    // to the name
-   return allowFixed && mFixedSizeEnabled ? avar("%s %d", nodeName, mFixedSize) : nodeName;
+   return allowFixed && fixedSizeEnabled ? avar("%s %d", nodeName, fixedSize) : nodeName;
 }
 
 MatrixF ColladaAppMesh::getMeshTransform(F32 time)
 {
-   return mAppNode->getNodeTransform(time);
+   return appNode->getNodeTransform(time);
 }
 
 bool ColladaAppMesh::animatesVis(const AppSequence* appSeq)
 {
    #define IS_VIS_ANIMATED(node)    \
-      (dynamic_cast<const ColladaAppNode*>(node)->nodeExt->mVisibility.isAnimated(appSeq->getStart(), appSeq->getEnd()))
+      (dynamic_cast<const ColladaAppNode*>(node)->nodeExt->visibility.isAnimated(appSeq->getStart(), appSeq->getEnd()))
 
    // Check if the node visibility is animated within the sequence interval
-   return IS_VIS_ANIMATED(mAppNode) || (mAppNode->appParent ? IS_VIS_ANIMATED(mAppNode->appParent) : false);
+   return IS_VIS_ANIMATED(appNode) || (appNode->appParent ? IS_VIS_ANIMATED(appNode->appParent) : false);
 }
 
 bool ColladaAppMesh::animatesMatFrame(const AppSequence* appSeq)
@@ -367,8 +367,8 @@ bool ColladaAppMesh::animatesMatFrame(const AppSequence* appSeq)
    // - by animating the morph weights for morph targets with different UVs
 
    // Check if the MAYA profile texture transform is animated
-   for (S32 iMat = 0; iMat < mAppMaterials.size(); iMat++) {
-      ColladaAppMaterial* appMat = static_cast<ColladaAppMaterial*>(mAppMaterials[iMat]);
+   for (S32 iMat = 0; iMat < appMaterials.size(); iMat++) {
+      ColladaAppMaterial* appMat = static_cast<ColladaAppMaterial*>(appMaterials[iMat]);
       if (appMat->effectExt &&
           appMat->effectExt->animatesTextureTransform(appSeq->getStart(), appSeq->getEnd()))
          return true;
@@ -418,10 +418,10 @@ bool ColladaAppMesh::animatesFrame(const AppSequence* appSeq)
 F32 ColladaAppMesh::getVisValue(F32 t)
 {
    #define GET_VIS(node)   \
-      (dynamic_cast<const ColladaAppNode*>(node)->nodeExt->mVisibility.getValue(t))
+      (dynamic_cast<const ColladaAppNode*>(node)->nodeExt->visibility.getValue(t))
 
    // Get the visibility of the mesh's node at time, 't'
-   return GET_VIS(mAppNode) * (mAppNode->appParent ? GET_VIS(mAppNode->appParent) : 1.0f);
+   return GET_VIS(appNode) * (appNode->appParent ? GET_VIS(appNode->appParent) : 1.0f);
 }
 
 S32 ColladaAppMesh::addMaterial(const char* symbol)
@@ -431,14 +431,14 @@ S32 ColladaAppMesh::addMaterial(const char* symbol)
 
    // Lookup the symbol in the materials already bound to this geometry/controller
    // instance
-   Map<StringTableEntry,U32>::Iterator itr = mBoundMaterials.find(symbol);
-   if (itr != mBoundMaterials.end())
+   Map<StringTableEntry,U32>::Iterator itr = boundMaterials.find(symbol);
+   if (itr != boundMaterials.end())
       return itr->value;
 
    // Find the Collada material that this symbol maps to
    U32 matIndex = TSDrawPrimitive::NoMaterial;
-   const domBind_material* binds = mInstanceGeom ? mInstanceGeom->getBind_material() :
-                                                  mInstanceCtrl->getBind_material();
+   const domBind_material* binds = instanceGeom ? instanceGeom->getBind_material() :
+                                                  instanceCtrl->getBind_material();
    if (binds) {
       const domInstance_material_Array& matArray = binds->getTechnique_common()->getInstance_material_array();
       for (S32 iBind = 0; iBind < matArray.getCount(); iBind++) {
@@ -446,17 +446,17 @@ S32 ColladaAppMesh::addMaterial(const char* symbol)
 
             // Find the index of the bound material in the shape global list
             const domMaterial* mat = daeSafeCast<domMaterial>(matArray[iBind]->getTarget().getElement());
-            for (matIndex = 0; matIndex < mAppMaterials.size(); matIndex++) {
-               if (static_cast<ColladaAppMaterial*>(mAppMaterials[matIndex])->mat == mat)
+            for (matIndex = 0; matIndex < appMaterials.size(); matIndex++) {
+               if (static_cast<ColladaAppMaterial*>(appMaterials[matIndex])->mat == mat)
                   break;
             }
 
             // Check if this material needs to be added to the shape global list
-            if (matIndex == mAppMaterials.size()) {
+            if (matIndex == appMaterials.size()) {
                if (mat)
-                  mAppMaterials.push_back(new ColladaAppMaterial(mat));
+                  appMaterials.push_back(new ColladaAppMaterial(mat));
                else
-                  mAppMaterials.push_back(new ColladaAppMaterial(symbol));
+                  appMaterials.push_back(new ColladaAppMaterial(symbol));
             }
 
             break;
@@ -466,23 +466,23 @@ S32 ColladaAppMesh::addMaterial(const char* symbol)
    else
    {
       // No Collada material is present for this symbol, so just create an empty one
-      mAppMaterials.push_back(new ColladaAppMaterial(symbol));
+      appMaterials.push_back(new ColladaAppMaterial(symbol));
    }
 
    // Add this symbol to the bound list for the mesh
-   mBoundMaterials.insert(StringTable->insert(symbol), matIndex);
+   boundMaterials.insert(StringTable->insert(symbol), matIndex);
    return matIndex;
 }
 
 void ColladaAppMesh::getPrimitives(const domGeometry* geometry)
 {
    // Only do this once
-   if (mPrimitives.size())
+   if (primitives.size())
       return;
 
    // Read the <geometry> extension
-   if (!mGeomExt)
-      mGeomExt = new ColladaExtension_geometry(geometry);
+   if (!geomExt)
+      geomExt = new ColladaExtension_geometry(geometry);
 
    // Get the supported primitive elements for this geometry, and warn
    // about unsupported elements
@@ -517,25 +517,25 @@ void ColladaAppMesh::getPrimitives(const domGeometry* geometry)
          continue;
 
       // Create TSMesh primitive
-      mPrimitives.increment();
-      TSDrawPrimitive& primitive = mPrimitives.last();
-      primitive.start = mIndices.size();
+      primitives.increment();
+      TSDrawPrimitive& primitive = primitives.last();
+      primitive.start = indices.size();
       primitive.matIndex = (TSDrawPrimitive::Triangles | TSDrawPrimitive::Indexed) |
                            addMaterial(meshPrims[iPrim]->getMaterial());
 
       // Get the AppMaterial associated with this primitive
       ColladaAppMaterial* appMat = 0;
       if (!(primitive.matIndex & TSDrawPrimitive::NoMaterial))
-         appMat = static_cast<ColladaAppMaterial*>(mAppMaterials[primitive.matIndex & TSDrawPrimitive::MaterialMask]);
+         appMat = static_cast<ColladaAppMaterial*>(appMaterials[primitive.matIndex & TSDrawPrimitive::MaterialMask]);
 
       // Force the material to be double-sided if this geometry is double-sided.
-      if (mGeomExt->mDoubleSided && appMat && appMat->effectExt)
-         appMat->effectExt->mDoubleSided = true;
+      if (geomExt->double_sided && appMat && appMat->effectExt)
+         appMat->effectExt->double_sided = true;
 
       // Pre-allocate triangle indices
       primitive.numElements = numTriangles * 3;
-      mIndices.setSize(mIndices.size() + primitive.numElements);
-      U32* dstIndex = mIndices.end() - primitive.numElements;
+      indices.setSize(indices.size() + primitive.numElements);
+      U32* dstIndex = indices.end() - primitive.numElements;
 
       // Determine the offset for each element type in the stream, and also the
       // maximum input offset, which will be the number of indices per vertex we
@@ -555,12 +555,12 @@ void ColladaAppMesh::getPrimitives(const domGeometry* geometry)
          // If the next triangle could cause us to index across a 16-bit
          // boundary, split this primitive and clear the tuple map to
          // ensure primitives only index verts within a 16-bit range.
-         if (mVertTuples.size() &&
-            (((mVertTuples.size()-1) ^ (mVertTuples.size()+2)) & 0x10000))
+         if (vertTuples.size() &&
+            (((vertTuples.size()-1) ^ (vertTuples.size()+2)) & 0x10000))
          {
             // Pad vertTuples up to the next 16-bit boundary
-            while (mVertTuples.size() & 0xFFFF)
-               mVertTuples.push_back(VertTuple(mVertTuples.last()));
+            while (vertTuples.size() & 0xFFFF)
+               vertTuples.push_back(VertTuple(vertTuples.last()));
 
             // Split the primitive at the current triangle
             S32 indicesRemaining = (numTriangles - iTri) * 3;
@@ -569,12 +569,12 @@ void ColladaAppMesh::getPrimitives(const domGeometry* geometry)
                daeErrorHandler::get()->handleWarning(avar("Splitting primitive "
                   "in %s: too many verts for 16-bit indices.", _GetNameOrId(geometry)));
 
-               mPrimitives.last().numElements -= indicesRemaining;
-               mPrimitives.push_back(TSDrawPrimitive(mPrimitives.last()));
+               primitives.last().numElements -= indicesRemaining;
+               primitives.push_back(TSDrawPrimitive(primitives.last()));
             }
 
-            mPrimitives.last().numElements = indicesRemaining;
-            mPrimitives.last().start = mIndices.size() - indicesRemaining;
+            primitives.last().numElements = indicesRemaining;
+            primitives.last().start = indices.size() - indicesRemaining;
 
             tupleMap.clear();
          }
@@ -586,29 +586,29 @@ void ColladaAppMesh::getPrimitives(const domGeometry* geometry)
             // Collect vert tuples into a single array so we can easily grab
             // vertex data later.
             VertTuple tuple;
-            tuple.mPrim = iPrim;
-            tuple.mVertex = offsets[MeshStreams::Points]  >= 0 ? pSrcData[offsets[MeshStreams::Points]] : -1;
-            tuple.mNormal = offsets[MeshStreams::Normals] >= 0 ? pSrcData[offsets[MeshStreams::Normals]] : -1;
-            tuple.mColor  = offsets[MeshStreams::Colors]  >= 0 ? pSrcData[offsets[MeshStreams::Colors]] : -1;
-            tuple.mUV     = offsets[MeshStreams::UVs]     >= 0 ? pSrcData[offsets[MeshStreams::UVs]] : -1;
-            tuple.mUV2    = offsets[MeshStreams::UV2s]    >= 0 ? pSrcData[offsets[MeshStreams::UV2s]] : -1;
+            tuple.prim = iPrim;
+            tuple.vertex = offsets[MeshStreams::Points]  >= 0 ? pSrcData[offsets[MeshStreams::Points]] : -1;
+            tuple.normal = offsets[MeshStreams::Normals] >= 0 ? pSrcData[offsets[MeshStreams::Normals]] : -1;
+            tuple.color  = offsets[MeshStreams::Colors]  >= 0 ? pSrcData[offsets[MeshStreams::Colors]] : -1;
+            tuple.uv     = offsets[MeshStreams::UVs]     >= 0 ? pSrcData[offsets[MeshStreams::UVs]] : -1;
+            tuple.uv2    = offsets[MeshStreams::UV2s]    >= 0 ? pSrcData[offsets[MeshStreams::UV2s]] : -1;
 
-            tuple.mDataVertex = tuple.mVertex > -1 ? streams.mPoints.getPoint3FValue(tuple.mVertex) : Point3F::Max;
-            tuple.mDataNormal = tuple.mNormal > -1 ? streams.mNormals.getPoint3FValue(tuple.mNormal) : Point3F::Max;
-            tuple.mDataColor  = tuple.mColor > -1  ? streams.mColors.getColorIValue(tuple.mColor) : ColorI(0,0,0);
-            tuple.mDataUV     = tuple.mUV > -1     ? streams.mUVs.getPoint2FValue(tuple.mUV) : Point2F::Max;
-            tuple.mDataUV2    = tuple.mUV2 > -1    ? streams.mUV2s.getPoint2FValue(tuple.mUV2) : Point2F::Max;
+            tuple.dataVertex = tuple.vertex > -1 ? streams.points.getPoint3FValue(tuple.vertex) : Point3F::Max;
+            tuple.dataNormal = tuple.normal > -1 ? streams.normals.getPoint3FValue(tuple.normal) : Point3F::Max;
+            tuple.dataColor  = tuple.color > -1  ? streams.colors.getColorIValue(tuple.color) : ColorI(0,0,0);
+            tuple.dataUV     = tuple.uv > -1     ? streams.uvs.getPoint2FValue(tuple.uv) : Point2F::Max;
+            tuple.dataUV2    = tuple.uv2 > -1    ? streams.uv2s.getPoint2FValue(tuple.uv2) : Point2F::Max;
 
             VertTupleMap::Iterator itr = tupleMap.find(tuple);
             if (itr == tupleMap.end())
             {
-               itr = tupleMap.insert(tuple, mVertTuples.size());
-               mVertTuples.push_back(tuple);
+               itr = tupleMap.insert(tuple, vertTuples.size());
+               vertTuples.push_back(tuple);
             }
 
             // Collada uses CCW for front face and Torque uses the opposite, so
             // for normal (non-inverted) meshes, the indices are flipped.
-            if (mAppNode->invertMeshes)
+            if (appNode->invertMeshes)
                dstIndex[v] = itr->value;
             else
                dstIndex[2 - v] = itr->value;
@@ -631,7 +631,7 @@ void ColladaAppMesh::getVertexData(const domGeometry* geometry, F32 time, const 
                                    Vector<Point2F>& v_uv2s,
                                    bool appendValues)
 {
-   if (!mPrimitives.size())
+   if (!primitives.size())
       return;
 
    MeshStreams streams;
@@ -648,24 +648,24 @@ void ColladaAppMesh::getVertexData(const domGeometry* geometry, F32 time, const 
 
    // If appending values, pre-allocate the arrays
    if (appendValues) {
-      v_points.setSize(v_points.size() + mVertTuples.size());
-      v_uvs.setSize(v_uvs.size() + mVertTuples.size());
+      v_points.setSize(v_points.size() + vertTuples.size());
+      v_uvs.setSize(v_uvs.size() + vertTuples.size());
    }
 
    // Get pointers to arrays
-   Point3F* points_array = &v_points[v_points.size() - mVertTuples.size()];
-   Point2F* uvs_array = &v_uvs[v_uvs.size() - mVertTuples.size()];
+   Point3F* points_array = &v_points[v_points.size() - vertTuples.size()];
+   Point2F* uvs_array = &v_uvs[v_uvs.size() - vertTuples.size()];
    Point3F* norms_array = NULL;
    ColorI*  colors_array = NULL;
    Point2F* uv2s_array = NULL;
 
-   for (S32 iVert = 0; iVert < mVertTuples.size(); iVert++) {
+   for (S32 iVert = 0; iVert < vertTuples.size(); iVert++) {
 
-      const VertTuple& tuple = mVertTuples[iVert];
+      const VertTuple& tuple = vertTuples[iVert];
 
       // Change primitives?
-      if (tuple.mPrim != lastPrimitive) {
-         if (meshPrims.size() <= tuple.mPrim) {
+      if (tuple.prim != lastPrimitive) {
+         if (meshPrims.size() <= tuple.prim) {
             daeErrorHandler::get()->handleError(avar("Failed to get vertex data "
                "for %s. Primitives do not match base geometry.", geometry->getID()));
             break;
@@ -673,31 +673,31 @@ void ColladaAppMesh::getVertexData(const domGeometry* geometry, F32 time, const 
 
          // Update vertex/normal/UV streams and get the new material index
          streams.reset();
-         streams.readInputs(meshPrims[tuple.mPrim]->getInputs());
-         S32 matIndex = addMaterial(meshPrims[tuple.mPrim]->getMaterial());
+         streams.readInputs(meshPrims[tuple.prim]->getInputs());
+         S32 matIndex = addMaterial(meshPrims[tuple.prim]->getMaterial());
          if (matIndex != TSDrawPrimitive::NoMaterial)
-            appMat = static_cast<ColladaAppMaterial*>(mAppMaterials[matIndex]);
+            appMat = static_cast<ColladaAppMaterial*>(appMaterials[matIndex]);
          else
             appMat = 0;
 
-         lastPrimitive = tuple.mPrim;
+         lastPrimitive = tuple.prim;
       }
 
       // If we are NOT appending values, only set the value if it actually exists
       // in the mesh data stream.
 
-      if (appendValues || ((tuple.mVertex >= 0) && (tuple.mVertex < streams.mPoints.size()))) {
-         points_array[iVert] = streams.mPoints.getPoint3FValue(tuple.mVertex);
+      if (appendValues || ((tuple.vertex >= 0) && (tuple.vertex < streams.points.size()))) {
+         points_array[iVert] = streams.points.getPoint3FValue(tuple.vertex);
 
          // Flip verts for inverted meshes
-         if (mAppNode->invertMeshes)
+         if (appNode->invertMeshes)
             points_array[iVert].z = -points_array[iVert].z;
 
          objOffset.mulP(points_array[iVert]);
       }
 
-      if (appendValues || ((tuple.mUV >= 0) && (tuple.mUV < streams.mUVs.size()))) {
-         uvs_array[iVert] = streams.mUVs.getPoint2FValue(tuple.mUV);
+      if (appendValues || ((tuple.uv >= 0) && (tuple.uv < streams.uvs.size()))) {
+         uvs_array[iVert] = streams.uvs.getPoint2FValue(tuple.uv);
          if (appMat && appMat->effectExt)
             appMat->effectExt->applyTextureTransform(uvs_array[iVert], time);
          uvs_array[iVert].y = 1.0f - uvs_array[iVert].y;   // Collada texcoords are upside down compared to TGE
@@ -705,45 +705,45 @@ void ColladaAppMesh::getVertexData(const domGeometry* geometry, F32 time, const 
 
       // The rest is non-required data... if it doesn't exist then don't append it.
 
-      if ( (tuple.mNormal >= 0) && (tuple.mNormal < streams.mNormals.size()) ) {
+      if ( (tuple.normal >= 0) && (tuple.normal < streams.normals.size()) ) {
          if ( !norms_array && iVert == 0 )
          {
-            v_norms.setSize(v_norms.size() + mVertTuples.size());
-            norms_array = &v_norms[v_norms.size() - mVertTuples.size()];
+            v_norms.setSize(v_norms.size() + vertTuples.size());
+            norms_array = &v_norms[v_norms.size() - vertTuples.size()];
          }
 
          if ( norms_array ) {
-            norms_array[iVert] = streams.mNormals.getPoint3FValue(tuple.mNormal);
+            norms_array[iVert] = streams.normals.getPoint3FValue(tuple.normal);
 
             // Flip normals for inverted meshes
-            if (mAppNode->invertMeshes)
+            if (appNode->invertMeshes)
                norms_array[iVert].z = -norms_array[iVert].z;
          }
       }
 
-      if ( (tuple.mColor >= 0) && (tuple.mColor < streams.mColors.size())) 
+      if ( (tuple.color >= 0) && (tuple.color < streams.colors.size())) 
       {
          if ( !colors_array && iVert == 0 )
          {
-            v_colors.setSize(v_colors.size() + mVertTuples.size());
-            colors_array = &v_colors[v_colors.size() - mVertTuples.size()];
+            v_colors.setSize(v_colors.size() + vertTuples.size());
+            colors_array = &v_colors[v_colors.size() - vertTuples.size()];
          }
 
          if ( colors_array )
-            colors_array[iVert] = streams.mColors.getColorIValue(tuple.mColor);
+            colors_array[iVert] = streams.colors.getColorIValue(tuple.color);
       }
 
-      if ( (tuple.mUV2 >= 0) && (tuple.mUV2 < streams.mUV2s.size()) ) 
+      if ( (tuple.uv2 >= 0) && (tuple.uv2 < streams.uv2s.size()) ) 
       {
          if ( !uv2s_array && iVert == 0 )
          {
-            v_uv2s.setSize(v_uv2s.size() + mVertTuples.size());
-            uv2s_array = &v_uv2s[v_uv2s.size() - mVertTuples.size()];
+            v_uv2s.setSize(v_uv2s.size() + vertTuples.size());
+            uv2s_array = &v_uv2s[v_uv2s.size() - vertTuples.size()];
          }
 
          if ( uv2s_array )
          {
-            uv2s_array[iVert] = streams.mUV2s.getPoint2FValue(tuple.mUV2);
+            uv2s_array[iVert] = streams.uv2s.getPoint2FValue(tuple.uv2);
             if (appMat && appMat->effectExt)
                appMat->effectExt->applyTextureTransform(uv2s_array[iVert], time);
             uv2s_array[iVert].y = 1.0f - uv2s_array[iVert].y;   // Collada texcoords are upside down compared to TGE
@@ -810,11 +810,11 @@ void ColladaAppMesh::getMorphVertexData(const domMorph* morph, F32 time, const M
    getVertexData(baseGeometry, time, objOffset, v_points, v_norms, v_colors, v_uvs, v_uv2s, true);
 
    // Get pointers to the arrays of base geometry data
-   Point3F* points_array = &v_points[v_points.size() - mVertTuples.size()];
-   Point3F* norms_array = &v_norms[v_norms.size() - mVertTuples.size()];
-   Point2F* uvs_array = &v_uvs[v_uvs.size() - mVertTuples.size()];
-   ColorI* colors_array = v_colors.size() ? &v_colors[v_colors.size() - mVertTuples.size()] : 0;
-   Point2F* uv2s_array = v_uv2s.size() ? &v_uv2s[v_uv2s.size() - mVertTuples.size()] : 0;
+   Point3F* points_array = &v_points[v_points.size() - vertTuples.size()];
+   Point3F* norms_array = &v_norms[v_norms.size() - vertTuples.size()];
+   Point2F* uvs_array = &v_uvs[v_uvs.size() - vertTuples.size()];
+   ColorI* colors_array = v_colors.size() ? &v_colors[v_colors.size() - vertTuples.size()] : 0;
+   Point2F* uv2s_array = v_uv2s.size() ? &v_uv2s[v_uv2s.size() - vertTuples.size()] : 0;
 
    // Normalize base vertex data?
    if (morph->getMethod() == MORPHMETHODTYPE_NORMALIZED) {
@@ -827,14 +827,14 @@ void ColladaAppMesh::getMorphVertexData(const domMorph* morph, F32 time, const M
       // Result = Base*(1.0-w1-w2 ... -wN) + w1*Target1 + w2*Target2 ... + wN*TargetN
       weightSum = mClampF(1.0f - weightSum, 0.0f, 1.0f);
 
-      for (S32 iVert = 0; iVert < mVertTuples.size(); iVert++) {
+      for (S32 iVert = 0; iVert < vertTuples.size(); iVert++) {
          points_array[iVert] *= weightSum;
          norms_array[iVert] *= weightSum;
          uvs_array[iVert] *= weightSum;
       }
 
       if (uv2s_array) {
-         for (S32 iVert = 0; iVert < mVertTuples.size(); iVert++)
+         for (S32 iVert = 0; iVert < vertTuples.size(); iVert++)
             uv2s_array[iVert] *= weightSum;
       }
    }
@@ -855,29 +855,29 @@ void ColladaAppMesh::getMorphVertexData(const domMorph* morph, F32 time, const M
 
       // Copy base geometry into target geometry (will be used if target does
       // not define normals or uvs)
-      targetPoints.set(points_array, mVertTuples.size());
-      targetNorms.set(norms_array, mVertTuples.size());
-      targetUvs.set(uvs_array, mVertTuples.size());
+      targetPoints.set(points_array, vertTuples.size());
+      targetNorms.set(norms_array, vertTuples.size());
+      targetUvs.set(uvs_array, vertTuples.size());
       if (colors_array)
-         targetColors.set(colors_array, mVertTuples.size());
+         targetColors.set(colors_array, vertTuples.size());
       if (uv2s_array)
-         targetUv2s.set(uv2s_array, mVertTuples.size());
+         targetUv2s.set(uv2s_array, vertTuples.size());
 
       getVertexData(targetGeoms[iTarget], time, objOffset, targetPoints, targetNorms, targetColors, targetUvs, targetUv2s, false);
 
       // Combine with base geometry
-      for (S32 iVert = 0; iVert < mVertTuples.size(); iVert++) {
+      for (S32 iVert = 0; iVert < vertTuples.size(); iVert++) {
          points_array[iVert] += targetPoints[iVert] * targetWeights[iTarget];
          norms_array[iVert] += targetNorms[iVert] * targetWeights[iTarget];
          uvs_array[iVert] += targetUvs[iVert] * targetWeights[iTarget];
       }
 
       if (uv2s_array) {
-         for (S32 iVert = 0; iVert < mVertTuples.size(); iVert++)
+         for (S32 iVert = 0; iVert < vertTuples.size(); iVert++)
             uv2s_array[iVert] += targetUv2s[iVert] * targetWeights[iTarget];
       }
       if (colors_array) {
-         for (S32 iVert = 0; iVert < mVertTuples.size(); iVert++)
+         for (S32 iVert = 0; iVert < vertTuples.size(); iVert++)
             colors_array[iVert] += targetColors[iVert] * (F32)targetWeights[iTarget];
       }
    }
@@ -891,12 +891,12 @@ void ColladaAppMesh::lockMesh(F32 t, const MatrixF& objOffset)
    // 3) a skin (skin geometry could also be a morph!)
    daeElement* geometry = 0;
 
-   if (mInstanceGeom) {
+   if (instanceGeom) {
       // Simple, static mesh
-      geometry = mInstanceGeom->getUrl().getElement();
+      geometry = instanceGeom->getUrl().getElement();
    }
-   else if (mInstanceCtrl) {
-      const domController* ctrl = daeSafeCast<domController>(mInstanceCtrl->getUrl().getElement());
+   else if (instanceCtrl) {
+      const domController* ctrl = daeSafeCast<domController>(instanceCtrl->getUrl().getElement());
       if (!ctrl) {
          daeErrorHandler::get()->handleWarning(avar("Failed to find <controller> "
             "element for %s", getName()));
@@ -923,10 +923,10 @@ void ColladaAppMesh::lockMesh(F32 t, const MatrixF& objOffset)
    // Now get the vertex data at the specified time
    if (geometry->getElementType() == COLLADA_TYPE::GEOMETRY) {
       getPrimitives(daeSafeCast<domGeometry>(geometry));
-      getVertexData(daeSafeCast<domGeometry>(geometry), t, objOffset, mPoints, mNormals, mColors, mUVs, mUV2s, true);
+      getVertexData(daeSafeCast<domGeometry>(geometry), t, objOffset, points, normals, colors, uvs, uv2s, true);
    }
    else if (geometry->getElementType() == COLLADA_TYPE::MORPH) {
-      getMorphVertexData(daeSafeCast<domMorph>(geometry), t, objOffset, mPoints, mNormals, mColors, mUVs, mUV2s);
+      getMorphVertexData(daeSafeCast<domMorph>(geometry), t, objOffset, points, normals, colors, uvs, uv2s);
    }
    else {
       daeErrorHandler::get()->handleWarning(avar("Unsupported geometry type "
@@ -937,11 +937,11 @@ void ColladaAppMesh::lockMesh(F32 t, const MatrixF& objOffset)
 void ColladaAppMesh::lookupSkinData()
 {
    // Only lookup skin data once
-   if (!isSkin() || mWeight.size())
+   if (!isSkin() || weight.size())
       return;
 
    // Get the skin and vertex weight data
-   const domSkin* skin = daeSafeCast<domController>(mInstanceCtrl->getUrl().getElement())->getSkin();
+   const domSkin* skin = daeSafeCast<domController>(instanceCtrl->getUrl().getElement())->getSkin();
    const domSkin::domVertex_weights& weightIndices = *(skin->getVertex_weights());
    const domListOfInts& weights_v = weightIndices.getV()->getValue();
    const domListOfUInts& weights_vcount = weightIndices.getVcount()->getValue();
@@ -950,7 +950,7 @@ void ColladaAppMesh::lookupSkinData()
    streams.readInputs(skin->getJoints()->getInput_array());
    streams.readInputs(weightIndices.getInput_array());
 
-   MatrixF invObjOffset(mObjectOffset);
+   MatrixF invObjOffset(objectOffset);
    invObjOffset.inverse();
 
    // Get the bind shape matrix
@@ -971,17 +971,17 @@ void ColladaAppMesh::lookupSkinData()
 
    // Set vertex weights
    bool tooManyWeightsWarning = false;
-   for (S32 iVert = 0; iVert < mVertsPerFrame; iVert++) {
+   for (S32 iVert = 0; iVert < vertsPerFrame; iVert++) {
       const domUint* vcount = (domUint*)weights_vcount.getRaw(0);
       const domInt* vindices = (domInt*)weights_v.getRaw(0);
-      vindices += vindicesOffset[mVertTuples[iVert].mVertex];
+      vindices += vindicesOffset[vertTuples[iVert].vertex];
 
       S32 nonZeroWeightCount = 0;
 
-      for (S32 iWeight = 0; iWeight < vcount[mVertTuples[iVert].mVertex]; iWeight++) {
+      for (S32 iWeight = 0; iWeight < vcount[vertTuples[iVert].vertex]; iWeight++) {
 
          S32 bIndex = vindices[iWeight*2];
-         F32 bWeight = streams.mWeights.getFloatValue( vindices[iWeight*2 + 1] );
+         F32 bWeight = streams.weights.getFloatValue( vindices[iWeight*2 + 1] );
 
          // Ignore empty weights
          if ( bIndex < 0 || bWeight == 0 )
@@ -990,7 +990,7 @@ void ColladaAppMesh::lookupSkinData()
          // Limit the number of weights per bone (keep the N largest influences)
          if ( nonZeroWeightCount >= TSSkinMesh::BatchData::maxBonePerVert )
          {
-            if (vcount[mVertTuples[iVert].mVertex] > TSSkinMesh::BatchData::maxBonePerVert)
+            if (vcount[vertTuples[iVert].vertex] > TSSkinMesh::BatchData::maxBonePerVert)
             {
                if (!tooManyWeightsWarning)
                {
@@ -1002,25 +1002,25 @@ void ColladaAppMesh::lookupSkinData()
             }
 
             // Too many weights => find and replace the smallest one
-            S32 minIndex = mWeight.size() - TSSkinMesh::BatchData::maxBonePerVert;
-            F32 minWeight = mWeight[minIndex];
-            for (S32 i = minIndex + 1; i < mWeight.size(); i++)
+            S32 minIndex = weight.size() - TSSkinMesh::BatchData::maxBonePerVert;
+            F32 minWeight = weight[minIndex];
+            for (S32 i = minIndex + 1; i < weight.size(); i++)
             {
-               if (mWeight[i] < minWeight)
+               if (weight[i] < minWeight)
                {
-                  minWeight = mWeight[i];
+                  minWeight = weight[i];
                   minIndex = i;
                }
             }
 
-            mBoneIndex[minIndex] = bIndex;
-            mWeight[minIndex] = bWeight;
+            boneIndex[minIndex] = bIndex;
+            weight[minIndex] = bWeight;
          }
          else
          {
-            mVertexIndex.push_back( iVert );
-            mBoneIndex.push_back( bIndex );
-            mWeight.push_back( bWeight );
+            vertexIndex.push_back( iVert );
+            boneIndex.push_back( bIndex );
+            weight.push_back( bWeight );
             nonZeroWeightCount++;
          }
       }
@@ -1028,36 +1028,36 @@ void ColladaAppMesh::lookupSkinData()
 
    // Normalize vertex weights (force weights for each vert to sum to 1)
    S32 iWeight = 0;
-   while (iWeight < mWeight.size()) {
+   while (iWeight < weight.size()) {
       // Find the last weight with the same vertex number, and sum all weights for
       // that vertex
       F32 invTotalWeight = 0;
       S32 iLast;
-      for (iLast = iWeight; iLast < mWeight.size(); iLast++) {
-         if (mVertexIndex[iLast] != mVertexIndex[iWeight])
+      for (iLast = iWeight; iLast < weight.size(); iLast++) {
+         if (vertexIndex[iLast] != vertexIndex[iWeight])
             break;
-         invTotalWeight += mWeight[iLast];
+         invTotalWeight += weight[iLast];
       }
 
       // Then normalize the vertex weights
       invTotalWeight = 1.0f / invTotalWeight;
       for (; iWeight < iLast; iWeight++)
-         mWeight[iWeight] *= invTotalWeight;
+         weight[iWeight] *= invTotalWeight;
    }
 
    // Add dummy AppNodes to allow Collada joints to be mapped to 3space nodes
-   mBones.setSize(streams.mJoints.size());
-   mInitialTransforms.setSize(streams.mJoints.size());
-   for (S32 iJoint = 0; iJoint < streams.mJoints.size(); iJoint++)
+   bones.setSize(streams.joints.size());
+   initialTransforms.setSize(streams.joints.size());
+   for (S32 iJoint = 0; iJoint < streams.joints.size(); iJoint++)
    {
-      const char* jointName = streams.mJoints.getStringValue(iJoint);
+      const char* jointName = streams.joints.getStringValue(iJoint);
 
       // Lookup the joint element
       const domNode* joint = 0;
-      if (mInstanceCtrl->getSkeleton_array().getCount()) {
+      if (instanceCtrl->getSkeleton_array().getCount()) {
          // Search for the node using the <skeleton> as the base element
-         for (S32 iSkel = 0; iSkel < mInstanceCtrl->getSkeleton_array().getCount(); iSkel++) {
-            xsAnyURI skeleton = mInstanceCtrl->getSkeleton_array()[iSkel]->getValue();
+         for (S32 iSkel = 0; iSkel < instanceCtrl->getSkeleton_array().getCount(); iSkel++) {
+            xsAnyURI skeleton = instanceCtrl->getSkeleton_array()[iSkel]->getValue();
             daeSIDResolver resolver(skeleton.getElement(), jointName);
             joint = daeSafeCast<domNode>(resolver.getElement());
             if (joint)
@@ -1072,33 +1072,33 @@ void ColladaAppMesh::lookupSkinData()
 
       if (!joint) {
          daeErrorHandler::get()->handleWarning(avar("Failed to find bone '%s', "
-            "defaulting to instance_controller parent node '%s'", jointName, mAppNode->getName()));
-         joint = mAppNode->getDomNode();
+            "defaulting to instance_controller parent node '%s'", jointName, appNode->getName()));
+         joint = appNode->getDomNode();
       }
-      mBones[iJoint] = new ColladaAppNode(joint);
+      bones[iJoint] = new ColladaAppNode(joint);
 
-      mInitialTransforms[iJoint] = mObjectOffset;
+      initialTransforms[iJoint] = objectOffset;
 
       // Bone scaling is generally ignored during import, since 3space only
       // stores default node transform and rotation. Compensate for this by
       // removing the scaling from the inverse bind transform as well
-      MatrixF invBind = streams.mInvBindMatrices.getMatrixFValue(iJoint);
-      if (!ColladaUtils::getOptions().mIgnoreNodeScale)
+      MatrixF invBind = streams.invBindMatrices.getMatrixFValue(iJoint);
+      if (!ColladaUtils::getOptions().ignoreNodeScale)
       {
          Point3F invScale = invBind.getScale();
          invScale.x = invScale.x ? (1.0f / invScale.x) : 0;
          invScale.y = invScale.y ? (1.0f / invScale.y) : 0;
          invScale.z = invScale.z ? (1.0f / invScale.z) : 0;
-         mInitialTransforms[iJoint].scale(invScale);
+         initialTransforms[iJoint].scale(invScale);
       }
 
       // Inverted node coordinate spaces (negative scale factor) are corrected
       // in ColladaAppNode::getNodeTransform, so need to apply the same operation
       // here to match
       if (m_matF_determinant(invBind) < 0.0f)
-         mInitialTransforms[iJoint].scale(Point3F(1, 1, -1));
+         initialTransforms[iJoint].scale(Point3F(1, 1, -1));
 
-      mInitialTransforms[iJoint].mul(invBind);
-      mInitialTransforms[iJoint].mul(bindShapeMatrix);
+      initialTransforms[iJoint].mul(invBind);
+      initialTransforms[iJoint].mul(bindShapeMatrix);
    }
 }

--- a/Engine/source/ts/collada/colladaAppMesh.h
+++ b/Engine/source/ts/collada/colladaAppMesh.h
@@ -57,20 +57,20 @@
 // AND all of the target geometries because they MUST have the same topology.
 struct VertTuple
 {
-   S32 mPrim, mVertex, mNormal, mColor, mUV, mUV2;
+   S32 prim, vertex, normal, color, uv, uv2;
 
-   Point3F mDataVertex, mDataNormal;
-   ColorI  mDataColor;
-   Point2F mDataUV, mDataUV2;
+   Point3F dataVertex, dataNormal;
+   ColorI  dataColor;
+   Point2F dataUV, dataUV2;
 
-   VertTuple(): mPrim(-1), mVertex(-1), mNormal(-1), mColor(-1), mUV(-1), mUV2(-1) {}
+   VertTuple(): prim(-1), vertex(-1), normal(-1), color(-1), uv(-1), uv2(-1) {}
    bool operator==(const VertTuple& p) const 
    {
-      return   mDataVertex == p.mDataVertex &&
-               mDataColor == p.mDataColor &&  
-               mDataNormal == p.mDataNormal &&   
-               mDataUV == p.mDataUV &&  
-               mDataUV2 == p.mDataUV2;
+      return   dataVertex == p.dataVertex &&
+               dataColor == p.dataColor &&  
+               dataNormal == p.dataNormal &&   
+               dataUV == p.dataUV &&  
+               dataUV2 == p.dataUV2;
    }
 };
 
@@ -79,24 +79,24 @@ class ColladaAppMesh : public AppMesh
    typedef AppMesh Parent;
 
 protected:
-   class ColladaAppNode* mAppNode;                    ///< Pointer to the node that owns this mesh
-   const domInstance_geometry* mInstanceGeom;
-   const domInstance_controller* mInstanceCtrl;
-   ColladaExtension_geometry* mGeomExt;               ///< geometry extension
+   class ColladaAppNode* appNode;                     ///< Pointer to the node that owns this mesh
+   const domInstance_geometry* instanceGeom;
+   const domInstance_controller* instanceCtrl;
+   ColladaExtension_geometry* geomExt;                ///< geometry extension
 
-   Vector<VertTuple> mVertTuples;                     ///<
-   Map<StringTableEntry,U32> mBoundMaterials;         ///< Local map of symbols to materials
+   Vector<VertTuple> vertTuples;                      ///<
+   Map<StringTableEntry,U32> boundMaterials;          ///< Local map of symbols to materials
 
-   static bool mFixedSizeEnabled;                     ///< Set to true to fix the detail size to a particular value for all geometry
-   static S32 mFixedSize;                             ///< The fixed detail size value for all geometry
+   static bool fixedSizeEnabled;                      ///< Set to true to fix the detail size to a particular value for all geometry
+   static S32 fixedSize;                              ///< The fixed detail size value for all geometry
 
    //-----------------------------------------------------------------------
 
    /// Get the morph controller for this mesh (if any)
    const domMorph* getMorph()
    {
-      if (mInstanceCtrl) {
-         const domController* ctrl = daeSafeCast<domController>(mInstanceCtrl->getUrl().getElement());
+      if (instanceCtrl) {
+         const domController* ctrl = daeSafeCast<domController>(instanceCtrl->getUrl().getElement());
          if (ctrl && ctrl->getSkin())
             ctrl = daeSafeCast<domController>(ctrl->getSkin()->getSource().getElement());
          return ctrl ? ctrl->getMorph() : NULL;
@@ -123,13 +123,13 @@ public:
    ColladaAppMesh(const domInstance_controller* instance, ColladaAppNode* node);
    ~ColladaAppMesh()
    {
-      delete mGeomExt;
+      delete geomExt;
    }
 
    static void fixDetailSize(bool fixed, S32 size=2)
    {
-      mFixedSizeEnabled = fixed;
-      mFixedSize = size;
+      fixedSizeEnabled = fixed;
+      fixedSize = size;
    }
 
    /// Get the name of this mesh
@@ -147,7 +147,7 @@ public:
    /// @return True if a value was set, false if not
    bool getFloat(const char *propName, F32 &defaultVal)
    {
-      return mAppNode->getFloat(propName,defaultVal);
+      return appNode->getFloat(propName,defaultVal);
    }
 
    /// Get an integer property value
@@ -158,7 +158,7 @@ public:
    /// @return True if a value was set, false if not
    bool getInt(const char *propName, S32 &defaultVal)
    {
-      return mAppNode->getInt(propName,defaultVal);
+      return appNode->getInt(propName,defaultVal);
    }
 
    /// Get a boolean property value
@@ -169,14 +169,14 @@ public:
    /// @return True if a value was set, false if not
    bool getBool(const char *propName, bool &defaultVal)
    {
-      return mAppNode->getBool(propName,defaultVal);
+      return appNode->getBool(propName,defaultVal);
    }
 
    /// Return true if this mesh is a skin
    bool isSkin()
    {
-      if (mInstanceCtrl) {
-         const domController* ctrl = daeSafeCast<domController>(mInstanceCtrl->getUrl().getElement());
+      if (instanceCtrl) {
+         const domController* ctrl = daeSafeCast<domController>(instanceCtrl->getUrl().getElement());
          if (ctrl && ctrl->getSkin() &&
             (ctrl->getSkin()->getVertex_weights()->getV()->getValue().getCount() > 0))
             return true;

--- a/Engine/source/ts/collada/colladaAppNode.cpp
+++ b/Engine/source/ts/collada/colladaAppNode.cpp
@@ -58,7 +58,7 @@ static char* TrimFirstWord(char* str)
 
 ColladaAppNode::ColladaAppNode(const domNode* node, ColladaAppNode* parent)
       : p_domNode(node), appParent(parent), nodeExt(new ColladaExtension_node(node)),
-      lastTransformTime(TSShapeLoader::smDefaultTime-1), defaultTransformValid(false),
+      lastTransformTime(TSShapeLoader::DefaultTime-1), defaultTransformValid(false),
       invertMeshes(false)
 {
    mName = dStrdup(_GetNameOrId(node));
@@ -66,7 +66,7 @@ ColladaAppNode::ColladaAppNode(const domNode* node, ColladaAppNode* parent)
 
    // Extract user properties from the <node> extension as whitespace separated
    // "name=value" pairs
-   char* properties = dStrdup(nodeExt->mUserProperties);
+   char* properties = dStrdup(nodeExt->user_properties);
    char* pos = properties;
    char* end = properties + dStrlen( properties );
    while ( pos < end )
@@ -99,7 +99,7 @@ ColladaAppNode::ColladaAppNode(const domNode* node, ColladaAppNode* parent)
          case COLLADA_TYPE::MATRIX:
          case COLLADA_TYPE::LOOKAT:
             nodeTransforms.increment();
-            nodeTransforms.last().mElement = node->getContents()[iChild];
+            nodeTransforms.last().element = node->getContents()[iChild];
             break;
       }
    }
@@ -178,7 +178,7 @@ bool ColladaAppNode::animatesTransform(const AppSequence* appSeq)
 MatrixF ColladaAppNode::getNodeTransform(F32 time)
 {
    // Avoid re-computing the default transform if possible
-   if (defaultTransformValid && time == TSShapeLoader::smDefaultTime)
+   if (defaultTransformValid && time == TSShapeLoader::DefaultTime)
    {
       return defaultNodeTransform;
    }
@@ -198,7 +198,7 @@ MatrixF ColladaAppNode::getNodeTransform(F32 time)
       }
 
       // Cache the default transform
-      if (time == TSShapeLoader::smDefaultTime)
+      if (time == TSShapeLoader::DefaultTime)
       {
          defaultTransformValid = true;
          defaultNodeTransform = nodeTransform;
@@ -221,7 +221,7 @@ MatrixF ColladaAppNode::getTransform(F32 time)
    else {
       // no parent (ie. root level) => scale by global shape <unit>
       lastTransform.identity();
-      lastTransform.scale(ColladaUtils::getOptions().mUnit);
+      lastTransform.scale(ColladaUtils::getOptions().unit);
       if (!isBounds())
          ColladaUtils::convertTransform(lastTransform);     // don't convert bounds node transform (or upAxis won't work!)
    }
@@ -232,7 +232,7 @@ MatrixF ColladaAppNode::getTransform(F32 time)
       MatrixF mat(true);
 
       // Convert the transform element to a MatrixF
-      switch (nodeTransforms[iTxfm].mElement->getElementType()) {
+      switch (nodeTransforms[iTxfm].element->getElementType()) {
          case COLLADA_TYPE::TRANSLATE: mat = vecToMatrixF<domTranslate>(nodeTransforms[iTxfm].getValue(time));  break;
          case COLLADA_TYPE::SCALE:     mat = vecToMatrixF<domScale>(nodeTransforms[iTxfm].getValue(time));      break;
          case COLLADA_TYPE::ROTATE:    mat = vecToMatrixF<domRotate>(nodeTransforms[iTxfm].getValue(time));     break;
@@ -242,7 +242,7 @@ MatrixF ColladaAppNode::getTransform(F32 time)
       }
 
       // Remove node scaling (but keep reflections) if desired
-      if (ColladaUtils::getOptions().mIgnoreNodeScale)
+      if (ColladaUtils::getOptions().ignoreNodeScale)
       {
          Point3F invScale = mat.getScale();
          invScale.x = invScale.x ? (1.0f / invScale.x) : 0;

--- a/Engine/source/ts/collada/colladaAppSequence.cpp
+++ b/Engine/source/ts/collada/colladaAppSequence.cpp
@@ -45,31 +45,31 @@ const char* ColladaAppSequence::getName() const
 
 S32 ColladaAppSequence::getNumTriggers()
 {
-   return clipExt->mTriggers.size();
+   return clipExt->triggers.size();
 }
 
 void ColladaAppSequence::getTrigger(S32 index, TSShape::Trigger& trigger)
 {
-   trigger.pos = clipExt->mTriggers[index].time;
-   trigger.state = clipExt->mTriggers[index].state;
+   trigger.pos = clipExt->triggers[index].time;
+   trigger.state = clipExt->triggers[index].state;
 }
 
 U32 ColladaAppSequence::getFlags() const
 {
    U32 flags = 0;
-   if (clipExt->mCyclic) flags |= TSShape::Cyclic;
-   if (clipExt->mBlend)  flags |= TSShape::Blend;
+   if (clipExt->cyclic) flags |= TSShape::Cyclic;
+   if (clipExt->blend)  flags |= TSShape::Blend;
    return flags;
 }
 
 F32 ColladaAppSequence::getPriority()
 {
-   return clipExt->mPriority;
+   return clipExt->priority;
 }
 
 F32 ColladaAppSequence::getBlendRefTime()
 {
-   return clipExt->mBlendReferenceTime;
+   return clipExt->blendReferenceTime;
 }
 
 void ColladaAppSequence::setActive(bool active)
@@ -88,7 +88,7 @@ void ColladaAppSequence::setAnimationActive(const domAnimation* anim, bool activ
       domChannel* channel = anim->getChannel_array()[iChannel];
       AnimData* animData = reinterpret_cast<AnimData*>(channel->getUserData());
       if (animData)
-         animData->mEnabled = active;
+         animData->enabled = active;
    }
 
    // Recurse into child animations

--- a/Engine/source/ts/collada/colladaExtensions.cpp
+++ b/Engine/source/ts/collada/colladaExtensions.cpp
@@ -29,10 +29,10 @@
 /// the interval
 bool ColladaExtension_effect::animatesTextureTransform(F32 start, F32 end)
 {
-   return mRepeatU.isAnimated(start, end)           || mRepeatV.isAnimated(start, end)         ||
-          mOffsetU.isAnimated(start, end)           || mOffsetV.isAnimated(start, end)         ||
-          mRotateUV.isAnimated(start, end)          || mNoiseU.isAnimated(start, end)          ||
-          mNoiseV.isAnimated(start, end);
+   return repeatU.isAnimated(start, end)           || repeatV.isAnimated(start, end)         ||
+          offsetU.isAnimated(start, end)           || offsetV.isAnimated(start, end)         ||
+          rotateUV.isAnimated(start, end)          || noiseU.isAnimated(start, end)          ||
+          noiseV.isAnimated(start, end);
 }
 
 /// Apply the MAYA texture transform to the given UV coordinates
@@ -41,21 +41,21 @@ void ColladaExtension_effect::applyTextureTransform(Point2F& uv, F32 time)
    // This function will be called for every tvert, every frame. So cache the
    // texture transform parameters to avoid interpolating them every call (since
    // they are constant for all tverts for a given 't')
-   if (time != mLastAnimTime) {
+   if (time != lastAnimTime) {
       // Update texture transform
-      mTextureTransform.set(EulerF(0, 0, mRotateUV.getValue(time)));
-      mTextureTransform.setPosition(Point3F(
-         mOffsetU.getValue(time) + mNoiseU.getValue(time)*gRandGen.randF(),
-         mOffsetV.getValue(time) + mNoiseV.getValue(time)*gRandGen.randF(),
+      textureTransform.set(EulerF(0, 0, rotateUV.getValue(time)));
+      textureTransform.setPosition(Point3F(
+         offsetU.getValue(time) + noiseU.getValue(time)*gRandGen.randF(),
+         offsetV.getValue(time) + noiseV.getValue(time)*gRandGen.randF(),
          0));
-      mTextureTransform.scale(Point3F(mRepeatU.getValue(time), mRepeatV.getValue(time), 1.0f));
+      textureTransform.scale(Point3F(repeatU.getValue(time), repeatV.getValue(time), 1.0f));
 
-      mLastAnimTime = time;
+      lastAnimTime = time;
    }
 
    // Apply texture transform
    Point3F result;
-   mTextureTransform.mulP(Point3F(uv.x, uv.y, 0), &result);
+   textureTransform.mulP(Point3F(uv.x, uv.y, 0), &result);
 
    uv.x = result.x;
    uv.y = result.y;

--- a/Engine/source/ts/collada/colladaLights.cpp
+++ b/Engine/source/ts/collada/colladaLights.cpp
@@ -117,7 +117,7 @@ static void processNodeLights(AppNode* appNode, const MatrixF& offset, SimGroup*
       Con::printf("Adding <%s> light \"%s\" as a %s", lightType, lightName.c_str(), pLight->getClassName());
 
       MatrixF mat(offset);
-      mat.mul(appNode->getNodeTransform(TSShapeLoader::smDefaultTime));
+      mat.mul(appNode->getNodeTransform(TSShapeLoader::DefaultTime));
 
       pLight->setDataField(StringTable->insert("color"), 0,
          avar("%f %f %f %f", color.red, color.green, color.blue, color.alpha));
@@ -210,8 +210,8 @@ DefineConsoleFunction( loadColladaLights, bool, (const char * filename, const ch
          upAxis = root->getAsset()->getUp_axis()->getValue();
    }
 
-   ColladaUtils::getOptions().mUnit = unit;
-   ColladaUtils::getOptions().mUpAxis = upAxis;
+   ColladaUtils::getOptions().unit = unit;
+   ColladaUtils::getOptions().upAxis = upAxis;
 
    // First grab all of the top-level nodes
    Vector<ColladaAppNode*> sceneNodes;

--- a/Engine/source/ts/collada/colladaUtils.cpp
+++ b/Engine/source/ts/collada/colladaUtils.cpp
@@ -49,7 +49,7 @@ void ColladaUtils::convertTransform(MatrixF& mat)
 {
    MatrixF rot(true);
 
-   switch (ColladaUtils::getOptions().mUpAxis)
+   switch (ColladaUtils::getOptions().upAxis)
    {
       case UPAXISTYPE_X_UP:
          // rotate 90 around Y-axis, then 90 around Z-axis
@@ -248,27 +248,27 @@ BasePrimitive* BasePrimitive::get(const daeElement* element)
 void AnimData::parseTargetString(const char* target, S32 fullCount, const char* elements[])
 {
    // Assume targeting all elements at offset 0
-   mTargetValueCount = fullCount;
-   mTargetValueOffset = 0;
+   targetValueCount = fullCount;
+   targetValueOffset = 0;
 
    // Check for array syntax: (n) or (n)(m)
    if (const char* p = dStrchr(target, '(')) {
       S32 indN, indM;
       if (dSscanf(p, "(%d)(%d)", &indN, &indM) == 2) {
-         mTargetValueOffset = (indN * 4) + indM;   // @todo: 4x4 matrix only
-         mTargetValueCount = 1;
+         targetValueOffset = (indN * 4) + indM;   // @todo: 4x4 matrix only
+         targetValueCount = 1;
       }
       else if (dSscanf(p, "(%d)", &indN) == 1) {
-         mTargetValueOffset = indN;
-         mTargetValueCount = 1;
+         targetValueOffset = indN;
+         targetValueCount = 1;
       }
    }
    else if (const char* p = dStrrchr(target, '.')) {
       // Check for named elements
       for (S32 iElem = 0; elements[iElem][0] != 0; iElem++) {
          if (!dStrcmp(p, elements[iElem])) {
-            mTargetValueOffset = iElem;
-            mTargetValueCount = 1;
+            targetValueOffset = iElem;
+            targetValueCount = 1;
             break;
          }
       }
@@ -327,47 +327,47 @@ F32 AnimData::invertParamCubic(F32 param, F32 x0, F32 x1, F32 x2, F32 x3) const
 void AnimData::interpValue(F32 t, U32 offset, double* value) const
 {
    // handle degenerate animation data
-   if (mInput.size() == 0)
+   if (input.size() == 0)
    {
       *value = 0.0f;
       return;
    }
-   else if (mInput.size() == 1)
+   else if (input.size() == 1)
    {
-      *value = mOutput.getStringArrayData(0)[offset];
+      *value = output.getStringArrayData(0)[offset];
       return;
    }
 
    // clamp time to valid range
-   F32 curveStart = mInput.getFloatValue(0);
-   F32 curveEnd = mInput.getFloatValue(mInput.size()-1);
+   F32 curveStart = input.getFloatValue(0);
+   F32 curveEnd = input.getFloatValue(input.size()-1);
    t = mClampF(t, curveStart, curveEnd);
 
    // find the index of the input keyframe BEFORE 't'
    S32 index;
-   for (index = 0; index < mInput.size()-2; index++) {
-      if (mInput.getFloatValue(index + 1) > t)
+   for (index = 0; index < input.size()-2; index++) {
+      if (input.getFloatValue(index + 1) > t)
          break;
    }
 
    // get the data for the two control points either side of 't'
    Point2F v0;
-   v0.x = mInput.getFloatValue(index);
-   v0.y = mOutput.getStringArrayData(index)[offset];
+   v0.x = input.getFloatValue(index);
+   v0.y = output.getStringArrayData(index)[offset];
 
    Point2F v3;
-   v3.x = mInput.getFloatValue(index + 1);
-   v3.y = mOutput.getStringArrayData(index + 1)[offset];
+   v3.x = input.getFloatValue(index + 1);
+   v3.y = output.getStringArrayData(index + 1)[offset];
 
    // If spline interpolation is specified but the tangents are not available,
    // default to LINEAR.
-   const char* interp_method = mInterpolation.getStringValue(index);
+   const char* interp_method = interpolation.getStringValue(index);
    if (dStrEqual(interp_method, "BEZIER") ||
        dStrEqual(interp_method, "HERMITE") ||
        dStrEqual(interp_method, "CARDINAL")) {
 
-      const double* inArray = mInTangent.getStringArrayData(index + 1);
-      const double* outArray = mOutTangent.getStringArrayData(index);
+      const double* inArray = inTangent.getStringArrayData(index + 1);
+      const double* outArray = outTangent.getStringArrayData(index);
       if (!inArray || !outArray)
          interp_method = "LINEAR";
    }
@@ -398,17 +398,17 @@ void AnimData::interpValue(F32 t, U32 offset, double* value) const
          v2 = v3;
 
          if (index > 0) {
-            v0.x = mInput.getFloatValue(index-1);
-            v0.y = mOutput.getStringArrayData(index-1)[offset];
+            v0.x = input.getFloatValue(index-1);
+            v0.y = output.getStringArrayData(index-1)[offset];
          }
          else {
             // mirror P1 through P0
             v0 = v1 + (v1 - v2);
          }
 
-         if (index < (mInput.size()-2)) {
-            v3.x = mInput.getFloatValue(index+2);
-            v3.y = mOutput.getStringArrayData(index+2)[offset];
+         if (index < (input.size()-2)) {
+            v3.x = input.getFloatValue(index+2);
+            v3.y = output.getStringArrayData(index+2)[offset];
          }
          else {
             // mirror P0 through P1
@@ -416,10 +416,10 @@ void AnimData::interpValue(F32 t, U32 offset, double* value) const
          }
       }
       else {
-         const double* inArray = mInTangent.getStringArrayData(index + 1);
-         const double* outArray = mOutTangent.getStringArrayData(index);
+         const double* inArray = inTangent.getStringArrayData(index + 1);
+         const double* outArray = outTangent.getStringArrayData(index);
 
-         if (mOutput.stride() == mInTangent.stride()) {
+         if (output.stride() == inTangent.stride()) {
             // This degenerate form (1D control points) does 2 things wrong:
             // 1) it does not specify the key (time) value
             // 2) the control point is specified as a tangent for both bezier and hermite
@@ -458,27 +458,27 @@ void AnimData::interpValue(F32 t, U32 offset, double* value) const
 
 void AnimData::interpValue(F32 t, U32 offset, const char** value) const
 {
-   if (mInput.size() == 0)
+   if (input.size() == 0)
       *value = "";
-   else if (mInput.size() == 1)
-      *value = mOutput.getStringValue(0);
+   else if (input.size() == 1)
+      *value = output.getStringValue(0);
    else
    {
       // clamp time to valid range
-      F32 curveStart = mInput.getFloatValue(0);
-      F32 curveEnd = mInput.getFloatValue(mInput.size()-1);
+      F32 curveStart = input.getFloatValue(0);
+      F32 curveEnd = input.getFloatValue(input.size()-1);
       t = mClampF(t, curveStart, curveEnd);
 
       // find the index of the input keyframe BEFORE 't'
       S32 index;
-      for (index = 0; index < mInput.size()-2; index++) {
-         if (mInput.getFloatValue(index + 1) > t)
+      for (index = 0; index < input.size()-2; index++) {
+         if (input.getFloatValue(index + 1) > t)
             break;
       }
 
       // String values only support STEP interpolation, so just get the
       // value at the input keyframe
-      *value = mOutput.getStringValue(index);
+      *value = output.getStringValue(index);
    }
 }
 

--- a/Engine/source/ts/collada/colladaUtils.h
+++ b/Engine/source/ts/collada/colladaUtils.h
@@ -76,20 +76,20 @@ namespace ColladaUtils
          NumLodTypes
       };
 
-      domUpAxisType  mUpAxis;             // Override for the collada <up_axis> element
-      F32            mUnit;               // Override for the collada <unit> element
-      eLodType       mLodType;            // LOD type option
-      S32            mSingleDetailSize;   // Detail size for all meshes in the model
-      String         mMatNamePrefix;      // Prefix to apply to collada material names
-      String         mAlwaysImport;       // List of node names (with wildcards) to import, even if in the neverImport list
-      String         mNeverImport;        // List of node names (with wildcards) to ignore on loading
-      String         mAlwaysImportMesh;   // List of mesh names (with wildcards) to import, even if in the neverImportMesh list
-      String         mNeverImportMesh;    // List of mesh names (with wildcards) to ignore on loading
-      bool           mIgnoreNodeScale;    // Ignore <scale> elements in <node>s
-      bool           mAdjustCenter;       // Translate model so origin is at the center
-      bool           mAdjustFloor;        // Translate model so origin is at the bottom
-      bool           mForceUpdateMaterials;  // Force update of materials.cs
-      bool           mUseDiffuseNames;    // Use diffuse texture as the material name
+      domUpAxisType  upAxis;           // Override for the collada <up_axis> element
+      F32            unit;             // Override for the collada <unit> element
+      eLodType       lodType;          // LOD type option
+      S32            singleDetailSize; // Detail size for all meshes in the model
+      String         matNamePrefix;    // Prefix to apply to collada material names
+      String         alwaysImport;     // List of node names (with wildcards) to import, even if in the neverImport list
+      String         neverImport;      // List of node names (with wildcards) to ignore on loading
+      String         alwaysImportMesh; // List of mesh names (with wildcards) to import, even if in the neverImportMesh list
+      String         neverImportMesh;  // List of mesh names (with wildcards) to ignore on loading
+      bool           ignoreNodeScale;  // Ignore <scale> elements in <node>s
+      bool           adjustCenter;     // Translate model so origin is at the center
+      bool           adjustFloor;      // Translate model so origin is at the bottom
+      bool           forceUpdateMaterials;   // Force update of materials.cs
+      bool           useDiffuseNames;  // Use diffuse texture as the material name
 
       ImportOptions()
       {
@@ -98,20 +98,20 @@ namespace ColladaUtils
 
       void reset()
       {
-         mUpAxis = UPAXISTYPE_COUNT;
-         mUnit = -1.0f;
-         mLodType = DetectDTS;
-         mSingleDetailSize = 2;
-         mMatNamePrefix = "";
-         mAlwaysImport = "";
-         mNeverImport = "";
-         mAlwaysImportMesh = "";
-         mNeverImportMesh = "";
-         mIgnoreNodeScale = false;
-         mAdjustCenter = false;
-         mAdjustFloor = false;
-         mForceUpdateMaterials = false;
-         mUseDiffuseNames = false;
+         upAxis = UPAXISTYPE_COUNT;
+         unit = -1.0f;
+         lodType = DetectDTS;
+         singleDetailSize = 2;
+         matNamePrefix = "";
+         alwaysImport = "";
+         neverImport = "";
+         alwaysImportMesh = "";
+         neverImportMesh = "";
+         ignoreNodeScale = false;
+         adjustCenter = false;
+         adjustFloor = false;
+         forceUpdateMaterials = false;
+         useDiffuseNames = false;
       }
    };
 
@@ -291,27 +291,27 @@ template<> inline const char* _GetNameOrId(const domInstance_controller* element
 // is done until we actually try to extract values from the source.
 class _SourceReader
 {
-   const domSource* mSource;     // the wrapped Collada source
-   const domAccessor* mAccessor; // shortcut to the source accessor
-   Vector<U32> mOffsets;         // offset of each of the desired values to pull from the source array
+   const domSource* source;      // the wrapped Collada source
+   const domAccessor* accessor;  // shortcut to the source accessor
+   Vector<U32> offsets;          // offset of each of the desired values to pull from the source array
 
 public:
-   _SourceReader() : mSource(0), mAccessor(0) {}
+   _SourceReader() : source(0), accessor(0) {}
 
    void reset()
    {
-      mSource = 0;
-      mAccessor = 0;
-      mOffsets.clear();
+      source = 0;
+      accessor = 0;
+      offsets.clear();
    }
 
    //------------------------------------------------------
    // Initialize the _SourceReader object
    bool initFromSource(const domSource* src, const char* paramNames[] = 0)
    {
-      mSource = src;
-      mAccessor = mSource->getTechnique_common()->getAccessor();
-      mOffsets.clear();
+      source = src;
+      accessor = source->getTechnique_common()->getAccessor();
+      offsets.clear();
 
       // The source array has groups of values in a 1D stream => need to map the
       // input param names to source params to determine the offset within the
@@ -319,11 +319,11 @@ public:
       U32 paramCount = 0;
       while (paramNames && paramNames[paramCount][0]) {
          // lookup the index of the source param that matches the input param
-         mOffsets.push_back(paramCount);
-         for (U32 iParam = 0; iParam < mAccessor->getParam_array().getCount(); iParam++) {
-            if (mAccessor->getParam_array()[iParam]->getName() &&
-               dStrEqual(mAccessor->getParam_array()[iParam]->getName(), paramNames[paramCount])) {
-               mOffsets.last() = iParam;
+         offsets.push_back(paramCount);
+         for (U32 iParam = 0; iParam < accessor->getParam_array().getCount(); iParam++) {
+            if (accessor->getParam_array()[iParam]->getName() &&
+               dStrEqual(accessor->getParam_array()[iParam]->getName(), paramNames[paramCount])) {
+               offsets.last() = iParam;
                break;
             }
          }
@@ -331,9 +331,9 @@ public:
       }
 
       // If no input params were specified, just map the source params directly
-      if (!mOffsets.size()) {
-         for (S32 iParam = 0; iParam < mAccessor->getParam_array().getCount(); iParam++)
-            mOffsets.push_back(iParam);
+      if (!offsets.size()) {
+         for (S32 iParam = 0; iParam < accessor->getParam_array().getCount(); iParam++)
+            offsets.push_back(iParam);
       }
 
       return true;
@@ -341,10 +341,10 @@ public:
 
    //------------------------------------------------------
    // Shortcut to the size of the array (should be the number of destination objects)
-   S32 size() const { return mAccessor ? mAccessor->getCount() : 0; }
+   S32 size() const { return accessor ? accessor->getCount() : 0; }
 
    // Get the number of elements per group in the source
-   S32 stride() const { return mAccessor ? mAccessor->getStride() : 0; }
+   S32 stride() const { return accessor ? accessor->getStride() : 0; }
 
    //------------------------------------------------------
    // Get a pointer to the start of a group of values (index advances by stride)
@@ -353,8 +353,8 @@ public:
    const double* getStringArrayData(S32 index) const
    {
       if ((index >= 0) && (index < size())) {
-         if (mSource->getFloat_array())
-            return &mSource->getFloat_array()->getValue()[index*stride()];
+         if (source->getFloat_array())
+            return &source->getFloat_array()->getValue()[index*stride()];
       }
       return 0;
    }
@@ -367,10 +367,10 @@ public:
    {
       if ((index >= 0) && (index < size())) {
          // could be plain strings or IDREFs
-         if (mSource->getName_array())
-            return mSource->getName_array()->getValue()[index*stride()];
-         else if (mSource->getIDREF_array())
-            return mSource->getIDREF_array()->getValue()[index*stride()].getID();
+         if (source->getName_array())
+            return source->getName_array()->getValue()[index*stride()];
+         else if (source->getIDREF_array())
+            return source->getIDREF_array()->getValue()[index*stride()].getID();
       }
       return "";
    }
@@ -379,7 +379,7 @@ public:
    {
       F32 value(0);
       if (const double* data = getStringArrayData(index))
-         return data[mOffsets[0]];
+         return data[offsets[0]];
       return value;
    }
 
@@ -387,7 +387,7 @@ public:
    {
       Point2F value(0, 0);
       if (const double* data = getStringArrayData(index))
-         value.set(data[mOffsets[0]], data[mOffsets[1]]);
+         value.set(data[offsets[0]], data[offsets[1]]);
       return value;
    }
 
@@ -395,7 +395,7 @@ public:
    {
       Point3F value(1, 0, 0);
       if (const double* data = getStringArrayData(index))
-         value.set(data[mOffsets[0]], data[mOffsets[1]], data[mOffsets[2]]);
+         value.set(data[offsets[0]], data[offsets[1]], data[offsets[2]]);
       return value;
    }
 
@@ -404,11 +404,11 @@ public:
       ColorI value(255, 255, 255, 255);
       if (const double* data = getStringArrayData(index))
       {
-         value.red = data[mOffsets[0]] * 255.0;
-         value.green = data[mOffsets[1]] * 255.0;
-         value.blue = data[mOffsets[2]] * 255.0;
+         value.red = data[offsets[0]] * 255.0;
+         value.green = data[offsets[1]] * 255.0;
+         value.blue = data[offsets[2]] * 255.0;
          if ( stride() == 4 )
-            value.alpha = data[mOffsets[3]] * 255.0;
+            value.alpha = data[offsets[3]] * 255.0;
       }
       return value;
    }
@@ -477,14 +477,14 @@ public:
 /// Template child class for supported Collada primitive elements
 template<class T> class ColladaPrimitive : public BasePrimitive
 {
-   T* mPrimitive;
-   domListOfUInts *mTriangleData;
+   T* primitive;
+   domListOfUInts *pTriangleData;
    S32 stride;
 public:
-   ColladaPrimitive(const daeElement* e) : mTriangleData(0)
+   ColladaPrimitive(const daeElement* e) : pTriangleData(0)
    {
       // Cast to geometric primitive element
-      mPrimitive = daeSafeCast<T>(const_cast<daeElement*>(e));
+      primitive = daeSafeCast<T>(const_cast<daeElement*>(e));
 
       // Determine stride
       stride = 0;
@@ -495,13 +495,13 @@ public:
    }
    ~ColladaPrimitive()
    {
-      delete mTriangleData;
+      delete pTriangleData;
    }
 
    /// Most primitives can use these common implementations
-   const char* getElementName() { return mPrimitive->getElementName(); }
-   const char* getMaterial() { return mPrimitive->getMaterial(); }
-   const domInputLocalOffset_Array& getInputs() { return mPrimitive->getInput_array(); }
+   const char* getElementName() { return primitive->getElementName(); }
+   const char* getMaterial() { return primitive->getMaterial(); }
+   const domInputLocalOffset_Array& getInputs() { return primitive->getInput_array(); }
    S32 getStride() const { return stride; }
 
    /// Each supported primitive needs to implement this method (and convert
@@ -514,21 +514,21 @@ public:
 template<> inline const domListOfUInts *ColladaPrimitive<domTriangles>::getTriangleData()
 {
    // Return the <p> integer list directly
-   return (mPrimitive->getP() ? &(mPrimitive->getP()->getValue()) : NULL);
+   return (primitive->getP() ? &(primitive->getP()->getValue()) : NULL);
 }
 
 //-----------------------------------------------------------------------------
 // <tristrips>
 template<> inline const domListOfUInts *ColladaPrimitive<domTristrips>::getTriangleData()
 {
-   if (!mTriangleData)
+   if (!pTriangleData)
    {
       // Convert strips to triangles
-      mTriangleData = new domListOfUInts();
+      pTriangleData = new domListOfUInts();
 
-      for (S32 iStrip = 0; iStrip < mPrimitive->getCount(); iStrip++) {
+      for (S32 iStrip = 0; iStrip < primitive->getCount(); iStrip++) {
 
-         domP* P = mPrimitive->getP_array()[iStrip];
+         domP* P = primitive->getP_array()[iStrip];
 
          // Ignore invalid P arrays
          if (!P || !P->getValue().getCount())
@@ -543,33 +543,33 @@ template<> inline const domListOfUInts *ColladaPrimitive<domTristrips>::getTrian
             if (iTri & 0x1)
             {
                // CW triangle
-               mTriangleData->appendArray(stride, v0);
-               mTriangleData->appendArray(stride, v0 + 2*stride);
-               mTriangleData->appendArray(stride, v0 + stride);
+               pTriangleData->appendArray(stride, v0);
+               pTriangleData->appendArray(stride, v0 + 2*stride);
+               pTriangleData->appendArray(stride, v0 + stride);
             }
             else
             {
                // CCW triangle
-               mTriangleData->appendArray(stride*3, v0);
+               pTriangleData->appendArray(stride*3, v0);
             }
          }
       }
    }
-   return mTriangleData;
+   return pTriangleData;
 }
 
 //-----------------------------------------------------------------------------
 // <trifans>
 template<> inline const domListOfUInts *ColladaPrimitive<domTrifans>::getTriangleData()
 {
-   if (!mTriangleData)
+   if (!pTriangleData)
    {
       // Convert strips to triangles
-      mTriangleData = new domListOfUInts();
+      pTriangleData = new domListOfUInts();
 
-      for (S32 iStrip = 0; iStrip < mPrimitive->getCount(); iStrip++) {
+      for (S32 iStrip = 0; iStrip < primitive->getCount(); iStrip++) {
 
-         domP* P = mPrimitive->getP_array()[iStrip];
+         domP* P = primitive->getP_array()[iStrip];
 
          // Ignore invalid P arrays
          if (!P || !P->getValue().getCount())
@@ -581,27 +581,27 @@ template<> inline const domListOfUInts *ColladaPrimitive<domTrifans>::getTriangl
          // Convert the fan back to a triangle list
          domUint* v0 = pSrcData + stride;
          for (S32 iTri = 0; iTri < numTriangles; iTri++, v0 += stride) {
-            mTriangleData->appendArray(stride, pSrcData);   // shared vertex
-            mTriangleData->appendArray(stride, v0);         // previous vertex
-            mTriangleData->appendArray(stride, v0+stride);  // current vertex
+            pTriangleData->appendArray(stride, pSrcData);   // shared vertex
+            pTriangleData->appendArray(stride, v0);         // previous vertex
+            pTriangleData->appendArray(stride, v0+stride);  // current vertex
          }
       }
    }
-   return mTriangleData;
+   return pTriangleData;
 }
 
 //-----------------------------------------------------------------------------
 // <polygons>
 template<> inline const domListOfUInts *ColladaPrimitive<domPolygons>::getTriangleData()
 {
-   if (!mTriangleData)
+   if (!pTriangleData)
    {
       // Convert polygons to triangles
-      mTriangleData = new domListOfUInts();
+      pTriangleData = new domListOfUInts();
 
-      for (S32 iPoly = 0; iPoly < mPrimitive->getCount(); iPoly++) {
+      for (S32 iPoly = 0; iPoly < primitive->getCount(); iPoly++) {
 
-         domP* P = mPrimitive->getP_array()[iPoly];
+         domP* P = primitive->getP_array()[iPoly];
 
          // Ignore invalid P arrays
          if (!P || !P->getValue().getCount())
@@ -615,41 +615,41 @@ template<> inline const domListOfUInts *ColladaPrimitive<domPolygons>::getTriang
          domUint* v0 = pSrcData;
          pSrcData += stride;
          for (S32 iTri = 0; iTri < numPoints-2; iTri++) {
-            mTriangleData->appendArray(stride, v0);
-            mTriangleData->appendArray(stride*2, pSrcData);
+            pTriangleData->appendArray(stride, v0);
+            pTriangleData->appendArray(stride*2, pSrcData);
             pSrcData += stride;
          }
       }
    }
-   return mTriangleData;
+   return pTriangleData;
 }
 
 //-----------------------------------------------------------------------------
 // <polylist>
 template<> inline const domListOfUInts *ColladaPrimitive<domPolylist>::getTriangleData()
 {
-   if (!mTriangleData)
+   if (!pTriangleData)
    {
       // Convert polygons to triangles
-      mTriangleData = new domListOfUInts();
+      pTriangleData = new domListOfUInts();
 
       // Check that the P element has the right number of values (this
       // has been seen with certain models exported using COLLADAMax)
-      const domListOfUInts& vcount = mPrimitive->getVcount()->getValue();
+      const domListOfUInts& vcount = primitive->getVcount()->getValue();
 
       U32 expectedCount = 0;
       for (S32 iPoly = 0; iPoly < vcount.getCount(); iPoly++)
          expectedCount += vcount[iPoly];
       expectedCount *= stride;
 
-      if (!mPrimitive->getP() || !mPrimitive->getP()->getValue().getCount() ||
-         (mPrimitive->getP()->getValue().getCount() != expectedCount) )
+      if (!primitive->getP() || !primitive->getP()->getValue().getCount() ||
+         (primitive->getP()->getValue().getCount() != expectedCount) )
       {
          Con::warnf("<polylist> element found with invalid <p> array. This primitive will be ignored.");
-         return mTriangleData;
+         return pTriangleData;
       }
 
-      domUint* pSrcData = &(mPrimitive->getP()->getValue()[0]);
+      domUint* pSrcData = &(primitive->getP()->getValue()[0]);
       for (S32 iPoly = 0; iPoly < vcount.getCount(); iPoly++) {
 
          // Use a simple tri-fan (centered at the first point) method of
@@ -657,14 +657,14 @@ template<> inline const domListOfUInts *ColladaPrimitive<domPolylist>::getTriang
          domUint* v0 = pSrcData;
          pSrcData += stride;
          for (S32 iTri = 0; iTri < vcount[iPoly]-2; iTri++) {
-            mTriangleData->appendArray(stride, v0);
-            mTriangleData->appendArray(stride*2, pSrcData);
+            pTriangleData->appendArray(stride, v0);
+            pTriangleData->appendArray(stride*2, pSrcData);
             pSrcData += stride;
          }
          pSrcData += stride;
       }
    }
-   return mTriangleData;
+   return pTriangleData;
 }
 
 //-----------------------------------------------------------------------------
@@ -680,32 +680,32 @@ template<> inline F32 convert(const char* value) { return convert<double>(value)
 /// Collada animation data
 struct AnimChannels : public Vector<struct AnimData*>
 {
-   daeElement  *mElement;
-   AnimChannels(daeElement* el) : mElement(el)
+   daeElement  *element;
+   AnimChannels(daeElement* el) : element(el)
    {
-      mElement->setUserData(this);
+      element->setUserData(this);
    }
    ~AnimChannels()
    {
-      if (mElement)
-         mElement->setUserData(0);
+      if (element)
+         element->setUserData(0);
    }
 };
 
 struct AnimData
 {
-   bool           mEnabled;      ///!< Used to select animation channels for the current clip
+   bool           enabled;       ///!< Used to select animation channels for the current clip
 
-   _SourceReader  mInput;
-   _SourceReader  mOutput;
+   _SourceReader  input;
+   _SourceReader  output;
 
-   _SourceReader  mInTangent;
-   _SourceReader  mOutTangent;
+   _SourceReader  inTangent;
+   _SourceReader  outTangent;
 
-   _SourceReader  mInterpolation;
+   _SourceReader  interpolation;
 
-   U32 mTargetValueOffset;       ///< Offset into the target element (for arrays of values)
-   U32 mTargetValueCount;        ///< Number of values animated (from OUTPUT source array)
+   U32 targetValueOffset;        ///< Offset into the target element (for arrays of values)
+   U32 targetValueCount;         ///< Number of values animated (from OUTPUT source array)
 
    /// Get the animation channels for the Collada element (if any)
    static AnimChannels* getAnimChannels(const daeElement* element)
@@ -713,7 +713,7 @@ struct AnimData
       return element ? (AnimChannels*)const_cast<daeElement*>(element)->getUserData() : 0;
    }
 
-   AnimData() : mEnabled(false) { }
+   AnimData() : enabled(false) { }
 
    void parseTargetString(const char* target, S32 fullCount, const char* elements[]);
 
@@ -737,13 +737,13 @@ struct AnimData
 template<class T>
 struct AnimatedElement
 {
-   const daeElement* mElement;   ///< The Collada element (can be NULL)
-   T mDefaultVal;                ///< Default value (used when element is NULL)
+   const daeElement* element;    ///< The Collada element (can be NULL)
+   T defaultVal;                 ///< Default value (used when element is NULL)
 
-   AnimatedElement(const daeElement* e=0) : mElement(e) { }
+   AnimatedElement(const daeElement* e=0) : element(e) { }
 
    /// Check if the element has any animations channels
-   bool isAnimated() { return (AnimData::getAnimChannels(mElement) != 0); }
+   bool isAnimated() { return (AnimData::getAnimChannels(element) != 0); }
    bool isAnimated(F32 start, F32 end) { return isAnimated(); }
 
    /// Get the value of the element at the specified time
@@ -751,17 +751,17 @@ struct AnimatedElement
    {
       // If the element is NULL, just use the default (handy for <extra> profiles which
       // may or may not be present in the document)
-      T value(mDefaultVal);
-      if (const domAny* param = daeSafeCast<domAny>(const_cast<daeElement*>(mElement))) {
+      T value(defaultVal);
+      if (const domAny* param = daeSafeCast<domAny>(const_cast<daeElement*>(element))) {
          // If the element is not animated, just use its current value
          value = convert<T>(param->getValue());
 
          // Animate the value
-         const AnimChannels* channels = AnimData::getAnimChannels(mElement);
+         const AnimChannels* channels = AnimData::getAnimChannels(element);
          if (channels && (time >= 0)) {
             for (S32 iChannel = 0; iChannel < channels->size(); iChannel++) {
                const AnimData* animData = (*channels)[iChannel];
-               if (animData->mEnabled)
+               if (animData->enabled)
                   animData->interpValue(time, 0, &value);
             }
          }
@@ -781,19 +781,19 @@ template<class T> struct AnimatedElementList : public AnimatedElement<T>
    // Get the value of the element list at the specified time
    T getValue(F32 time)
    {
-      T vec(this->mDefaultVal);
-      if (this->mElement) {
+      T vec(this->defaultVal);
+      if (this->element) {
          // Get a copy of the vector
-         vec = *(T*)const_cast<daeElement*>(this->mElement)->getValuePointer();
+         vec = *(T*)const_cast<daeElement*>(this->element)->getValuePointer();
 
          // Animate the vector
-         const AnimChannels* channels = AnimData::getAnimChannels(this->mElement);
+         const AnimChannels* channels = AnimData::getAnimChannels(this->element);
          if (channels && (time >= 0)) {
             for (S32 iChannel = 0; iChannel < channels->size(); iChannel++) {
                const AnimData* animData = (*channels)[iChannel];
-               if (animData->mEnabled) {
-                  for (S32 iValue = 0; iValue < animData->mTargetValueCount; iValue++)
-                     animData->interpValue(time, iValue, &vec[animData->mTargetValueOffset + iValue]);
+               if (animData->enabled) {
+                  for (S32 iValue = 0; iValue < animData->targetValueCount; iValue++)
+                     animData->interpValue(time, iValue, &vec[animData->targetValueOffset + iValue]);
                }
             }
          }

--- a/Engine/source/ts/loader/appMesh.cpp
+++ b/Engine/source/ts/loader/appMesh.cpp
@@ -23,10 +23,10 @@
 #include "ts/loader/appMesh.h"
 #include "ts/loader/tsShapeLoader.h"
 
-Vector<AppMaterial*> AppMesh::mAppMaterials;
+Vector<AppMaterial*> AppMesh::appMaterials;
 
 AppMesh::AppMesh()
-   : mFlags(0), mNumFrames(0), mNumMatFrames(0), mVertsPerFrame(0)
+   : flags(0), numFrames(0), numMatFrames(0), vertsPerFrame(0)
 {
 }
 
@@ -44,43 +44,43 @@ void AppMesh::computeBounds(Box3F& bounds)
 
       // Setup bone transforms
       Vector<MatrixF> boneTransforms;
-      boneTransforms.setSize( mNodeIndex.size() );
+      boneTransforms.setSize( nodeIndex.size() );
       for (S32 iBone = 0; iBone < boneTransforms.size(); iBone++)
       {
-         MatrixF nodeMat = mBones[iBone]->getNodeTransform( TSShapeLoader::smDefaultTime );
+         MatrixF nodeMat = bones[iBone]->getNodeTransform( TSShapeLoader::DefaultTime );
          TSShapeLoader::zapScale(nodeMat);
-         boneTransforms[iBone].mul( nodeMat, mInitialTransforms[iBone] );
+         boneTransforms[iBone].mul( nodeMat, initialTransforms[iBone] );
       }
 
       // Multiply verts by weighted bone transforms
-      for (S32 iVert = 0; iVert < mInitialVerts.size(); iVert++)
-         mPoints[iVert].set( Point3F::Zero );
+      for (S32 iVert = 0; iVert < initialVerts.size(); iVert++)
+         points[iVert].set( Point3F::Zero );
 
-      for (S32 iWeight = 0; iWeight < mVertexIndex.size(); iWeight++)
+      for (S32 iWeight = 0; iWeight < vertexIndex.size(); iWeight++)
       {
-         const S32& vertIndex = mVertexIndex[iWeight];
-         const MatrixF& deltaTransform = boneTransforms[ mBoneIndex[iWeight] ];
+         const S32& vertIndex = vertexIndex[iWeight];
+         const MatrixF& deltaTransform = boneTransforms[ boneIndex[iWeight] ];
 
          Point3F v;
-         deltaTransform.mulP( mInitialVerts[vertIndex], &v );
-         v *= mWeight[iWeight];
+         deltaTransform.mulP( initialVerts[vertIndex], &v );
+         v *= weight[iWeight];
 
-         mPoints[vertIndex] += v;
+         points[vertIndex] += v;
       }
 
       // compute bounds for the skinned mesh
-      for (S32 iVert = 0; iVert < mInitialVerts.size(); iVert++)
-         bounds.extend( mPoints[iVert] );
+      for (S32 iVert = 0; iVert < initialVerts.size(); iVert++)
+         bounds.extend( points[iVert] );
    }
    else
    {
-      MatrixF transform = getMeshTransform(TSShapeLoader::smDefaultTime);
+      MatrixF transform = getMeshTransform(TSShapeLoader::DefaultTime);
       TSShapeLoader::zapScale(transform);
 
-      for (S32 iVert = 0; iVert < mPoints.size(); iVert++)
+      for (S32 iVert = 0; iVert < points.size(); iVert++)
       {
          Point3F p;
-         transform.mulP(mPoints[iVert], &p);
+         transform.mulP(points[iVert], &p);
          bounds.extend(p);
       }
    }
@@ -89,39 +89,39 @@ void AppMesh::computeBounds(Box3F& bounds)
 void AppMesh::computeNormals()
 {
    // Clear normals
-   mNormals.setSize( mPoints.size() );
-   for (S32 iNorm = 0; iNorm < mNormals.size(); iNorm++)
-      mNormals[iNorm] = Point3F::Zero;
+   normals.setSize( points.size() );
+   for (S32 iNorm = 0; iNorm < normals.size(); iNorm++)
+      normals[iNorm] = Point3F::Zero;
 
    // Sum triangle normals for each vertex
-   for (S32 iPrim = 0; iPrim < mPrimitives.size(); iPrim++)
+   for (S32 iPrim = 0; iPrim < primitives.size(); iPrim++)
    {
-      const TSDrawPrimitive& prim = mPrimitives[iPrim];
+      const TSDrawPrimitive& prim = primitives[iPrim];
 
       for (S32 iInd = 0; iInd < prim.numElements; iInd += 3)
       {
          // Compute the normal for this triangle
-         S32 idx0 = mIndices[prim.start + iInd + 0];
-         S32 idx1 = mIndices[prim.start + iInd + 1];
-         S32 idx2 = mIndices[prim.start + iInd + 2];
+         S32 idx0 = indices[prim.start + iInd + 0];
+         S32 idx1 = indices[prim.start + iInd + 1];
+         S32 idx2 = indices[prim.start + iInd + 2];
 
-         const Point3F& v0 = mPoints[idx0];
-         const Point3F& v1 = mPoints[idx1];
-         const Point3F& v2 = mPoints[idx2];
+         const Point3F& v0 = points[idx0];
+         const Point3F& v1 = points[idx1];
+         const Point3F& v2 = points[idx2];
 
          Point3F n;
          mCross(v2 - v0, v1 - v0, &n);
          n.normalize();    // remove this to use 'weighted' normals (large triangles will have more effect)
 
-         mNormals[idx0] += n;
-         mNormals[idx1] += n;
-         mNormals[idx2] += n;
+         normals[idx0] += n;
+         normals[idx1] += n;
+         normals[idx2] += n;
       }
    }
 
    // Normalize the vertex normals (this takes care of averaging the triangle normals)
-   for (S32 iNorm = 0; iNorm < mNormals.size(); iNorm++)
-      mNormals[iNorm].normalize();
+   for (S32 iNorm = 0; iNorm < normals.size(); iNorm++)
+      normals[iNorm].normalize();
 }
 
 TSMesh* AppMesh::constructTSMesh()
@@ -133,13 +133,13 @@ TSMesh* AppMesh::constructTSMesh()
       tsmesh = tsskin;
 
       // Copy skin elements
-      tsskin->mWeight = mWeight;
-      tsskin->mBoneIndex = mBoneIndex;
-      tsskin->mVertexIndex = mVertexIndex;
-      tsskin->mBatchData.nodeIndex = mNodeIndex;
-      tsskin->mBatchData.initialTransforms = mInitialTransforms;
-      tsskin->mBatchData.initialVerts = mInitialVerts;
-      tsskin->mBatchData.initialNorms = mInitialNorms;
+      tsskin->weight = weight;
+      tsskin->boneIndex = boneIndex;
+      tsskin->vertexIndex = vertexIndex;
+      tsskin->batchData.nodeIndex = nodeIndex;
+      tsskin->batchData.initialTransforms = initialTransforms;
+      tsskin->batchData.initialVerts = initialVerts;
+      tsskin->batchData.initialNorms = initialNorms;
    }
    else
    {
@@ -147,22 +147,22 @@ TSMesh* AppMesh::constructTSMesh()
    }
 
    // Copy mesh elements
-   tsmesh->mVerts = mPoints;
-   tsmesh->mNorms = mNormals;
-   tsmesh->mTVerts = mUVs;
-   tsmesh->mPrimitives = mPrimitives;
-   tsmesh->mIndices = mIndices;
-   tsmesh->mColors = mColors;
-   tsmesh->mTVerts2 = mUV2s;
+   tsmesh->verts = points;
+   tsmesh->norms = normals;
+   tsmesh->tverts = uvs;
+   tsmesh->primitives = primitives;
+   tsmesh->indices = indices;
+   tsmesh->colors = colors;
+   tsmesh->tverts2 = uv2s;
 
    // Finish initializing the shape
-   tsmesh->setFlags(mFlags);
+   tsmesh->setFlags(flags);
    tsmesh->computeBounds();
-   tsmesh->mNumFrames = mNumFrames;
-   tsmesh->mNumMatFrames = mNumMatFrames;
-   tsmesh->mVertsPerFrame = mVertsPerFrame;
-   tsmesh->createTangents(tsmesh->mVerts, tsmesh->mNorms);
-   tsmesh->mEncodedNorms.set(NULL,0);
+   tsmesh->numFrames = numFrames;
+   tsmesh->numMatFrames = numMatFrames;
+   tsmesh->vertsPerFrame = vertsPerFrame;
+   tsmesh->createTangents(tsmesh->verts, tsmesh->norms);
+   tsmesh->encodedNorms.set(NULL,0);
 
    return tsmesh;
 }

--- a/Engine/source/ts/loader/appMesh.h
+++ b/Engine/source/ts/loader/appMesh.h
@@ -42,33 +42,33 @@ class AppMesh
 {
 public:
    // Mesh and skin elements
-   Vector<Point3F> mPoints;
-   Vector<Point3F> mNormals;
-   Vector<Point2F> mUVs;
-   Vector<Point2F> mUV2s;
-   Vector<ColorI> mColors;
-   Vector<TSDrawPrimitive> mPrimitives;
-   Vector<U32> mIndices;
+   Vector<Point3F> points;
+   Vector<Point3F> normals;
+   Vector<Point2F> uvs;
+   Vector<Point2F> uv2s;
+   Vector<ColorI> colors;
+   Vector<TSDrawPrimitive> primitives;
+   Vector<U32> indices;
 
    // Skin elements
-   Vector<F32> mWeight;
-   Vector<S32> mBoneIndex;
-   Vector<S32> mVertexIndex;
-   Vector<S32> mNodeIndex;
-   Vector<MatrixF> mInitialTransforms;
-   Vector<Point3F> mInitialVerts;
-   Vector<Point3F> mInitialNorms;
+   Vector<F32> weight;
+   Vector<S32> boneIndex;
+   Vector<S32> vertexIndex;
+   Vector<S32> nodeIndex;
+   Vector<MatrixF> initialTransforms;
+   Vector<Point3F> initialVerts;
+   Vector<Point3F> initialNorms;
 
-   U32 mFlags;
-   U32 mVertsPerFrame;
-   S32 mNumFrames;
-   S32 mNumMatFrames;
+   U32 flags;
+   U32 vertsPerFrame;
+   S32 numFrames;
+   S32 numMatFrames;
 
    // Loader elements (can be discarded after loading)
-   S32                           mDetailSize;
-   MatrixF                       mObjectOffset;
-   Vector<AppNode*>              mBones;
-   static Vector<AppMaterial*>   mAppMaterials;
+   S32                           detailSize;
+   MatrixF                       objectOffset;
+   Vector<AppNode*>              bones;
+   static Vector<AppMaterial*>   appMaterials;
 
 public:
    AppMesh();

--- a/Engine/source/ts/loader/tsShapeLoader.cpp
+++ b/Engine/source/ts/loader/tsShapeLoader.cpp
@@ -40,11 +40,11 @@ MODULE_BEGIN( ShapeLoader )
    }
 MODULE_END;
 
-const F32 TSShapeLoader::smDefaultTime = -1.0f;
-const F64 TSShapeLoader::smMinFrameRate = 15.0f;
-const F64 TSShapeLoader::smMaxFrameRate = 60.0f;
-const F64 TSShapeLoader::smAppGroundFrameRate = 10.0f;
-Torque::Path TSShapeLoader::smShapePath;
+const F32 TSShapeLoader::DefaultTime = -1.0f;
+const F64 TSShapeLoader::MinFrameRate = 15.0f;
+const F64 TSShapeLoader::MaxFrameRate = 60.0f;
+const F64 TSShapeLoader::AppGroundFrameRate = 10.0f;
+Torque::Path TSShapeLoader::shapePath;
 
 Vector<TSShapeLoader::ShapeFormat> TSShapeLoader::smFormats;
 
@@ -68,26 +68,26 @@ MatrixF TSShapeLoader::getLocalNodeMatrix(AppNode* node, F32 t)
    MatrixF m1 = node->getNodeTransform(t);
 
    // multiply by inverse scale at t=0
-   MatrixF m10 = node->getNodeTransform(smDefaultTime);
+   MatrixF m10 = node->getNodeTransform(DefaultTime);
    m1.scale(Point3F(1.0f/m10.getScale().x, 1.0f/m10.getScale().y, 1.0f/m10.getScale().z));
 
    if (node->mParentIndex >= 0)
    {
-      AppNode *parent = mAppNodes[node->mParentIndex];
+      AppNode *parent = appNodes[node->mParentIndex];
 
       MatrixF m2 = parent->getNodeTransform(t);
 
       // multiply by inverse scale at t=0
-      MatrixF m20 = parent->getNodeTransform(smDefaultTime);
+      MatrixF m20 = parent->getNodeTransform(DefaultTime);
       m2.scale(Point3F(1.0f/m20.getScale().x, 1.0f/m20.getScale().y, 1.0f/m20.getScale().z));
 
       // get local transform by pre-multiplying by inverted parent transform
       m1 = m2.inverse() * m1;
    }
-   else if (mBoundsNode && node != mBoundsNode)
+   else if (boundsNode && node != boundsNode)
    {
       // make transform relative to bounds node transform at time=t
-      MatrixF mb = mBoundsNode->getNodeTransform(t);
+      MatrixF mb = boundsNode->getNodeTransform(t);
       zapScale(mb);
       m1 = mb.inverse() * m1;
    }
@@ -133,22 +133,22 @@ void TSShapeLoader::updateProgress(S32 major, const char* msg, S32 numMinor, S32
 
 TSShape* TSShapeLoader::generateShape(const Torque::Path& path)
 {
-   smShapePath = path;
-   mShape = new TSShape();
+   shapePath = path;
+   shape = new TSShape();
 
-   mShape->mExporterVersion = 124;
-   mShape->mSmallestVisibleSize = 999999;
-   mShape->mSmallestVisibleDL = 0;
-   mShape->mReadVersion = 24;
-   mShape->mFlags = 0;
-   mShape->mSequencesConstructed = 0;
+   shape->mExporterVersion = 124;
+   shape->mSmallestVisibleSize = 999999;
+   shape->mSmallestVisibleDL = 0;
+   shape->mReadVersion = 24;
+   shape->mFlags = 0;
+   shape->mSequencesConstructed = 0;
 
    // Get all nodes, objects and sequences in the shape
    updateProgress(Load_EnumerateScene, "Enumerating scene...");
    enumerateScene();
-   if (!mSubShapes.size())
+   if (!subshapes.size())
    {
-      delete mShape;
+      delete shape;
       Con::errorf("Failed to load shape \"%s\", no subshapes found", path.getFullPath().c_str());
       return NULL;
    }
@@ -178,7 +178,7 @@ TSShape* TSShapeLoader::generateShape(const Torque::Path& path)
    // Install the TS memory helper into a TSShape object.
    install();
 
-   return mShape;
+   return shape;
 }
 
 bool TSShapeLoader::processNode(AppNode* node)
@@ -186,23 +186,23 @@ bool TSShapeLoader::processNode(AppNode* node)
    // Detect bounds node
    if ( node->isBounds() )
    {
-      if ( mBoundsNode )
+      if ( boundsNode )
       {
          Con::warnf( "More than one bounds node found" );
          return false;
       }
-      mBoundsNode = node;
+      boundsNode = node;
 
       // Process bounds geometry
-      MatrixF boundsMat(mBoundsNode->getNodeTransform(smDefaultTime));
+      MatrixF boundsMat(boundsNode->getNodeTransform(DefaultTime));
       boundsMat.inverse();
       zapScale(boundsMat);
-      for (S32 iMesh = 0; iMesh < mBoundsNode->getNumMesh(); iMesh++)
+      for (S32 iMesh = 0; iMesh < boundsNode->getNumMesh(); iMesh++)
       {
-         AppMesh* mesh = mBoundsNode->getMesh(iMesh);
-         MatrixF transform = mesh->getMeshTransform(smDefaultTime);
+         AppMesh* mesh = boundsNode->getMesh(iMesh);
+         MatrixF transform = mesh->getMeshTransform(DefaultTime);
          transform.mulL(boundsMat);
-         mesh->lockMesh(smDefaultTime, transform);
+         mesh->lockMesh(DefaultTime, transform);
       }
       return true;
    }
@@ -215,10 +215,10 @@ bool TSShapeLoader::processNode(AppNode* node)
    }
 
    // Add this node to the subshape (create one if needed)
-   if ( mSubShapes.size() == 0 )
-      mSubShapes.push_back( new TSShapeLoader::Subshape );
+   if ( subshapes.size() == 0 )
+      subshapes.push_back( new TSShapeLoader::Subshape );
 
-   mSubShapes.last()->branches.push_back( node );
+   subshapes.last()->branches.push_back( node );
 
    return true;
 }
@@ -263,8 +263,8 @@ void TSShapeLoader::recurseSubshape(AppNode* appNode, S32 parentIndex, bool recu
    if (appNode->isBounds())
       return;
 
-   S32 subShapeNum = mShape->mSubShapeFirstNode.size()-1;
-   Subshape* subshape = mSubShapes[subShapeNum];
+   S32 subShapeNum = shape->subShapeFirstNode.size()-1;
+   Subshape* subshape = subshapes[subShapeNum];
 
    // Check if we should collapse this node
    S32 myIndex;
@@ -275,24 +275,24 @@ void TSShapeLoader::recurseSubshape(AppNode* appNode, S32 parentIndex, bool recu
    else
    {
       // Check that adding this node will not exceed the maximum node count
-      if (mShape->mNodes.size() >= MAX_TS_SET_SIZE)
+      if (shape->nodes.size() >= MAX_TS_SET_SIZE)
          return;
 
-      myIndex = mShape->mNodes.size();
-      String nodeName = getUniqueName(appNode->getName(), cmpShapeName, mShape->mNames);
+      myIndex = shape->nodes.size();
+      String nodeName = getUniqueName(appNode->getName(), cmpShapeName, shape->names);
 
       // Create the 3space node
-      mShape->mNodes.increment();
-      mShape->mNodes.last().nameIndex = mShape->addName(nodeName);
-      mShape->mNodes.last().parentIndex = parentIndex;
-      mShape->mNodes.last().firstObject = -1;
-      mShape->mNodes.last().firstChild = -1;
-      mShape->mNodes.last().nextSibling = -1;
+      shape->nodes.increment();
+      shape->nodes.last().nameIndex = shape->addName(nodeName);
+      shape->nodes.last().parentIndex = parentIndex;
+      shape->nodes.last().firstObject = -1;
+      shape->nodes.last().firstChild = -1;
+      shape->nodes.last().nextSibling = -1;
 
       // Add the AppNode to a matching list (so AppNodes can be accessed using 3space
       // node indices)
-      mAppNodes.push_back(appNode);
-      mAppNodes.last()->mParentIndex = parentIndex;
+      appNodes.push_back(appNode);
+      appNodes.last()->mParentIndex = parentIndex;
 
       // Check for NULL detail or AutoBillboard nodes (no children or geometry)
       if ((appNode->getNumChildNodes() == 0) &&
@@ -303,7 +303,7 @@ void TSShapeLoader::recurseSubshape(AppNode* appNode, S32 parentIndex, bool recu
 
          if (dStrEqual(dname, "nulldetail") && (size != 0x7FFFFFFF))
          {
-            mShape->addDetail("detail", size, subShapeNum);
+            shape->addDetail("detail", size, subShapeNum);
          }
          else if (appNode->isBillboard() && (size != 0x7FFFFFFF))
          {
@@ -322,13 +322,13 @@ void TSShapeLoader::recurseSubshape(AppNode* appNode, S32 parentIndex, bool recu
             appNode->getInt("BB::DIM", dim);
             appNode->getBool("BB::INCLUDE_POLES", includePoles);
 
-            S32 detIndex = mShape->addDetail( "bbDetail", size, -1 );
-            mShape->mDetails[detIndex].bbEquatorSteps = numEquatorSteps;
-            mShape->mDetails[detIndex].bbPolarSteps = numPolarSteps;
-            mShape->mDetails[detIndex].bbDetailLevel = dl;
-            mShape->mDetails[detIndex].bbDimension = dim;
-            mShape->mDetails[detIndex].bbIncludePoles = includePoles;
-            mShape->mDetails[detIndex].bbPolarAngle = polarAngle;
+            S32 detIndex = shape->addDetail( "bbDetail", size, -1 );
+            shape->details[detIndex].bbEquatorSteps = numEquatorSteps;
+            shape->details[detIndex].bbPolarSteps = numPolarSteps;
+            shape->details[detIndex].bbDetailLevel = dl;
+            shape->details[detIndex].bbDimension = dim;
+            shape->details[detIndex].bbIncludePoles = includePoles;
+            shape->details[detIndex].bbPolarAngle = polarAngle;
          }
       }
    }
@@ -354,23 +354,23 @@ void TSShapeLoader::recurseSubshape(AppNode* appNode, S32 parentIndex, bool recu
 
 void TSShapeLoader::generateSubshapes()
 {
-   for (U32 iSub = 0; iSub < mSubShapes.size(); iSub++)
+   for (U32 iSub = 0; iSub < subshapes.size(); iSub++)
    {
-      updateProgress(Load_GenerateSubshapes, "Generating subshapes...", mSubShapes.size(), iSub);
+      updateProgress(Load_GenerateSubshapes, "Generating subshapes...", subshapes.size(), iSub);
 
-      Subshape* subshape = mSubShapes[iSub];
+      Subshape* subshape = subshapes[iSub];
 
       // Recurse through the node hierarchy, adding 3space nodes and
       // collecting geometry
-      S32 firstNode = mShape->mNodes.size();
-      mShape->mSubShapeFirstNode.push_back(firstNode);      
+      S32 firstNode = shape->nodes.size();
+      shape->subShapeFirstNode.push_back(firstNode);      
 
       for (U32 iBranch = 0; iBranch < subshape->branches.size(); iBranch++)
          recurseSubshape(subshape->branches[iBranch], -1, true);
 
-      mShape->mSubShapeNumNodes.push_back(mShape->mNodes.size() - firstNode);
+      shape->subShapeNumNodes.push_back(shape->nodes.size() - firstNode);
 
-      if (mShape->mNodes.size() >= MAX_TS_SET_SIZE)
+      if (shape->nodes.size() >= MAX_TS_SET_SIZE)
       {
          Con::warnf("Shape exceeds the maximum node count (%d). Ignoring additional nodes.",
             MAX_TS_SET_SIZE);
@@ -388,7 +388,7 @@ bool cmpMeshNameAndSize(const String& key, const Vector<String>& names, void* ar
    {
       if (names[i].compare(key, 0, String::NoCase) == 0)
       {
-         if (meshes[i]->mDetailSize == meshSize)
+         if (meshes[i]->detailSize == meshSize)
             return false;
       }
    }
@@ -397,27 +397,27 @@ bool cmpMeshNameAndSize(const String& key, const Vector<String>& names, void* ar
 
 void TSShapeLoader::generateObjects()
 {
-   for (S32 iSub = 0; iSub < mSubShapes.size(); iSub++)
+   for (S32 iSub = 0; iSub < subshapes.size(); iSub++)
    {
-      Subshape* subshape = mSubShapes[iSub];
-      mShape->mSubShapeFirstObject.push_back(mShape->mObjects.size());
+      Subshape* subshape = subshapes[iSub];
+      shape->subShapeFirstObject.push_back(shape->objects.size());
 
       // Get the names and sizes of the meshes for this subshape
       Vector<String> meshNames;
       for (S32 iMesh = 0; iMesh < subshape->objMeshes.size(); iMesh++)
       {
          AppMesh* mesh = subshape->objMeshes[iMesh];
-         mesh->mDetailSize = 2;
-         String name = String::GetTrailingNumber( mesh->getName(), mesh->mDetailSize );
-         name = getUniqueName( name, cmpMeshNameAndSize, meshNames, &(subshape->objMeshes), (void*)mesh->mDetailSize );
+         mesh->detailSize = 2;
+         String name = String::GetTrailingNumber( mesh->getName(), mesh->detailSize );
+         name = getUniqueName( name, cmpMeshNameAndSize, meshNames, &(subshape->objMeshes), (void*)mesh->detailSize );
          meshNames.push_back( name );
 
          // Fix up any collision details that don't have a negative detail level.
          if (  dStrStartsWith(meshNames[iMesh], "Collision") ||
                dStrStartsWith(meshNames[iMesh], "LOSCol") )
          {
-            if (mesh->mDetailSize > 0)
-               mesh->mDetailSize = -mesh->mDetailSize;
+            if (mesh->detailSize > 0)
+               mesh->detailSize = -mesh->detailSize;
          }
       }
 
@@ -432,7 +432,7 @@ void TSShapeLoader::generateObjects()
          {
             if ((meshNames[i].compare(meshNames[j]) < 0) ||
                ((meshNames[i].compare(meshNames[j]) == 0) &&
-               (subshape->objMeshes[i]->mDetailSize < subshape->objMeshes[j]->mDetailSize)))
+               (subshape->objMeshes[i]->detailSize < subshape->objMeshes[j]->detailSize)))
             {
                {
                   AppMesh* tmp = subshape->objMeshes[i];
@@ -461,30 +461,30 @@ void TSShapeLoader::generateObjects()
 
          if (!lastName || (meshNames[iMesh] != *lastName))
          {
-            mShape->mObjects.increment();
-            mShape->mObjects.last().nameIndex = mShape->addName(meshNames[iMesh]);
-            mShape->mObjects.last().nodeIndex = subshape->objNodes[iMesh];
-            mShape->mObjects.last().startMeshIndex = mAppMeshes.size();
-            mShape->mObjects.last().numMeshes = 0;
+            shape->objects.increment();
+            shape->objects.last().nameIndex = shape->addName(meshNames[iMesh]);
+            shape->objects.last().nodeIndex = subshape->objNodes[iMesh];
+            shape->objects.last().startMeshIndex = appMeshes.size();
+            shape->objects.last().numMeshes = 0;
             lastName = &meshNames[iMesh];
          }
 
          // Add this mesh to the object
-         mAppMeshes.push_back(mesh);
-         mShape->mObjects.last().numMeshes++;
+         appMeshes.push_back(mesh);
+         shape->objects.last().numMeshes++;
 
          // Set mesh flags
-         mesh->mFlags = 0;
+         mesh->flags = 0;
          if (mesh->isBillboard())
          {
-            mesh->mFlags |= TSMesh::Billboard;
+            mesh->flags |= TSMesh::Billboard;
             if (mesh->isBillboardZAxis())
-               mesh->mFlags |= TSMesh::BillboardZAxis;
+               mesh->flags |= TSMesh::BillboardZAxis;
          }
 
          // Set the detail name... do fixups for collision details.
          const char* detailName = "detail";
-         if ( mesh->mDetailSize < 0 )
+         if ( mesh->detailSize < 0 )
          {
             if (  dStrStartsWith(meshNames[iMesh], "Collision") ||
                   dStrStartsWith(meshNames[iMesh], "Col") )
@@ -494,28 +494,28 @@ void TSShapeLoader::generateObjects()
          }
 
          // Attempt to add the detail (will fail if it already exists)
-         S32 oldNumDetails = mShape->mDetails.size();
-         mShape->addDetail(detailName, mesh->mDetailSize, iSub);
-         if (mShape->mDetails.size() > oldNumDetails)
+         S32 oldNumDetails = shape->details.size();
+         shape->addDetail(detailName, mesh->detailSize, iSub);
+         if (shape->details.size() > oldNumDetails)
          {
             Con::warnf("Object mesh \"%s\" has no matching detail (\"%s%d\" has"
-               " been added automatically)", mesh->getName(false), detailName, mesh->mDetailSize);
+               " been added automatically)", mesh->getName(false), detailName, mesh->detailSize);
          }
       }
 
       // Get object count for this subshape
-      mShape->mSubShapeNumObjects.push_back(mShape->mObjects.size() - mShape->mSubShapeFirstObject.last());
+      shape->subShapeNumObjects.push_back(shape->objects.size() - shape->subShapeFirstObject.last());
    }
 }
 
 void TSShapeLoader::generateSkins()
 {
    Vector<AppMesh*> skins;
-   for (S32 iObject = 0; iObject < mShape->mObjects.size(); iObject++)
+   for (S32 iObject = 0; iObject < shape->objects.size(); iObject++)
    {
-      for (S32 iMesh = 0; iMesh < mShape->mObjects[iObject].numMeshes; iMesh++)
+      for (S32 iMesh = 0; iMesh < shape->objects[iObject].numMeshes; iMesh++)
       {
-         AppMesh* mesh = mAppMeshes[mShape->mObjects[iObject].startMeshIndex + iMesh];
+         AppMesh* mesh = appMeshes[shape->objects[iObject].startMeshIndex + iMesh];
          if (mesh->isSkin())
             skins.push_back(mesh);
       }
@@ -530,30 +530,30 @@ void TSShapeLoader::generateSkins()
       skin->lookupSkinData();
 
       // Just copy initial verts and norms for now
-      skin->mInitialVerts.set(skin->mPoints.address(), skin->mVertsPerFrame);
-      skin->mInitialNorms.set(skin->mNormals.address(), skin->mVertsPerFrame);
+      skin->initialVerts.set(skin->points.address(), skin->vertsPerFrame);
+      skin->initialNorms.set(skin->normals.address(), skin->vertsPerFrame);
 
       // Map bones to nodes
-      skin->mNodeIndex.setSize(skin->mBones.size());
-      for (S32 iBone = 0; iBone < skin->mBones.size(); iBone++)
+      skin->nodeIndex.setSize(skin->bones.size());
+      for (S32 iBone = 0; iBone < skin->bones.size(); iBone++)
       {
          // Find the node that matches this bone
-         skin->mNodeIndex[iBone] = -1;
-         for (S32 iNode = 0; iNode < mAppNodes.size(); iNode++)
+         skin->nodeIndex[iBone] = -1;
+         for (S32 iNode = 0; iNode < appNodes.size(); iNode++)
          {
-            if (mAppNodes[iNode]->isEqual(skin->mBones[iBone]))
+            if (appNodes[iNode]->isEqual(skin->bones[iBone]))
             {
-               delete skin->mBones[iBone];
-               skin->mBones[iBone] = mAppNodes[iNode];
-               skin->mNodeIndex[iBone] = iNode;
+               delete skin->bones[iBone];
+               skin->bones[iBone] = appNodes[iNode];
+               skin->nodeIndex[iBone] = iNode;
                break;
             }
          }
 
-         if (skin->mNodeIndex[iBone] == -1)
+         if (skin->nodeIndex[iBone] == -1)
          {
             Con::warnf("Could not find bone %d. Defaulting to first node", iBone);
-            skin->mNodeIndex[iBone] = 0;
+            skin->nodeIndex[iBone] = 0;
          }
       }
    }
@@ -562,37 +562,37 @@ void TSShapeLoader::generateSkins()
 void TSShapeLoader::generateDefaultStates()
 {
    // Generate default object states (includes initial geometry)
-   for (S32 iObject = 0; iObject < mShape->mObjects.size(); iObject++)
+   for (S32 iObject = 0; iObject < shape->objects.size(); iObject++)
    {
       updateProgress(Load_GenerateDefaultStates, "Generating initial mesh and node states...",
-         mShape->mObjects.size(), iObject);
+         shape->objects.size(), iObject);
 
-      TSShape::Object& obj = mShape->mObjects[iObject];
+      TSShape::Object& obj = shape->objects[iObject];
 
       // Calculate the objectOffset for each mesh at T=0
       for (S32 iMesh = 0; iMesh < obj.numMeshes; iMesh++)
       {
-         AppMesh* appMesh = mAppMeshes[obj.startMeshIndex + iMesh];
-         AppNode* appNode = obj.nodeIndex >= 0 ? mAppNodes[obj.nodeIndex] : mBoundsNode;
+         AppMesh* appMesh = appMeshes[obj.startMeshIndex + iMesh];
+         AppNode* appNode = obj.nodeIndex >= 0 ? appNodes[obj.nodeIndex] : boundsNode;
 
-         MatrixF meshMat(appMesh->getMeshTransform(smDefaultTime));
-         MatrixF nodeMat(appMesh->isSkin() ? meshMat : appNode->getNodeTransform(smDefaultTime));
+         MatrixF meshMat(appMesh->getMeshTransform(DefaultTime));
+         MatrixF nodeMat(appMesh->isSkin() ? meshMat : appNode->getNodeTransform(DefaultTime));
 
          zapScale(nodeMat);
 
-         appMesh->mObjectOffset = nodeMat.inverse() * meshMat;
+         appMesh->objectOffset = nodeMat.inverse() * meshMat;
       }
 
-      generateObjectState(mShape->mObjects[iObject], smDefaultTime, true, true);
+      generateObjectState(shape->objects[iObject], DefaultTime, true, true);
    }
 
    // Generate default node transforms
-   for (S32 iNode = 0; iNode < mAppNodes.size(); iNode++)
+   for (S32 iNode = 0; iNode < appNodes.size(); iNode++)
    {
       // Determine the default translation and rotation for the node
       QuatF rot, srot;
       Point3F trans, scale;
-      generateNodeTransform(mAppNodes[iNode], smDefaultTime, false, 0, rot, trans, srot, scale);
+      generateNodeTransform(appNodes[iNode], DefaultTime, false, 0, rot, trans, srot, scale);
 
       // Add default node translation and rotation
       addNodeRotation(rot, true);
@@ -602,20 +602,20 @@ void TSShapeLoader::generateDefaultStates()
 
 void TSShapeLoader::generateObjectState(TSShape::Object& obj, F32 t, bool addFrame, bool addMatFrame)
 {
-   mShape->mObjectStates.increment();
-   TSShape::ObjectState& state = mShape->mObjectStates.last();
+   shape->objectStates.increment();
+   TSShape::ObjectState& state = shape->objectStates.last();
 
    state.frameIndex = 0;
    state.matFrameIndex = 0;
-   state.vis = mClampF(mAppMeshes[obj.startMeshIndex]->getVisValue(t), 0.0f, 1.0f);
+   state.vis = mClampF(appMeshes[obj.startMeshIndex]->getVisValue(t), 0.0f, 1.0f);
 
    if (addFrame || addMatFrame)
    {
       generateFrame(obj, t, addFrame, addMatFrame);
 
       // set the frame number for the object state
-      state.frameIndex = mAppMeshes[obj.startMeshIndex]->mNumFrames - 1;
-      state.matFrameIndex = mAppMeshes[obj.startMeshIndex]->mNumMatFrames - 1;
+      state.frameIndex = appMeshes[obj.startMeshIndex]->numFrames - 1;
+      state.matFrameIndex = appMeshes[obj.startMeshIndex]->numMatFrames - 1;
    }
 }
 
@@ -623,47 +623,47 @@ void TSShapeLoader::generateFrame(TSShape::Object& obj, F32 t, bool addFrame, bo
 {
    for (S32 iMesh = 0; iMesh < obj.numMeshes; iMesh++)
    {
-      AppMesh* appMesh = mAppMeshes[obj.startMeshIndex + iMesh];
+      AppMesh* appMesh = appMeshes[obj.startMeshIndex + iMesh];
 
-      U32 oldNumPoints = appMesh->mPoints.size();
-      U32 oldNumUvs = appMesh->mUVs.size();
+      U32 oldNumPoints = appMesh->points.size();
+      U32 oldNumUvs = appMesh->uvs.size();
 
       // Get the mesh geometry at time, 't'
       // Geometry verts, normals and tverts can be animated (different set for
       // each frame), but the TSDrawPrimitives stay the same, so the way lockMesh
       // works is that it will only generate the primitives once, then after that
       // will just append verts, normals and tverts each time it is called.
-      appMesh->lockMesh(t, appMesh->mObjectOffset);
+      appMesh->lockMesh(t, appMesh->objectOffset);
 
       // Calculate vertex normals if required
-      if (appMesh->mNormals.size() != appMesh->mPoints.size())
+      if (appMesh->normals.size() != appMesh->points.size())
          appMesh->computeNormals();
 
       // If this is the first call, set the number of points per frame
-      if (appMesh->mNumFrames == 0)
+      if (appMesh->numFrames == 0)
       {
-         appMesh->mVertsPerFrame = appMesh->mPoints.size();
+         appMesh->vertsPerFrame = appMesh->points.size();
       }
       else
       {
          // Check frame topology => ie. that the right number of points, normals
          // and tverts was added
-         if ((appMesh->mPoints.size() - oldNumPoints) != appMesh->mVertsPerFrame)
+         if ((appMesh->points.size() - oldNumPoints) != appMesh->vertsPerFrame)
          {
             Con::warnf("Wrong number of points (%d) added at time=%f (expected %d)",
-               appMesh->mPoints.size() - oldNumPoints, t, appMesh->mVertsPerFrame);
+               appMesh->points.size() - oldNumPoints, t, appMesh->vertsPerFrame);
             addFrame = false;
          }
-         if ((appMesh->mNormals.size() - oldNumPoints) != appMesh->mVertsPerFrame)
+         if ((appMesh->normals.size() - oldNumPoints) != appMesh->vertsPerFrame)
          {
             Con::warnf("Wrong number of normals (%d) added at time=%f (expected %d)",
-               appMesh->mNormals.size() - oldNumPoints, t, appMesh->mVertsPerFrame);
+               appMesh->normals.size() - oldNumPoints, t, appMesh->vertsPerFrame);
             addFrame = false;
          }
-         if ((appMesh->mUVs.size() - oldNumUvs) != appMesh->mVertsPerFrame)
+         if ((appMesh->uvs.size() - oldNumUvs) != appMesh->vertsPerFrame)
          {
             Con::warnf("Wrong number of tverts (%d) added at time=%f (expected %d)",
-               appMesh->mUVs.size() - oldNumUvs, t, appMesh->mVertsPerFrame);
+               appMesh->uvs.size() - oldNumUvs, t, appMesh->vertsPerFrame);
             addMatFrame = false;
          }
       }
@@ -674,21 +674,21 @@ void TSShapeLoader::generateFrame(TSShape::Object& obj, F32 t, bool addFrame, bo
       // points/normals/tverts are already in place!
       if (addFrame)
       {
-         appMesh->mNumFrames++;
+         appMesh->numFrames++;
       }
       else
       {
-         appMesh->mPoints.setSize(oldNumPoints);
-         appMesh->mNormals.setSize(oldNumPoints);
+         appMesh->points.setSize(oldNumPoints);
+         appMesh->normals.setSize(oldNumPoints);
       }
 
       if (addMatFrame)
       {
-         appMesh->mNumMatFrames++;
+         appMesh->numMatFrames++;
       }
       else
       {
-         appMesh->mUVs.setSize(oldNumPoints);
+         appMesh->uvs.setSize(oldNumPoints);
       }
    }
 }
@@ -700,13 +700,13 @@ void TSShapeLoader::generateFrame(TSShape::Object& obj, F32 t, bool addFrame, bo
 void TSShapeLoader::generateMaterialList()
 {
    // Install the materials into the material list
-   mShape->mMaterialList = new TSMaterialList;
-   for (S32 iMat = 0; iMat < AppMesh::mAppMaterials.size(); iMat++)
+   shape->materialList = new TSMaterialList;
+   for (S32 iMat = 0; iMat < AppMesh::appMaterials.size(); iMat++)
    {
-      updateProgress(Load_GenerateMaterials, "Generating materials...", AppMesh::mAppMaterials.size(), iMat);
+      updateProgress(Load_GenerateMaterials, "Generating materials...", AppMesh::appMaterials.size(), iMat);
 
-      AppMaterial* appMat = AppMesh::mAppMaterials[iMat];
-      mShape->mMaterialList->push_back(appMat->getName(), appMat->getFlags(), U32(-1), U32(-1), U32(-1), 1.0f, appMat->getReflectance());
+      AppMaterial* appMat = AppMesh::appMaterials[iMat];
+      shape->materialList->push_back(appMat->getName(), appMat->getFlags(), U32(-1), U32(-1), U32(-1), 1.0f, appMat->getReflectance());
    }
 }
 
@@ -716,38 +716,38 @@ void TSShapeLoader::generateMaterialList()
 
 void TSShapeLoader::generateSequences()
 {
-   for (S32 iSeq = 0; iSeq < mAppSequences.size(); iSeq++)
+   for (S32 iSeq = 0; iSeq < appSequences.size(); iSeq++)
    {
-      updateProgress(Load_GenerateSequences, "Generating sequences...", mAppSequences.size(), iSeq);
+      updateProgress(Load_GenerateSequences, "Generating sequences...", appSequences.size(), iSeq);
 
       // Initialize the sequence
-      mAppSequences[iSeq]->setActive(true);
+      appSequences[iSeq]->setActive(true);
 
-      mShape->mSequences.increment();
-      TSShape::Sequence& seq = mShape->mSequences.last();
+      shape->sequences.increment();
+      TSShape::Sequence& seq = shape->sequences.last();
 
-      seq.nameIndex = mShape->addName(mAppSequences[iSeq]->getName());
-      seq.toolBegin = mAppSequences[iSeq]->getStart();
-      seq.priority = mAppSequences[iSeq]->getPriority();
-      seq.flags = mAppSequences[iSeq]->getFlags();
+      seq.nameIndex = shape->addName(appSequences[iSeq]->getName());
+      seq.toolBegin = appSequences[iSeq]->getStart();
+      seq.priority = appSequences[iSeq]->getPriority();
+      seq.flags = appSequences[iSeq]->getFlags();
 
       // Compute duration and number of keyframes (then adjust time between frames to match)
-      seq.duration = mAppSequences[iSeq]->getEnd() - mAppSequences[iSeq]->getStart();
-      seq.numKeyframes = (S32)(seq.duration * mAppSequences[iSeq]->fps + 0.5f) + 1;
+      seq.duration = appSequences[iSeq]->getEnd() - appSequences[iSeq]->getStart();
+      seq.numKeyframes = (S32)(seq.duration * appSequences[iSeq]->fps + 0.5f) + 1;
 
       seq.sourceData.start = 0;
       seq.sourceData.end = seq.numKeyframes-1;
       seq.sourceData.total = seq.numKeyframes;
 
       // Set membership arrays (ie. which nodes and objects are affected by this sequence)
-      setNodeMembership(seq, mAppSequences[iSeq]);
-      setObjectMembership(seq, mAppSequences[iSeq]);
+      setNodeMembership(seq, appSequences[iSeq]);
+      setObjectMembership(seq, appSequences[iSeq]);
 
       // Generate keyframes
       generateNodeAnimation(seq);
-      generateObjectAnimation(seq, mAppSequences[iSeq]);
-      generateGroundAnimation(seq, mAppSequences[iSeq]);
-      generateFrameTriggers(seq, mAppSequences[iSeq]);
+      generateObjectAnimation(seq, appSequences[iSeq]);
+      generateGroundAnimation(seq, appSequences[iSeq]);
+      generateFrameTriggers(seq, appSequences[iSeq]);
 
       // Set sequence flags
       seq.dirtyFlags = 0;
@@ -761,11 +761,11 @@ void TSShapeLoader::generateSequences()
          seq.dirtyFlags |= TSShapeInstance::MatFrameDirty;
 
       // Set shape flags (only the most significant scale type)
-      U32 curVal = mShape->mFlags & TSShape::AnyScale;
-      mShape->mFlags &= ~(TSShape::AnyScale);
-      mShape->mFlags |= getMax(curVal, seq.flags & TSShape::AnyScale); // take the larger value (can only convert upwards)
+      U32 curVal = shape->mFlags & TSShape::AnyScale;
+      shape->mFlags &= ~(TSShape::AnyScale);
+      shape->mFlags |= getMax(curVal, seq.flags & TSShape::AnyScale); // take the larger value (can only convert upwards)
 
-      mAppSequences[iSeq]->setActive(false);
+      appSequences[iSeq]->setActive(false);
    }
 }
 
@@ -794,16 +794,16 @@ void TSShapeLoader::setNodeMembership(TSShape::Sequence& seq, const AppSequence*
 
 void TSShapeLoader::setRotationMembership(TSShape::Sequence& seq)
 {
-   for (S32 iNode = 0; iNode < mAppNodes.size(); iNode++)
+   for (S32 iNode = 0; iNode < appNodes.size(); iNode++)
    {
       // Check if any of the node rotations are different to
       // the default rotation
       QuatF defaultRot;
-      mShape->mDefaultRotations[iNode].getQuatF(&defaultRot);
+      shape->defaultRotations[iNode].getQuatF(&defaultRot);
 
       for (S32 iFrame = 0; iFrame < seq.numKeyframes; iFrame++)
       {
-         if (mNodeRotCache[iNode][iFrame] != defaultRot)
+         if (nodeRotCache[iNode][iFrame] != defaultRot)
          {
             seq.rotationMatters.set(iNode);
             break;
@@ -814,15 +814,15 @@ void TSShapeLoader::setRotationMembership(TSShape::Sequence& seq)
 
 void TSShapeLoader::setTranslationMembership(TSShape::Sequence& seq)
 {
-   for (S32 iNode = 0; iNode < mAppNodes.size(); iNode++)
+   for (S32 iNode = 0; iNode < appNodes.size(); iNode++)
    {
       // Check if any of the node translations are different to
       // the default translation
-      Point3F& defaultTrans = mShape->mDefaultTranslations[iNode];
+      Point3F& defaultTrans = shape->defaultTranslations[iNode];
 
       for (S32 iFrame = 0; iFrame < seq.numKeyframes; iFrame++)
       {
-         if (!mNodeTransCache[iNode][iFrame].equal(defaultTrans))
+         if (!nodeTransCache[iNode][iFrame].equal(defaultTrans))
          {
             seq.translationMatters.set(iNode);
             break;
@@ -839,16 +839,16 @@ void TSShapeLoader::setScaleMembership(TSShape::Sequence& seq)
    U32 alignedScaleCount = 0;
    U32 uniformScaleCount = 0;
 
-   for (S32 iNode = 0; iNode < mAppNodes.size(); iNode++)
+   for (S32 iNode = 0; iNode < appNodes.size(); iNode++)
    {
       // Check if any of the node scales are not the unit scale
       for (S32 iFrame = 0; iFrame < seq.numKeyframes; iFrame++)
       {
-         Point3F& scale = mNodeScaleCache[iNode][iFrame];
+         Point3F& scale = nodeScaleCache[iNode][iFrame];
          if (!unitScale.equal(scale))
          {
             // Determine what type of scale this is
-            if (!mNodeScaleRotCache[iNode][iFrame].isIdentity())
+            if (!nodeScaleRotCache[iNode][iFrame].isIdentity())
                arbitraryScaleCount++;
             else if (scale.x != scale.y || scale.y != scale.z)
                alignedScaleCount++;
@@ -876,12 +876,12 @@ void TSShapeLoader::setObjectMembership(TSShape::Sequence& seq, const AppSequenc
    seq.frameMatters.clearAll();        // vert animation (morph) (size = objects.size())
    seq.matFrameMatters.clearAll();     // UV animation (size = objects.size())
 
-   for (S32 iObject = 0; iObject < mShape->mObjects.size(); iObject++)
+   for (S32 iObject = 0; iObject < shape->objects.size(); iObject++)
    {
-      if (!mAppMeshes[mShape->mObjects[iObject].startMeshIndex])
+      if (!appMeshes[shape->objects[iObject].startMeshIndex])
          continue;
 
-      if (mAppMeshes[mShape->mObjects[iObject].startMeshIndex]->animatesVis(appSeq))
+      if (appMeshes[shape->objects[iObject].startMeshIndex]->animatesVis(appSeq))
          seq.visMatters.set(iObject);
       // Morph and UV animation has been deprecated
       //if (appMeshes[shape->objects[iObject].startMeshIndex]->animatesFrame(appSeq))
@@ -894,18 +894,18 @@ void TSShapeLoader::setObjectMembership(TSShape::Sequence& seq, const AppSequenc
 void TSShapeLoader::clearNodeTransformCache()
 {
    // clear out the transform caches
-   for (S32 i = 0; i < mNodeRotCache.size(); i++)
-      delete [] mNodeRotCache[i];
-   mNodeRotCache.clear();
-   for (S32 i = 0; i < mNodeTransCache.size(); i++)
-      delete [] mNodeTransCache[i];
-   mNodeTransCache.clear();
-   for (S32 i = 0; i < mNodeScaleRotCache.size(); i++)
-      delete [] mNodeScaleRotCache[i];
-   mNodeScaleRotCache.clear();
-   for (S32 i = 0; i < mNodeScaleCache.size(); i++)
-      delete [] mNodeScaleCache[i];
-   mNodeScaleCache.clear();
+   for (S32 i = 0; i < nodeRotCache.size(); i++)
+      delete [] nodeRotCache[i];
+   nodeRotCache.clear();
+   for (S32 i = 0; i < nodeTransCache.size(); i++)
+      delete [] nodeTransCache[i];
+   nodeTransCache.clear();
+   for (S32 i = 0; i < nodeScaleRotCache.size(); i++)
+      delete [] nodeScaleRotCache[i];
+   nodeScaleRotCache.clear();
+   for (S32 i = 0; i < nodeScaleCache.size(); i++)
+      delete [] nodeScaleCache[i];
+   nodeScaleCache.clear();
 }
 
 void TSShapeLoader::fillNodeTransformCache(TSShape::Sequence& seq, const AppSequence* appSeq)
@@ -913,28 +913,28 @@ void TSShapeLoader::fillNodeTransformCache(TSShape::Sequence& seq, const AppSequ
    // clear out the transform caches and set it up for this sequence
    clearNodeTransformCache();
 
-   mNodeRotCache.setSize(mAppNodes.size());
-   for (S32 i = 0; i < mNodeRotCache.size(); i++)
-      mNodeRotCache[i] = new QuatF[seq.numKeyframes];
-   mNodeTransCache.setSize(mAppNodes.size());
-   for (S32 i = 0; i < mNodeTransCache.size(); i++)
-      mNodeTransCache[i] = new Point3F[seq.numKeyframes];
-   mNodeScaleRotCache.setSize(mAppNodes.size());
-   for (S32 i = 0; i < mNodeScaleRotCache.size(); i++)
-      mNodeScaleRotCache[i] = new QuatF[seq.numKeyframes];
-   mNodeScaleCache.setSize(mAppNodes.size());
-   for (S32 i = 0; i < mNodeScaleCache.size(); i++)
-      mNodeScaleCache[i] = new Point3F[seq.numKeyframes];
+   nodeRotCache.setSize(appNodes.size());
+   for (S32 i = 0; i < nodeRotCache.size(); i++)
+      nodeRotCache[i] = new QuatF[seq.numKeyframes];
+   nodeTransCache.setSize(appNodes.size());
+   for (S32 i = 0; i < nodeTransCache.size(); i++)
+      nodeTransCache[i] = new Point3F[seq.numKeyframes];
+   nodeScaleRotCache.setSize(appNodes.size());
+   for (S32 i = 0; i < nodeScaleRotCache.size(); i++)
+      nodeScaleRotCache[i] = new QuatF[seq.numKeyframes];
+   nodeScaleCache.setSize(appNodes.size());
+   for (S32 i = 0; i < nodeScaleCache.size(); i++)
+      nodeScaleCache[i] = new Point3F[seq.numKeyframes];
 
    // get the node transforms for every frame
    for (S32 iFrame = 0; iFrame < seq.numKeyframes; iFrame++)
    {
       F32 time = appSeq->getStart() + seq.duration * iFrame / getMax(1, seq.numKeyframes - 1);
-      for (S32 iNode = 0; iNode < mAppNodes.size(); iNode++)
+      for (S32 iNode = 0; iNode < appNodes.size(); iNode++)
       {
-         generateNodeTransform(mAppNodes[iNode], time, seq.isBlend(), appSeq->getBlendRefTime(),
-                               mNodeRotCache[iNode][iFrame], mNodeTransCache[iNode][iFrame],
-                               mNodeScaleRotCache[iNode][iFrame], mNodeScaleCache[iNode][iFrame]);
+         generateNodeTransform(appNodes[iNode], time, seq.isBlend(), appSeq->getBlendRefTime(),
+                               nodeRotCache[iNode][iFrame], nodeTransCache[iNode][iFrame],
+                               nodeScaleRotCache[iNode][iFrame], nodeScaleCache[iNode][iFrame]);
       }
    }
 }
@@ -945,57 +945,57 @@ void TSShapeLoader::addNodeRotation(QuatF& rot, bool defaultVal)
    rot16.set(rot);
 
    if (!defaultVal)
-      mShape->mNodeRotations.push_back(rot16);
+      shape->nodeRotations.push_back(rot16);
    else
-      mShape->mDefaultRotations.push_back(rot16);
+      shape->defaultRotations.push_back(rot16);
 }
 
 void TSShapeLoader::addNodeTranslation(Point3F& trans, bool defaultVal)
 {
    if (!defaultVal)
-      mShape->mNodeTranslations.push_back(trans);
+      shape->nodeTranslations.push_back(trans);
    else
-      mShape->mDefaultTranslations.push_back(trans);
+      shape->defaultTranslations.push_back(trans);
 }
 
 void TSShapeLoader::addNodeUniformScale(F32 scale)
 {
-   mShape->mNodeUniformScales.push_back(scale);
+   shape->nodeUniformScales.push_back(scale);
 }
 
 void TSShapeLoader::addNodeAlignedScale(Point3F& scale)
 {
-   mShape->mNodeAlignedScales.push_back(scale);
+   shape->nodeAlignedScales.push_back(scale);
 }
 
 void TSShapeLoader::addNodeArbitraryScale(QuatF& qrot, Point3F& scale)
 {
    Quat16 rot16;
    rot16.set(qrot);
-   mShape->mNodeArbitraryScaleRots.push_back(rot16);
-   mShape->mNodeArbitraryScaleFactors.push_back(scale);
+   shape->nodeArbitraryScaleRots.push_back(rot16);
+   shape->nodeArbitraryScaleFactors.push_back(scale);
 }
 
 void TSShapeLoader::generateNodeAnimation(TSShape::Sequence& seq)
 {
-   seq.baseRotation = mShape->mNodeRotations.size();
-   seq.baseTranslation = mShape->mNodeTranslations.size();
-   seq.baseScale = (seq.flags & TSShape::ArbitraryScale) ? mShape->mNodeArbitraryScaleRots.size() :
-                   (seq.flags & TSShape::AlignedScale) ? mShape->mNodeAlignedScales.size() :
-                   mShape->mNodeUniformScales.size();
+   seq.baseRotation = shape->nodeRotations.size();
+   seq.baseTranslation = shape->nodeTranslations.size();
+   seq.baseScale = (seq.flags & TSShape::ArbitraryScale) ? shape->nodeArbitraryScaleRots.size() :
+                   (seq.flags & TSShape::AlignedScale) ? shape->nodeAlignedScales.size() :
+                   shape->nodeUniformScales.size();
 
-   for (S32 iNode = 0; iNode < mAppNodes.size(); iNode++)
+   for (S32 iNode = 0; iNode < appNodes.size(); iNode++)
    {
       for (S32 iFrame = 0; iFrame < seq.numKeyframes; iFrame++)
       {
          if (seq.rotationMatters.test(iNode))
-            addNodeRotation(mNodeRotCache[iNode][iFrame], false);
+            addNodeRotation(nodeRotCache[iNode][iFrame], false);
          if (seq.translationMatters.test(iNode))
-            addNodeTranslation(mNodeTransCache[iNode][iFrame], false);
+            addNodeTranslation(nodeTransCache[iNode][iFrame], false);
          if (seq.scaleMatters.test(iNode))
          {
-            QuatF& rot = mNodeScaleRotCache[iNode][iFrame];
-            Point3F scale = mNodeScaleCache[iNode][iFrame];
+            QuatF& rot = nodeScaleRotCache[iNode][iFrame];
+            Point3F scale = nodeScaleCache[iNode][iFrame];
 
             if (seq.flags & TSShape::ArbitraryScale)
                addNodeArbitraryScale(rot, scale);
@@ -1010,9 +1010,9 @@ void TSShapeLoader::generateNodeAnimation(TSShape::Sequence& seq)
 
 void TSShapeLoader::generateObjectAnimation(TSShape::Sequence& seq, const AppSequence* appSeq)
 {
-   seq.baseObjectState = mShape->mObjectStates.size();
+   seq.baseObjectState = shape->objectStates.size();
 
-   for (S32 iObject = 0; iObject < mShape->mObjects.size(); iObject++)
+   for (S32 iObject = 0; iObject < shape->objects.size(); iObject++)
    {
       bool visMatters = seq.visMatters.test(iObject);
       bool frameMatters = seq.frameMatters.test(iObject);
@@ -1023,7 +1023,7 @@ void TSShapeLoader::generateObjectAnimation(TSShape::Sequence& seq, const AppSeq
          for (S32 iFrame = 0; iFrame < seq.numKeyframes; iFrame++)
          {
             F32 time = appSeq->getStart() + seq.duration * iFrame / getMax(1, seq.numKeyframes - 1);
-            generateObjectState(mShape->mObjects[iObject], time, frameMatters, matFrameMatters);
+            generateObjectState(shape->objects[iObject], time, frameMatters, matFrameMatters);
          }
       }
    }
@@ -1031,19 +1031,19 @@ void TSShapeLoader::generateObjectAnimation(TSShape::Sequence& seq, const AppSeq
 
 void TSShapeLoader::generateGroundAnimation(TSShape::Sequence& seq, const AppSequence* appSeq)
 {
-   seq.firstGroundFrame = mShape->mGroundTranslations.size();
+   seq.firstGroundFrame = shape->groundTranslations.size();
    seq.numGroundFrames = 0;
 
-   if (!mBoundsNode)
+   if (!boundsNode)
       return;
 
    // Check if the bounds node is animated by this sequence
-   seq.numGroundFrames = (S32)((seq.duration + 0.25f/smAppGroundFrameRate) * smAppGroundFrameRate);
+   seq.numGroundFrames = (S32)((seq.duration + 0.25f/AppGroundFrameRate) * AppGroundFrameRate);
 
    seq.flags |= TSShape::MakePath;
 
    // Get ground transform at the start of the sequence
-   MatrixF invStartMat = mBoundsNode->getNodeTransform(appSeq->getStart());
+   MatrixF invStartMat = boundsNode->getNodeTransform(appSeq->getStart());
    zapScale(invStartMat);
    invStartMat.inverse();
 
@@ -1052,22 +1052,22 @@ void TSShapeLoader::generateGroundAnimation(TSShape::Sequence& seq, const AppSeq
       F32 time = appSeq->getStart() + seq.duration * iFrame / getMax(1, seq.numGroundFrames - 1);
 
       // Determine delta bounds node transform at 't'
-      MatrixF mat = mBoundsNode->getNodeTransform(time);
+      MatrixF mat = boundsNode->getNodeTransform(time);
       zapScale(mat);
       mat = invStartMat * mat;
 
       // Add ground transform
       Quat16 rotation;
       rotation.set(QuatF(mat));
-      mShape->mGroundTranslations.push_back(mat.getPosition());
-      mShape->mGroundRotations.push_back(rotation);
+      shape->groundTranslations.push_back(mat.getPosition());
+      shape->groundRotations.push_back(rotation);
    }
 }
 
 void TSShapeLoader::generateFrameTriggers(TSShape::Sequence& seq, const AppSequence* appSeq)
 {
    // Initialize triggers
-   seq.firstTrigger = mShape->mTriggers.size();
+   seq.firstTrigger = shape->triggers.size();
    seq.numTriggers  = appSeq->getNumTriggers();
    if (!seq.numTriggers)
       return;
@@ -1077,8 +1077,8 @@ void TSShapeLoader::generateFrameTriggers(TSShape::Sequence& seq, const AppSeque
    // Add triggers
    for (S32 iTrigger = 0; iTrigger < seq.numTriggers; iTrigger++)
    {
-      mShape->mTriggers.increment();
-      appSeq->getTrigger(iTrigger, mShape->mTriggers.last());
+      shape->triggers.increment();
+      appSeq->getTrigger(iTrigger, shape->triggers.last());
    }
 
    // Track the triggers that get turned off by this shape...normally, triggers
@@ -1088,7 +1088,7 @@ void TSShapeLoader::generateFrameTriggers(TSShape::Sequence& seq, const AppSeque
    U32 offTriggers = 0;
    for (S32 iTrigger = 0; iTrigger < seq.numTriggers; iTrigger++)
    {
-      U32 state = mShape->mTriggers[seq.firstTrigger+iTrigger].state;
+      U32 state = shape->triggers[seq.firstTrigger+iTrigger].state;
       if ((state & TSShape::Trigger::StateOn) == 0)
          offTriggers |= (state & TSShape::Trigger::StateMask);
    }
@@ -1096,8 +1096,8 @@ void TSShapeLoader::generateFrameTriggers(TSShape::Sequence& seq, const AppSeque
    // We now know which states are turned off, set invert on all those (including when turned on)
    for (int iTrigger = 0; iTrigger < seq.numTriggers; iTrigger++)
    {
-      if (mShape->mTriggers[seq.firstTrigger + iTrigger].state & offTriggers)
-         mShape->mTriggers[seq.firstTrigger + iTrigger].state |= TSShape::Trigger::InvertOnReverse;
+      if (shape->triggers[seq.firstTrigger + iTrigger].state & offTriggers)
+         shape->triggers[seq.firstTrigger + iTrigger].state |= TSShape::Trigger::InvertOnReverse;
    }
 }
 
@@ -1109,36 +1109,36 @@ void TSShapeLoader::sortDetails()
 
 
    // Insert NULL meshes where required
-   for (S32 iSub = 0; iSub < mSubShapes.size(); iSub++)
+   for (S32 iSub = 0; iSub < subshapes.size(); iSub++)
    {
       Vector<S32> validDetails;
-      mShape->getSubShapeDetails(iSub, validDetails);
+      shape->getSubShapeDetails(iSub, validDetails);
 
       for (S32 iDet = 0; iDet < validDetails.size(); iDet++)
       {
-         TSShape::Detail &detail = mShape->mDetails[validDetails[iDet]];
+         TSShape::Detail &detail = shape->details[validDetails[iDet]];
          if (detail.subShapeNum >= 0)
             detail.objectDetailNum = iDet;
 
-         for (S32 iObj = mShape->mSubShapeFirstObject[iSub];
-            iObj < (mShape->mSubShapeFirstObject[iSub] + mShape->mSubShapeNumObjects[iSub]);
+         for (S32 iObj = shape->subShapeFirstObject[iSub];
+            iObj < (shape->subShapeFirstObject[iSub] + shape->subShapeNumObjects[iSub]);
             iObj++)
          {
-            TSShape::Object &object = mShape->mObjects[iObj];
+            TSShape::Object &object = shape->objects[iObj];
 
             // Insert a NULL mesh for this detail level if required (ie. if the
             // object does not already have a mesh with an equal or higher detail)
             S32 meshIndex = (iDet < object.numMeshes) ? iDet : object.numMeshes-1;
 
-            if (mAppMeshes[object.startMeshIndex + meshIndex]->mDetailSize < mShape->mDetails[iDet].size)
+            if (appMeshes[object.startMeshIndex + meshIndex]->detailSize < shape->details[iDet].size)
             {
                // Add a NULL mesh
-               mAppMeshes.insert(object.startMeshIndex + iDet, NULL);
+               appMeshes.insert(object.startMeshIndex + iDet, NULL);
                object.numMeshes++;
 
                // Fixup the start index for the other objects
-               for (S32 k = iObj+1; k < mShape->mObjects.size(); k++)
-                  mShape->mObjects[k].startMeshIndex++;
+               for (S32 k = iObj+1; k < shape->objects.size(); k++)
+                  shape->objects[k].startMeshIndex++;
             }
          }
       }
@@ -1153,76 +1153,76 @@ void TSShapeLoader::install()
 {
    // Arrays that are filled in by ts shape init, but need
    // to be allocated beforehand.
-   mShape->mSubShapeFirstTranslucentObject.setSize(mShape->mSubShapeFirstObject.size());
+   shape->subShapeFirstTranslucentObject.setSize(shape->subShapeFirstObject.size());
 
    // Construct TS sub-meshes
-   mShape->mMeshes.setSize(mAppMeshes.size());
-   for (U32 m = 0; m < mAppMeshes.size(); m++)
-      mShape->mMeshes[m] = mAppMeshes[m] ? mAppMeshes[m]->constructTSMesh() : NULL;
+   shape->meshes.setSize(appMeshes.size());
+   for (U32 m = 0; m < appMeshes.size(); m++)
+      shape->meshes[m] = appMeshes[m] ? appMeshes[m]->constructTSMesh() : NULL;
 
    // Remove empty meshes and objects
-   for (S32 iObj = mShape->mObjects.size()-1; iObj >= 0; iObj--)
+   for (S32 iObj = shape->objects.size()-1; iObj >= 0; iObj--)
    {
-      TSShape::Object& obj = mShape->mObjects[iObj];
+      TSShape::Object& obj = shape->objects[iObj];
       for (S32 iMesh = obj.numMeshes-1; iMesh >= 0; iMesh--)
       {
-         TSMesh *mesh = mShape->mMeshes[obj.startMeshIndex + iMesh];
+         TSMesh *mesh = shape->meshes[obj.startMeshIndex + iMesh];
 
-         if (mesh && !mesh->mPrimitives.size())
+         if (mesh && !mesh->primitives.size())
          {
             S32 oldMeshCount = obj.numMeshes;
             destructInPlace(mesh);
-            mShape->removeMeshFromObject(iObj, iMesh);
+            shape->removeMeshFromObject(iObj, iMesh);
             iMesh -= (oldMeshCount - obj.numMeshes - 1);      // handle when more than one mesh is removed
          }
       }
 
       if (!obj.numMeshes)
-         mShape->removeObject(mShape->getName(obj.nameIndex));
+         shape->removeObject(shape->getName(obj.nameIndex));
    }
 
    // Add a dummy object if needed so the shape loads and renders ok
-   if (!mShape->mDetails.size())
+   if (!shape->details.size())
    {
-      mShape->addDetail("detail", 2, 0);
-      mShape->mSubShapeNumObjects.last() = 1;
+      shape->addDetail("detail", 2, 0);
+      shape->subShapeNumObjects.last() = 1;
 
-      mShape->mMeshes.push_back(NULL);
+      shape->meshes.push_back(NULL);
 
-      mShape->mObjects.increment();
-      mShape->mObjects.last().nameIndex = mShape->addName("dummy");
-      mShape->mObjects.last().nodeIndex = 0;
-      mShape->mObjects.last().startMeshIndex = 0;
-      mShape->mObjects.last().numMeshes = 1;
+      shape->objects.increment();
+      shape->objects.last().nameIndex = shape->addName("dummy");
+      shape->objects.last().nodeIndex = 0;
+      shape->objects.last().startMeshIndex = 0;
+      shape->objects.last().numMeshes = 1;
 
-      mShape->mObjectStates.increment();
-      mShape->mObjectStates.last().frameIndex = 0;
-      mShape->mObjectStates.last().matFrameIndex = 0;
-      mShape->mObjectStates.last().vis = 1.0f;
+      shape->objectStates.increment();
+      shape->objectStates.last().frameIndex = 0;
+      shape->objectStates.last().matFrameIndex = 0;
+      shape->objectStates.last().vis = 1.0f;
    }
 
    // Update smallest visible detail
-   mShape->mSmallestVisibleDL = -1;
-   mShape->mSmallestVisibleSize = 999999;
-   for (S32 i = 0; i < mShape->mDetails.size(); i++)
+   shape->mSmallestVisibleDL = -1;
+   shape->mSmallestVisibleSize = 999999;
+   for (S32 i = 0; i < shape->details.size(); i++)
    {
-      if ((mShape->mDetails[i].size >= 0) &&
-         (mShape->mDetails[i].size < mShape->mSmallestVisibleSize))
+      if ((shape->details[i].size >= 0) &&
+         (shape->details[i].size < shape->mSmallestVisibleSize))
       {
-         mShape->mSmallestVisibleDL = i;
-         mShape->mSmallestVisibleSize = mShape->mDetails[i].size;
+         shape->mSmallestVisibleDL = i;
+         shape->mSmallestVisibleSize = shape->details[i].size;
       }
    }
 
-   computeBounds(mShape->mBounds);
-   if (!mShape->mBounds.isValidBox())
-      mShape->mBounds = Box3F(1.0f);
+   computeBounds(shape->bounds);
+   if (!shape->bounds.isValidBox())
+      shape->bounds = Box3F(1.0f);
 
-   mShape->mBounds.getCenter(&mShape->mCenter);
-   mShape->mRadius = (mShape->mBounds.maxExtents - mShape->mCenter).len();
-   mShape->mTubeRadius = mShape->mRadius;
+   shape->bounds.getCenter(&shape->center);
+   shape->radius = (shape->bounds.maxExtents - shape->center).len();
+   shape->tubeRadius = shape->radius;
 
-   mShape->init();
+   shape->init();
 }
 
 void TSShapeLoader::computeBounds(Box3F& bounds)
@@ -1231,11 +1231,11 @@ void TSShapeLoader::computeBounds(Box3F& bounds)
    bounds = Box3F::Invalid;
 
    // Use bounds node geometry if present
-   if ( mBoundsNode && mBoundsNode->getNumMesh() )
+   if ( boundsNode && boundsNode->getNumMesh() )
    {
-      for (S32 iMesh = 0; iMesh < mBoundsNode->getNumMesh(); iMesh++)
+      for (S32 iMesh = 0; iMesh < boundsNode->getNumMesh(); iMesh++)
       {
-         AppMesh* mesh = mBoundsNode->getMesh( iMesh );
+         AppMesh* mesh = boundsNode->getMesh( iMesh );
          if ( !mesh )
             continue;
 
@@ -1248,9 +1248,9 @@ void TSShapeLoader::computeBounds(Box3F& bounds)
    else
    {
       // Compute bounds based on all geometry in the model
-      for (S32 iMesh = 0; iMesh < mAppMeshes.size(); iMesh++)
+      for (S32 iMesh = 0; iMesh < appMeshes.size(); iMesh++)
       {
-         AppMesh* mesh = mAppMeshes[iMesh];
+         AppMesh* mesh = appMeshes[iMesh];
          if ( !mesh )
             continue;
 
@@ -1267,19 +1267,19 @@ TSShapeLoader::~TSShapeLoader()
    clearNodeTransformCache();
 
    // Clear shared AppMaterial list
-   for (S32 iMat = 0; iMat < AppMesh::mAppMaterials.size(); iMat++)
-      delete AppMesh::mAppMaterials[iMat];
-   AppMesh::mAppMaterials.clear();
+   for (S32 iMat = 0; iMat < AppMesh::appMaterials.size(); iMat++)
+      delete AppMesh::appMaterials[iMat];
+   AppMesh::appMaterials.clear();
 
    // Delete Subshapes
-   delete mBoundsNode;
-   for (S32 iSub = 0; iSub < mSubShapes.size(); iSub++)
-      delete mSubShapes[iSub];
+   delete boundsNode;
+   for (S32 iSub = 0; iSub < subshapes.size(); iSub++)
+      delete subshapes[iSub];
 
    // Delete AppSequences
-   for (S32 iSeq = 0; iSeq < mAppSequences.size(); iSeq++)
-      delete mAppSequences[iSeq];
-   mAppSequences.clear();   
+   for (S32 iSeq = 0; iSeq < appSequences.size(); iSeq++)
+      delete appSequences[iSeq];
+   appSequences.clear();   
 }
 
 // Static functions to handle supported formats for shape loader.

--- a/Engine/source/ts/loader/tsShapeLoader.h
+++ b/Engine/source/ts/loader/tsShapeLoader.h
@@ -94,31 +94,31 @@ protected:
    };
 
 public:
-   static const F32 smDefaultTime;
-   static const F64 smMinFrameRate;
-   static const F64 smMaxFrameRate;
-   static const F64 smAppGroundFrameRate;
+   static const F32 DefaultTime;
+   static const F64 MinFrameRate;
+   static const F64 MaxFrameRate;
+   static const F64 AppGroundFrameRate;
 
 protected:
    // Variables used during loading that must be held until the shape is deleted
-   TSShape*                      mShape;
-   Vector<AppMesh*>              mAppMeshes;
+   TSShape*                      shape;
+   Vector<AppMesh*>              appMeshes;
 
    // Variables used during loading, but that can be discarded afterwards
-   static Torque::Path           smShapePath;
+   static Torque::Path           shapePath;
 
-   AppNode*                      mBoundsNode;
-   Vector<AppNode*>              mAppNodes;            ///< Nodes in the loaded shape
-   Vector<AppSequence*>          mAppSequences;
+   AppNode*                      boundsNode;
+   Vector<AppNode*>              appNodes;            ///< Nodes in the loaded shape
+   Vector<AppSequence*>          appSequences;
 
-   Vector<Subshape*>             mSubShapes;
+   Vector<Subshape*>             subshapes;
 
-   Vector<QuatF*>                mNodeRotCache;
-   Vector<Point3F*>              mNodeTransCache;
-   Vector<QuatF*>                mNodeScaleRotCache;
-   Vector<Point3F*>              mNodeScaleCache;
+   Vector<QuatF*>                nodeRotCache;
+   Vector<Point3F*>              nodeTransCache;
+   Vector<QuatF*>                nodeScaleRotCache;
+   Vector<Point3F*>              nodeScaleCache;
 
-   Point3F                       mShapeOffset;         ///< Offset used to translate the shape origin
+   Point3F                       shapeOffset;         ///< Offset used to translate the shape origin
 
    //--------------------------------------------------------------------------
 
@@ -183,10 +183,10 @@ protected:
    void install();
 
 public:
-   TSShapeLoader() : mBoundsNode(0) { }
+   TSShapeLoader() : boundsNode(0) { }
    virtual ~TSShapeLoader();
 
-   static const Torque::Path& getShapePath() { return smShapePath; }
+   static const Torque::Path& getShapePath() { return shapePath; }
 
    static void zapScale(MatrixF& mat);
 

--- a/Engine/source/ts/tsAnimate.cpp
+++ b/Engine/source/ts/tsAnimate.cpp
@@ -43,14 +43,14 @@ void TSShapeInstance::sortThreads()
 void TSShapeInstance::setDirty(U32 dirty)
 {
    AssertFatal((dirty & AllDirtyMask) == dirty,"TSShapeInstance::setDirty: illegal dirty flags");
-   for (S32 i=0; i<mShape->mSubShapeFirstNode.size(); i++)
+   for (S32 i=0; i<mShape->subShapeFirstNode.size(); i++)
       mDirtyFlags[i] |= dirty;
 }
 
 void TSShapeInstance::clearDirty(U32 dirty)
 {
    AssertFatal((dirty & AllDirtyMask) == dirty,"TSShapeInstance::clearDirty: illegal dirty flags");
-   for (S32 i=0; i<mShape->mSubShapeFirstNode.size(); i++)
+   for (S32 i=0; i<mShape->subShapeFirstNode.size(); i++)
       mDirtyFlags[i] &= ~dirty;
 }
 
@@ -62,25 +62,25 @@ void TSShapeInstance::animateNodes(S32 ss)
 {
    PROFILE_SCOPE( TSShapeInstance_animateNodes );
 
-   if (!mShape->mNodes.size())
+   if (!mShape->nodes.size())
       return;
 
    // @todo: When a node is added, we need to make sure to resize the nodeTransforms array as well
-   mNodeTransforms.setSize(mShape->mNodes.size());
+   mNodeTransforms.setSize(mShape->nodes.size());
 
    // temporary storage for node transforms
-   smNodeCurrentRotations.setSize(mShape->mNodes.size());
-   smNodeCurrentTranslations.setSize(mShape->mNodes.size());
-   smNodeLocalTransforms.setSize(mShape->mNodes.size());
-   smRotationThreads.setSize(mShape->mNodes.size());
-   smTranslationThreads.setSize(mShape->mNodes.size());
+   smNodeCurrentRotations.setSize(mShape->nodes.size());
+   smNodeCurrentTranslations.setSize(mShape->nodes.size());
+   smNodeLocalTransforms.setSize(mShape->nodes.size());
+   smRotationThreads.setSize(mShape->nodes.size());
+   smTranslationThreads.setSize(mShape->nodes.size());
 
    TSIntegerSet rotBeenSet;
    TSIntegerSet tranBeenSet;
    TSIntegerSet scaleBeenSet;
-   rotBeenSet.setAll(mShape->mNodes.size());
-   tranBeenSet.setAll(mShape->mNodes.size());
-   scaleBeenSet.setAll(mShape->mNodes.size());
+   rotBeenSet.setAll(mShape->nodes.size());
+   tranBeenSet.setAll(mShape->nodes.size());
+   scaleBeenSet.setAll(mShape->nodes.size());
    smNodeLocalTransformDirty.clearAll();
 
    S32 i,j,nodeIndex,a,b,start,end,firstBlend = mThreadList.size();
@@ -114,18 +114,18 @@ void TSShapeInstance::animateNodes(S32 ss)
    // we'll set default regardless of mask status
 
    // all the nodes marked above need to have the default transform
-   a = mShape->mSubShapeFirstNode[ss];
-   b = a + mShape->mSubShapeNumNodes[ss];
+   a = mShape->subShapeFirstNode[ss];
+   b = a + mShape->subShapeNumNodes[ss];
    for (i=a; i<b; i++)
    {
       if (rotBeenSet.test(i))
       {
-         mShape->mDefaultRotations[i].getQuatF(&smNodeCurrentRotations[i]);
+         mShape->defaultRotations[i].getQuatF(&smNodeCurrentRotations[i]);
          smRotationThreads[i] = NULL;
       }
       if (tranBeenSet.test(i))
       {
-         smNodeCurrentTranslations[i] = mShape->mDefaultTranslations[i];
+         smNodeCurrentTranslations[i] = mShape->defaultTranslations[i];
          smTranslationThreads[i] = NULL;
       }
    }
@@ -157,9 +157,9 @@ void TSShapeInstance::animateNodes(S32 ss)
          if (!rotBeenSet.test(nodeIndex))
          {
             QuatF q1,q2;
-            mShape->getRotation(*th->getSequence(),th->mKeyNum1,j,&q1);
-            mShape->getRotation(*th->getSequence(),th->mKeyNum2,j,&q2);
-            TSTransform::interpolate(q1,q2,th->mKeyPos,&smNodeCurrentRotations[nodeIndex]);
+            mShape->getRotation(*th->getSequence(),th->keyNum1,j,&q1);
+            mShape->getRotation(*th->getSequence(),th->keyNum2,j,&q2);
+            TSTransform::interpolate(q1,q2,th->keyPos,&smNodeCurrentRotations[nodeIndex]);
             rotBeenSet.set(nodeIndex);
             smRotationThreads[nodeIndex] = th;
          }
@@ -178,9 +178,9 @@ void TSShapeInstance::animateNodes(S32 ss)
                handleMaskedPositionNode(th,nodeIndex,j);
             else
             {
-               const Point3F & p1 = mShape->getTranslation(*th->getSequence(),th->mKeyNum1,j);
-               const Point3F & p2 = mShape->getTranslation(*th->getSequence(),th->mKeyNum2,j);
-               TSTransform::interpolate(p1,p2,th->mKeyPos,&smNodeCurrentTranslations[nodeIndex]);
+               const Point3F & p1 = mShape->getTranslation(*th->getSequence(),th->keyNum1,j);
+               const Point3F & p2 = mShape->getTranslation(*th->getSequence(),th->keyNum2,j);
+               TSTransform::interpolate(p1,p2,th->keyPos,&smNodeCurrentTranslations[nodeIndex]);
                smTranslationThreads[nodeIndex] = th;
             }
             tranBeenSet.set(nodeIndex);
@@ -222,7 +222,7 @@ void TSShapeInstance::animateNodes(S32 ss)
    for (i=firstBlend; i<mThreadList.size(); i++)
    {
       TSThread * th = mThreadList[i];
-      if (th->mBlendDisabled)
+      if (th->blendDisabled)
          continue;
 
       handleBlendSequence(th,a,b);
@@ -235,7 +235,7 @@ void TSShapeInstance::animateNodes(S32 ss)
    // multiply transforms...
    for (i=a; i<b; i++)
    {
-      S32 parentIdx = mShape->mNodes[i].parentIndex;
+      S32 parentIdx = mShape->nodes[i].parentIndex;
       if (parentIdx < 0)
          mNodeTransforms[i] = smNodeLocalTransforms[i];
       else
@@ -248,12 +248,12 @@ void TSShapeInstance::handleDefaultScale(S32 a, S32 b, TSIntegerSet & scaleBeenS
    // set default scale values (i.e., identity) and do any initialization
    // relating to animated scale (since scale normally not animated)
 
-   smScaleThreads.setSize(mShape->mNodes.size());
+   smScaleThreads.setSize(mShape->nodes.size());
    scaleBeenSet.takeAway(mCallbackNodes);
    scaleBeenSet.takeAway(mHandsOffNodes);
    if (animatesUniformScale())
    {
-      smNodeCurrentUniformScales.setSize(mShape->mNodes.size());
+      smNodeCurrentUniformScales.setSize(mShape->nodes.size());
       for (S32 i=a; i<b; i++)
          if (scaleBeenSet.test(i))
          {
@@ -263,7 +263,7 @@ void TSShapeInstance::handleDefaultScale(S32 a, S32 b, TSIntegerSet & scaleBeenS
    }
    else if (animatesAlignedScale())
    {
-      smNodeCurrentAlignedScales.setSize(mShape->mNodes.size());
+      smNodeCurrentAlignedScales.setSize(mShape->nodes.size());
       for (S32 i=a; i<b; i++)
          if (scaleBeenSet.test(i))
          {
@@ -273,7 +273,7 @@ void TSShapeInstance::handleDefaultScale(S32 a, S32 b, TSIntegerSet & scaleBeenS
    }
    else
    {
-      smNodeCurrentArbitraryScales.setSize(mShape->mNodes.size());
+      smNodeCurrentArbitraryScales.setSize(mShape->nodes.size());
       for (S32 i=a; i<b; i++)
          if (scaleBeenSet.test(i))
          {
@@ -330,7 +330,7 @@ void TSShapeInstance::handleTransitionNodes(S32 a, S32 b)
       if (nodeIndex<a)
          continue;
       TSThread * thread = smRotationThreads[nodeIndex];
-      thread = thread && thread->mTransitionData.inTransition ? thread : NULL;
+      thread = thread && thread->transitionData.inTransition ? thread : NULL;
       if (!thread)
       {
          // if not controlled by a sequence in transition then there must be
@@ -338,7 +338,7 @@ void TSShapeInstance::handleTransitionNodes(S32 a, S32 b)
          // transition now...use that thread to control interpolation
          for (S32 i=0; i<mTransitionThreads.size(); i++)
          {
-            if (mTransitionThreads[i]->mTransitionData.oldRotationNodes.test(nodeIndex) || mTransitionThreads[i]->getSequence()->rotationMatters.test(nodeIndex))
+            if (mTransitionThreads[i]->transitionData.oldRotationNodes.test(nodeIndex) || mTransitionThreads[i]->getSequence()->rotationMatters.test(nodeIndex))
             {
                thread = mTransitionThreads[i];
                break;
@@ -347,7 +347,7 @@ void TSShapeInstance::handleTransitionNodes(S32 a, S32 b)
          AssertFatal(thread!=NULL,"TSShapeInstance::handleRotTransitionNodes (rotation)");
       }
       QuatF tmpQ;
-      TSTransform::interpolate(mNodeReferenceRotations[nodeIndex].getQuatF(&tmpQ),smNodeCurrentRotations[nodeIndex],thread->mTransitionData.pos,&smNodeCurrentRotations[nodeIndex]);
+      TSTransform::interpolate(mNodeReferenceRotations[nodeIndex].getQuatF(&tmpQ),smNodeCurrentRotations[nodeIndex],thread->transitionData.pos,&smNodeCurrentRotations[nodeIndex]);
    }
 
    // then translation
@@ -356,7 +356,7 @@ void TSShapeInstance::handleTransitionNodes(S32 a, S32 b)
    for (nodeIndex=start; nodeIndex<end; mTransitionTranslationNodes.next(nodeIndex))
    {
       TSThread * thread = smTranslationThreads[nodeIndex];
-      thread = thread && thread->mTransitionData.inTransition ? thread : NULL;
+      thread = thread && thread->transitionData.inTransition ? thread : NULL;
       if (!thread)
       {
          // if not controlled by a sequence in transition then there must be
@@ -364,7 +364,7 @@ void TSShapeInstance::handleTransitionNodes(S32 a, S32 b)
          // transition now...use that thread to control interpolation
          for (S32 i=0; i<mTransitionThreads.size(); i++)
          {
-            if (mTransitionThreads[i]->mTransitionData.oldTranslationNodes.test(nodeIndex) || mTransitionThreads[i]->getSequence()->translationMatters.test(nodeIndex))
+            if (mTransitionThreads[i]->transitionData.oldTranslationNodes.test(nodeIndex) || mTransitionThreads[i]->getSequence()->translationMatters.test(nodeIndex))
             {
                thread = mTransitionThreads[i];
                break;
@@ -375,7 +375,7 @@ void TSShapeInstance::handleTransitionNodes(S32 a, S32 b)
       Point3F & p = smNodeCurrentTranslations[nodeIndex];
       Point3F & p1 = mNodeReferenceTranslations[nodeIndex];
       Point3F & p2 = p;
-      F32 k = thread->mTransitionData.pos;
+      F32 k = thread->transitionData.pos;
       p.x = p1.x + k * (p2.x-p1.x);
       p.y = p1.y + k * (p2.y-p1.y);
       p.z = p1.z + k * (p2.z-p1.z);
@@ -389,7 +389,7 @@ void TSShapeInstance::handleTransitionNodes(S32 a, S32 b)
       for (nodeIndex=start; nodeIndex<end; mTransitionScaleNodes.next(nodeIndex))
       {
          TSThread * thread = smScaleThreads[nodeIndex];
-         thread = thread && thread->mTransitionData.inTransition ? thread : NULL;
+         thread = thread && thread->transitionData.inTransition ? thread : NULL;
          if (!thread)
          {
             // if not controlled by a sequence in transition then there must be
@@ -397,7 +397,7 @@ void TSShapeInstance::handleTransitionNodes(S32 a, S32 b)
             // transition now...use that thread to control interpolation
             for (S32 i=0; i<mTransitionThreads.size(); i++)
             {
-               if (mTransitionThreads[i]->mTransitionData.oldScaleNodes.test(nodeIndex) || mTransitionThreads[i]->getSequence()->scaleMatters.test(nodeIndex))
+               if (mTransitionThreads[i]->transitionData.oldScaleNodes.test(nodeIndex) || mTransitionThreads[i]->getSequence()->scaleMatters.test(nodeIndex))
                {
                   thread = mTransitionThreads[i];
                   break;
@@ -406,14 +406,14 @@ void TSShapeInstance::handleTransitionNodes(S32 a, S32 b)
             AssertFatal(thread!=NULL,"TSShapeInstance::handleTransitionNodes (scale).");
          }
          if (animatesUniformScale())
-            smNodeCurrentUniformScales[nodeIndex] += thread->mTransitionData.pos * (mNodeReferenceUniformScales[nodeIndex]-smNodeCurrentUniformScales[nodeIndex]);
+            smNodeCurrentUniformScales[nodeIndex] += thread->transitionData.pos * (mNodeReferenceUniformScales[nodeIndex]-smNodeCurrentUniformScales[nodeIndex]);
          else if (animatesAlignedScale())
-            TSTransform::interpolate(mNodeReferenceScaleFactors[nodeIndex],smNodeCurrentAlignedScales[nodeIndex],thread->mTransitionData.pos,&smNodeCurrentAlignedScales[nodeIndex]);
+            TSTransform::interpolate(mNodeReferenceScaleFactors[nodeIndex],smNodeCurrentAlignedScales[nodeIndex],thread->transitionData.pos,&smNodeCurrentAlignedScales[nodeIndex]);
          else
          {
             QuatF q;
-            TSTransform::interpolate(mNodeReferenceScaleFactors[nodeIndex],smNodeCurrentArbitraryScales[nodeIndex].mScale,thread->mTransitionData.pos,&smNodeCurrentArbitraryScales[nodeIndex].mScale);
-            TSTransform::interpolate(mNodeReferenceArbitraryScaleRots[nodeIndex].getQuatF(&q),smNodeCurrentArbitraryScales[nodeIndex].mRotate,thread->mTransitionData.pos,&smNodeCurrentArbitraryScales[nodeIndex].mRotate);
+            TSTransform::interpolate(mNodeReferenceScaleFactors[nodeIndex],smNodeCurrentArbitraryScales[nodeIndex].mScale,thread->transitionData.pos,&smNodeCurrentArbitraryScales[nodeIndex].mScale);
+            TSTransform::interpolate(mNodeReferenceArbitraryScaleRots[nodeIndex].getQuatF(&q),smNodeCurrentArbitraryScales[nodeIndex].mRotate,thread->transitionData.pos,&smNodeCurrentArbitraryScales[nodeIndex].mRotate);
          }
       }
    }
@@ -498,26 +498,26 @@ void TSShapeInstance::handleAnimatedScale(TSThread * thread, S32 a, S32 b, TSInt
             case 4:  // uniform -> aligned
             case 8:  // uniform -> arbitrary
             {
-               F32 s1 = mShape->getUniformScale(*thread->getSequence(),thread->mKeyNum1,j);
-               F32 s2 = mShape->getUniformScale(*thread->getSequence(),thread->mKeyNum2,j);
-               uniformScale = TSTransform::interpolate(s1,s2,thread->mKeyPos);
+               F32 s1 = mShape->getUniformScale(*thread->getSequence(),thread->keyNum1,j);
+               F32 s2 = mShape->getUniformScale(*thread->getSequence(),thread->keyNum2,j);
+               uniformScale = TSTransform::interpolate(s1,s2,thread->keyPos);
                alignedScale.set(uniformScale,uniformScale,uniformScale);
                break;
             }
             case 5:  // aligned -> aligned
             case 9:  // aligned -> arbitrary
             {
-               const Point3F & s1 = mShape->getAlignedScale(*thread->getSequence(),thread->mKeyNum1,j);
-               const Point3F & s2 = mShape->getAlignedScale(*thread->getSequence(),thread->mKeyNum2,j);
-               TSTransform::interpolate(s1,s2,thread->mKeyPos,&alignedScale);
+               const Point3F & s1 = mShape->getAlignedScale(*thread->getSequence(),thread->keyNum1,j);
+               const Point3F & s2 = mShape->getAlignedScale(*thread->getSequence(),thread->keyNum2,j);
+               TSTransform::interpolate(s1,s2,thread->keyPos,&alignedScale);
                break;
             }
             case 10: // arbitrary -> arbitary
             {
                TSScale s1,s2;
-               mShape->getArbitraryScale(*thread->getSequence(),thread->mKeyNum1,j,&s1);
-               mShape->getArbitraryScale(*thread->getSequence(),thread->mKeyNum2,j,&s2);
-               TSTransform::interpolate(s1,s2,thread->mKeyPos,&arbitraryScale);
+               mShape->getArbitraryScale(*thread->getSequence(),thread->keyNum1,j,&s1);
+               mShape->getArbitraryScale(*thread->getSequence(),thread->keyNum2,j,&s2);
+               TSTransform::interpolate(s1,s2,thread->keyPos,&arbitraryScale);
                break;
             }
             default: AssertFatal(0,"TSShapeInstance::handleAnimatedScale"); break;
@@ -556,10 +556,10 @@ void TSShapeInstance::handleAnimatedScale(TSThread * thread, S32 a, S32 b, TSInt
 
 void TSShapeInstance::handleMaskedPositionNode(TSThread * th, S32 nodeIndex, S32 offset)
 {
-   const Point3F & p1 = mShape->getTranslation(*th->getSequence(),th->mKeyNum1,offset);
-   const Point3F & p2 = mShape->getTranslation(*th->getSequence(),th->mKeyNum2,offset);
+   const Point3F & p1 = mShape->getTranslation(*th->getSequence(),th->keyNum1,offset);
+   const Point3F & p2 = mShape->getTranslation(*th->getSequence(),th->keyNum2,offset);
    Point3F p;
-   TSTransform::interpolate(p1,p2,th->mKeyPos,&p);
+   TSTransform::interpolate(p1,p2,th->keyPos,&p);
 
    if (!mMaskPosXNodes.test(nodeIndex))
       smNodeCurrentTranslations[nodeIndex].x = p.x;
@@ -600,20 +600,20 @@ void TSShapeInstance::handleBlendSequence(TSThread * thread, S32 a, S32 b)
       if (thread->getSequence()->rotationMatters.test(nodeIndex))
       {
          QuatF q1,q2;
-         mShape->getRotation(*thread->getSequence(),thread->mKeyNum1,jrot,&q1);
-         mShape->getRotation(*thread->getSequence(),thread->mKeyNum2,jrot,&q2);
+         mShape->getRotation(*thread->getSequence(),thread->keyNum1,jrot,&q1);
+         mShape->getRotation(*thread->getSequence(),thread->keyNum2,jrot,&q2);
          QuatF quat;
-         TSTransform::interpolate(q1,q2,thread->mKeyPos,&quat);
+         TSTransform::interpolate(q1,q2,thread->keyPos,&quat);
          TSTransform::setMatrix(quat,&mat);
          jrot++;
       }
 
       if (thread->getSequence()->translationMatters.test(nodeIndex))
       {
-         const Point3F & p1 = mShape->getTranslation(*thread->getSequence(),thread->mKeyNum1,jtrans);
-         const Point3F & p2 = mShape->getTranslation(*thread->getSequence(),thread->mKeyNum2,jtrans);
+         const Point3F & p1 = mShape->getTranslation(*thread->getSequence(),thread->keyNum1,jtrans);
+         const Point3F & p2 = mShape->getTranslation(*thread->getSequence(),thread->keyNum2,jtrans);
          Point3F p;
-         TSTransform::interpolate(p1,p2,thread->mKeyPos,&p);
+         TSTransform::interpolate(p1,p2,thread->keyPos,&p);
          mat.setColumn(3,p);
          jtrans++;
       }
@@ -622,26 +622,26 @@ void TSShapeInstance::handleBlendSequence(TSThread * thread, S32 a, S32 b)
       {
          if (thread->getSequence()->animatesUniformScale())
          {
-            F32 s1 = mShape->getUniformScale(*thread->getSequence(),thread->mKeyNum1,jscale);
-            F32 s2 = mShape->getUniformScale(*thread->getSequence(),thread->mKeyNum2,jscale);
-            F32 scale = TSTransform::interpolate(s1,s2,thread->mKeyPos);
+            F32 s1 = mShape->getUniformScale(*thread->getSequence(),thread->keyNum1,jscale);
+            F32 s2 = mShape->getUniformScale(*thread->getSequence(),thread->keyNum2,jscale);
+            F32 scale = TSTransform::interpolate(s1,s2,thread->keyPos);
             TSTransform::applyScale(scale,&mat);
          }
          else if (animatesAlignedScale())
          {
-            Point3F s1 = mShape->getAlignedScale(*thread->getSequence(),thread->mKeyNum1,jscale);
-            Point3F s2 = mShape->getAlignedScale(*thread->getSequence(),thread->mKeyNum2,jscale);
+            Point3F s1 = mShape->getAlignedScale(*thread->getSequence(),thread->keyNum1,jscale);
+            Point3F s2 = mShape->getAlignedScale(*thread->getSequence(),thread->keyNum2,jscale);
             Point3F scale;
-            TSTransform::interpolate(s1,s2,thread->mKeyPos,&scale);
+            TSTransform::interpolate(s1,s2,thread->keyPos,&scale);
             TSTransform::applyScale(scale,&mat);
          }
          else
          {
             TSScale s1,s2;
-            mShape->getArbitraryScale(*thread->getSequence(),thread->mKeyNum1,jscale,&s1);
-            mShape->getArbitraryScale(*thread->getSequence(),thread->mKeyNum2,jscale,&s2);
+            mShape->getArbitraryScale(*thread->getSequence(),thread->keyNum1,jscale,&s1);
+            mShape->getArbitraryScale(*thread->getSequence(),thread->keyNum2,jscale,&s2);
             TSScale scale;
-            TSTransform::interpolate(s1,s2,thread->mKeyPos,&scale);
+            TSTransform::interpolate(s1,s2,thread->keyPos,&scale);
             TSTransform::applyScale(scale,&mat);
          }
          jscale++;
@@ -672,12 +672,12 @@ void TSShapeInstance::animateVisibility(S32 ss)
       beenSet.takeAway(mThreadList[i]->getSequence()->visMatters);
 
    // set defaults
-   S32 a = mShape->mSubShapeFirstObject[ss];
-   S32 b = a + mShape->mSubShapeNumObjects[ss];
+   S32 a = mShape->subShapeFirstObject[ss];
+   S32 b = a + mShape->subShapeNumObjects[ss];
    for (i=a; i<b; i++)
    {
       if (beenSet.test(i))
-         mMeshObjects[i].visible = mShape->mObjectStates[i].vis;
+         mMeshObjects[i].visible = mShape->objectStates[i].vis;
    }
 
    // go through each thread and set visibility on those objects that
@@ -704,14 +704,14 @@ void TSShapeInstance::animateVisibility(S32 ss)
       {
          if (!beenSet.test(objectIndex) && th->getSequence()->visMatters.test(objectIndex))
          {
-            F32 state1 = mShape->getObjectState(*th->getSequence(),th->mKeyNum1,j).vis;
-            F32 state2 = mShape->getObjectState(*th->getSequence(),th->mKeyNum2,j).vis;
+            F32 state1 = mShape->getObjectState(*th->getSequence(),th->keyNum1,j).vis;
+            F32 state2 = mShape->getObjectState(*th->getSequence(),th->keyNum2,j).vis;
             if ((state1-state2) * (state1-state2) > 0.99f)
                // goes from 0 to 1 -- discreet jump
-               mMeshObjects[objectIndex].visible = th->mKeyPos<0.5f ? state1 : state2;
+               mMeshObjects[objectIndex].visible = th->keyPos<0.5f ? state1 : state2;
             else
                // interpolate between keyframes when visibility change is gradual
-               mMeshObjects[objectIndex].visible = (1.0f-th->mKeyPos) * state1 + th->mKeyPos * state2;
+               mMeshObjects[objectIndex].visible = (1.0f-th->keyPos) * state1 + th->keyPos * state2;
 
             // record change so that later threads don't over-write us...
             beenSet.set(objectIndex);
@@ -735,11 +735,11 @@ void TSShapeInstance::animateFrame(S32 ss)
       beenSet.takeAway(mThreadList[i]->getSequence()->frameMatters);
 
    // set defaults
-   S32 a = mShape->mSubShapeFirstObject[ss];
-   S32 b = a + mShape->mSubShapeNumObjects[ss];
+   S32 a = mShape->subShapeFirstObject[ss];
+   S32 b = a + mShape->subShapeNumObjects[ss];
    for (i=a; i<b; i++)
       if (beenSet.test(i))
-         mMeshObjects[i].frame = mShape->mObjectStates[i].frameIndex;
+         mMeshObjects[i].frame = mShape->objectStates[i].frameIndex;
 
    // go through each thread and set frame on those objects that
    // are not set yet and are controlled by that thread
@@ -765,7 +765,7 @@ void TSShapeInstance::animateFrame(S32 ss)
       {
          if (!beenSet.test(objectIndex) && th->getSequence()->frameMatters.test(objectIndex))
          {
-            S32 key = (th->mKeyPos<0.5f) ? th->mKeyNum1 : th->mKeyNum2;
+            S32 key = (th->keyPos<0.5f) ? th->keyNum1 : th->keyNum2;
             mMeshObjects[objectIndex].frame = mShape->getObjectState(*th->getSequence(),key,j).frameIndex;
 
             // record change so that later threads don't over-write us...
@@ -790,11 +790,11 @@ void TSShapeInstance::animateMatFrame(S32 ss)
       beenSet.takeAway(mThreadList[i]->getSequence()->matFrameMatters);
 
    // set defaults
-   S32 a = mShape->mSubShapeFirstObject[ss];
-   S32 b = a + mShape->mSubShapeNumObjects[ss];
+   S32 a = mShape->subShapeFirstObject[ss];
+   S32 b = a + mShape->subShapeNumObjects[ss];
    for (i=a; i<b; i++)
       if (beenSet.test(i))
-         mMeshObjects[i].matFrame = mShape->mObjectStates[i].matFrameIndex;
+         mMeshObjects[i].matFrame = mShape->objectStates[i].matFrameIndex;
 
    // go through each thread and set matFrame on those objects that
    // are not set yet and are controlled by that thread
@@ -820,7 +820,7 @@ void TSShapeInstance::animateMatFrame(S32 ss)
       {
          if (!beenSet.test(objectIndex) && th->getSequence()->matFrameMatters.test(objectIndex))
          {
-            S32 key = (th->mKeyPos<0.5f) ? th->mKeyNum1 : th->mKeyNum2;
+            S32 key = (th->keyPos<0.5f) ? th->keyNum1 : th->keyNum2;
             mMeshObjects[objectIndex].matFrame = mShape->getObjectState(*th->getSequence(),key,j).matFrameIndex;
 
             // record change so that later threads don't over-write us...
@@ -842,7 +842,7 @@ void TSShapeInstance::animate(S32 dl)
       // nothing to do
       return;
 
-   S32 ss = mShape->mDetails[dl].subShapeNum;
+   S32 ss = mShape->details[dl].subShapeNum;
 
    // this is a billboard detail...
    if (ss<0)
@@ -878,7 +878,7 @@ void TSShapeInstance::animateNodeSubtrees(bool forceFull)
       // force transforms to animate
       setDirty(TransformDirty);
 
-   for (S32 i=0; i<mShape->mSubShapeNumNodes.size(); i++)
+   for (S32 i=0; i<mShape->subShapeNumNodes.size(); i++)
    {
       if (mDirtyFlags[i] & TransformDirty)
       {
@@ -896,7 +896,7 @@ void TSShapeInstance::animateSubtrees(bool forceFull)
       // force full animate
       setDirty(AllDirtyMask);
 
-   for (S32 i=0; i<mShape->mSubShapeNumNodes.size(); i++)
+   for (S32 i=0; i<mShape->subShapeNumNodes.size(); i++)
    {
       if (mDirtyFlags[i] & TransformDirty)
       {
@@ -909,7 +909,7 @@ void TSShapeInstance::animateSubtrees(bool forceFull)
 void TSShapeInstance::addPath(TSThread *gt, F32 start, F32 end, MatrixF *mat)
 {
    // never get here while in transition...
-   AssertFatal(!gt->mTransitionData.inTransition,"TSShapeInstance::addPath");
+   AssertFatal(!gt->transitionData.inTransition,"TSShapeInstance::addPath");
 
    if (!mat)
       mat = &mGroundTransform;
@@ -932,7 +932,7 @@ bool TSShapeInstance::initGround()
    for (S32 i=0; i<mThreadList.size(); i++)
    {
       TSThread * th = mThreadList[i];
-      if (!th->mTransitionData.inTransition && th->getSequence()->numGroundFrames>0)
+      if (!th->transitionData.inTransition && th->getSequence()->numGroundFrames>0)
       {
          mGroundThread = th;
          return true;
@@ -950,9 +950,9 @@ void TSShapeInstance::animateGround()
    if (!mGroundThread && !initGround())
       return;
 
-   S32 & loop    = mGroundThread->mPath.loop;
-   F32 & start = mGroundThread->mPath.start;
-   F32 & end   = mGroundThread->mPath.end;
+   S32 & loop    = mGroundThread->path.loop;
+   F32 & start = mGroundThread->path.start;
+   F32 & end   = mGroundThread->path.end;
 
    // accumulate path transform
    if (loop>0)
@@ -980,7 +980,7 @@ void TSShapeInstance::deltaGround(TSThread * thread, F32 start, F32 end, MatrixF
       mat = &mGroundTransform;
 
    mat->identity();
-   if (thread->mTransitionData.inTransition)
+   if (thread->transitionData.inTransition)
       return;
 
    F32 invDuration = 1.0f / thread->getDuration();
@@ -994,7 +994,7 @@ void TSShapeInstance::deltaGround(TSThread * thread, F32 start, F32 end, MatrixF
 void TSShapeInstance::deltaGround1(TSThread * thread, F32 start, F32 end, MatrixF& mat)
 {
    mat.identity();
-   if (thread->mTransitionData.inTransition)
+   if (thread->transitionData.inTransition)
       return;
    addPath(thread, start, end, &mat);
 }

--- a/Engine/source/ts/tsCollision.cpp
+++ b/Engine/source/ts/tsCollision.cpp
@@ -52,10 +52,10 @@ bool TSShapeInstance::buildPolyList(AbstractPolyList * polyList, S32 dl)
    if (dl==-1)
       return false;
 
-   AssertFatal(dl>=0 && dl<mShape->mDetails.size(),"TSShapeInstance::buildPolyList");
+   AssertFatal(dl>=0 && dl<mShape->details.size(),"TSShapeInstance::buildPolyList");
 
    // get subshape and object detail
-   const TSDetail * detail = &mShape->mDetails[dl];
+   const TSDetail * detail = &mShape->details[dl];
    S32 ss = detail->subShapeNum;
    S32 od = detail->objectDetailNum;
 
@@ -67,8 +67,8 @@ bool TSShapeInstance::buildPolyList(AbstractPolyList * polyList, S32 dl)
    bool emitted = false;
    U32 surfaceKey = 0;
 
-   S32 start = mShape->mSubShapeFirstObject[ss];
-   S32 end   = mShape->mSubShapeNumObjects[ss] + start;
+   S32 start = mShape->subShapeFirstObject[ss];
+   S32 end   = mShape->subShapeNumObjects[ss] + start;
    if (start<end)
    {
       MatrixF initialMat;
@@ -124,10 +124,10 @@ bool TSShapeInstance::getFeatures(const MatrixF& mat, const Point3F& n, ConvexFe
    if (dl==-1)
       return false;
 
-   AssertFatal(dl>=0 && dl<mShape->mDetails.size(),"TSShapeInstance::buildPolyList");
+   AssertFatal(dl>=0 && dl<mShape->details.size(),"TSShapeInstance::buildPolyList");
 
    // get subshape and object detail
-   const TSDetail * detail = &mShape->mDetails[dl];
+   const TSDetail * detail = &mShape->details[dl];
    S32 ss = detail->subShapeNum;
    S32 od = detail->objectDetailNum;
 
@@ -135,8 +135,8 @@ bool TSShapeInstance::getFeatures(const MatrixF& mat, const Point3F& n, ConvexFe
    bool emitted = false;
    U32 surfaceKey = 0;
 
-   S32 start = mShape->mSubShapeFirstObject[ss];
-   S32 end   = mShape->mSubShapeNumObjects[ss] + start;
+   S32 start = mShape->subShapeFirstObject[ss];
+   S32 end   = mShape->subShapeNumObjects[ss] + start;
    if (start<end)
    {
       MatrixF final;
@@ -168,10 +168,10 @@ bool TSShapeInstance::castRay(const Point3F & a, const Point3F & b, RayInfo * ra
    if (dl==-1)
       return false;
 
-   AssertFatal(dl>=0 && dl<mShape->mDetails.size(),"TSShapeInstance::castRay");
+   AssertFatal(dl>=0 && dl<mShape->details.size(),"TSShapeInstance::castRay");
 
    // get subshape and object detail
-   const TSDetail * detail = &mShape->mDetails[dl];
+   const TSDetail * detail = &mShape->details[dl];
    S32 ss = detail->subShapeNum;
    S32 od = detail->objectDetailNum;
 
@@ -179,8 +179,8 @@ bool TSShapeInstance::castRay(const Point3F & a, const Point3F & b, RayInfo * ra
    if ( ss < 0 )
       return false;
 
-   S32 start = mShape->mSubShapeFirstObject[ss];
-   S32 end   = mShape->mSubShapeNumObjects[ss] + start;
+   S32 start = mShape->subShapeFirstObject[ss];
+   S32 end   = mShape->subShapeNumObjects[ss] + start;
    RayInfo saveRay;
    saveRay.t = 1.0f;
    const MatrixF * saveMat = NULL;
@@ -255,18 +255,18 @@ bool TSShapeInstance::castRayRendered(const Point3F & a, const Point3F & b, RayI
    if (dl==-1)
       return false;
 
-   AssertFatal(dl>=0 && dl<mShape->mDetails.size(),"TSShapeInstance::castRayRendered");
+   AssertFatal(dl>=0 && dl<mShape->details.size(),"TSShapeInstance::castRayRendered");
 
    // get subshape and object detail
-   const TSDetail * detail = &mShape->mDetails[dl];
+   const TSDetail * detail = &mShape->details[dl];
    S32 ss = detail->subShapeNum;
    S32 od = detail->objectDetailNum;
 
    if ( ss == -1 )
       return false;
 
-   S32 start = mShape->mSubShapeFirstObject[ss];
-   S32 end   = mShape->mSubShapeNumObjects[ss] + start;
+   S32 start = mShape->subShapeFirstObject[ss];
+   S32 end   = mShape->subShapeNumObjects[ss] + start;
    RayInfo saveRay;
    saveRay.t = 1.0f;
    const MatrixF * saveMat = NULL;
@@ -339,15 +339,15 @@ Point3F TSShapeInstance::support(const Point3F & v, S32 dl)
 {
    // if dl==-1, nothing to do
    AssertFatal(dl != -1, "Error, should never try to collide with a non-existant detail level!");
-   AssertFatal(dl>=0 && dl<mShape->mDetails.size(),"TSShapeInstance::support");
+   AssertFatal(dl>=0 && dl<mShape->details.size(),"TSShapeInstance::support");
 
    // get subshape and object detail
-   const TSDetail * detail = &mShape->mDetails[dl];
+   const TSDetail * detail = &mShape->details[dl];
    S32 ss = detail->subShapeNum;
    S32 od = detail->objectDetailNum;
 
-   S32 start = mShape->mSubShapeFirstObject[ss];
-   S32 end   = mShape->mSubShapeNumObjects[ss] + start;
+   S32 start = mShape->subShapeFirstObject[ss];
+   S32 end   = mShape->subShapeNumObjects[ss] + start;
 
    F32     currMaxDP   = -1e9f;
    Point3F currSupport = Point3F(0, 0, 0);
@@ -404,22 +404,22 @@ void TSShapeInstance::computeBounds(S32 dl, Box3F & bounds)
    if (dl==-1)
       return;
 
-   AssertFatal(dl>=0 && dl<mShape->mDetails.size(),"TSShapeInstance::computeBounds");
+   AssertFatal(dl>=0 && dl<mShape->details.size(),"TSShapeInstance::computeBounds");
 
    // get subshape and object detail
-   const TSDetail * detail = &mShape->mDetails[dl];
+   const TSDetail * detail = &mShape->details[dl];
    S32 ss = detail->subShapeNum;
    S32 od = detail->objectDetailNum;
 
    // use shape bounds for imposter details
    if (ss < 0)
    {
-      bounds = mShape->mBounds;
+      bounds = mShape->bounds;
       return;
    }
 
-   S32 start = mShape->mSubShapeFirstObject[ss];
-   S32 end   = mShape->mSubShapeNumObjects[ss] + start;
+   S32 start = mShape->subShapeFirstObject[ss];
+   S32 end   = mShape->subShapeNumObjects[ss] + start;
 
    // run through objects and updating bounds as we go
    bounds.minExtents.set( 10E30f, 10E30f, 10E30f);
@@ -587,10 +587,10 @@ bool TSShapeInstance::buildPolyListOpcode( S32 dl, AbstractPolyList *polyList, c
    if (dl==-1)
       return false;
 
-   AssertFatal(dl>=0 && dl<mShape->mDetails.size(),"TSShapeInstance::buildPolyListOpcode");
+   AssertFatal(dl>=0 && dl<mShape->details.size(),"TSShapeInstance::buildPolyListOpcode");
 
    // get subshape and object detail
-   const TSDetail * detail = &mShape->mDetails[dl];
+   const TSDetail * detail = &mShape->details[dl];
    S32 ss = detail->subShapeNum;
    if ( ss < 0 )
       return false;
@@ -600,8 +600,8 @@ bool TSShapeInstance::buildPolyListOpcode( S32 dl, AbstractPolyList *polyList, c
    // nothing emitted yet...
    bool emitted = false;
 
-   S32 start = mShape->mSubShapeFirstObject[ss];
-   S32 end   = mShape->mSubShapeNumObjects[ss] + start;
+   S32 start = mShape->subShapeFirstObject[ss];
+   S32 end   = mShape->subShapeNumObjects[ss] + start;
    if (start<end)
    {
       MatrixF initialMat;
@@ -670,12 +670,12 @@ bool TSShapeInstance::castRayOpcode( S32 dl, const Point3F & startPos, const Poi
    if (dl==-1)
       return false;
 
-   AssertFatal(dl>=0 && dl<mShape->mDetails.size(),"TSShapeInstance::castRayOpcode");
+   AssertFatal(dl>=0 && dl<mShape->details.size(),"TSShapeInstance::castRayOpcode");
 
    info->t = 100.f;
 
    // get subshape and object detail
-   const TSDetail * detail = &mShape->mDetails[dl];
+   const TSDetail * detail = &mShape->details[dl];
    S32 ss = detail->subShapeNum;
    if ( ss < 0 )
       return false;
@@ -686,8 +686,8 @@ bool TSShapeInstance::castRayOpcode( S32 dl, const Point3F & startPos, const Poi
    bool emitted = false;
 
    const MatrixF* saveMat = NULL;
-   S32 start = mShape->mSubShapeFirstObject[ss];
-   S32 end   = mShape->mSubShapeNumObjects[ss] + start;
+   S32 start = mShape->subShapeFirstObject[ss];
+   S32 end   = mShape->subShapeNumObjects[ss] + start;
    if (start<end)
    {
       MatrixF mat;
@@ -742,18 +742,18 @@ bool TSShapeInstance::castRayOpcode( S32 dl, const Point3F & startPos, const Poi
 
 bool TSShapeInstance::buildConvexOpcode( const MatrixF &objMat, const Point3F &objScale, S32 dl, const Box3F &bounds, Convex *c, Convex *list )
 {
-   AssertFatal(dl>=0 && dl<mShape->mDetails.size(),"TSShapeInstance::buildConvexOpcode");
+   AssertFatal(dl>=0 && dl<mShape->details.size(),"TSShapeInstance::buildConvexOpcode");
 
    // get subshape and object detail
-   const TSDetail * detail = &mShape->mDetails[dl];
+   const TSDetail * detail = &mShape->details[dl];
    S32 ss = detail->subShapeNum;
    S32 od = detail->objectDetailNum;
 
    // nothing emitted yet...
    bool emitted = false;
 
-   S32 start = mShape->mSubShapeFirstObject[ss];
-   S32 end   = mShape->mSubShapeNumObjects[ss] + start;
+   S32 start = mShape->subShapeFirstObject[ss];
+   S32 end   = mShape->subShapeNumObjects[ss] + start;
    if (start<end)
    {
       MatrixF initialMat = objMat;
@@ -823,10 +823,10 @@ void TSShape::findColDetails( bool useVisibleMesh, Vector<S32> *outDetails, Vect
       U32 highestDetail = -1;
       F32 highestSize = -F32_MAX;
 
-      for ( U32 i = 0; i < mDetails.size(); i++ )
+      for ( U32 i = 0; i < details.size(); i++ )
       {
          // Make sure we skip any details that shouldn't be rendered
-         if ( mDetails[i].size < 0 )
+         if ( details[i].size < 0 )
             continue;
 
          /*
@@ -838,10 +838,10 @@ void TSShape::findColDetails( bool useVisibleMesh, Vector<S32> *outDetails, Vect
          */
 
          // Otherwise test against the current highest size
-         if ( mDetails[i].size > highestSize )
+         if ( details[i].size > highestSize )
          {
             highestDetail = i;
-            highestSize = mDetails[i].size;
+            highestSize = details[i].size;
          }
       }
 
@@ -861,9 +861,9 @@ void TSShape::findColDetails( bool useVisibleMesh, Vector<S32> *outDetails, Vect
    //
    // The LOS (light of sight) details are used for raycasts.
 
-   for ( U32 i = 0; i < mDetails.size(); i++ )
+   for ( U32 i = 0; i < details.size(); i++ )
    {
-      const String &name = mNames[ mDetails[i].nameIndex ];
+      const String &name = names[ details[i].nameIndex ];
       if ( !dStrStartsWith( name, "Collision" ) )
          continue;
 
@@ -906,9 +906,9 @@ void TSShape::findColDetails( bool useVisibleMesh, Vector<S32> *outDetails, Vect
 
    // Snag any "unmatched" LOS details and put 
    // them at the end of the list.
-   for ( U32 i = 0; i < mDetails.size(); i++ )
+   for ( U32 i = 0; i < details.size(); i++ )
    {
-      const String &name = mNames[ mDetails[i].nameIndex ];
+      const String &name = names[ details[i].nameIndex ];
       if ( !dStrStartsWith( name, "LOS" ) )
          continue;
 
@@ -954,7 +954,7 @@ PhysicsCollision* TSShape::_buildColShapes( bool useVisibleMesh, const Point3F &
       // visible detail levels.
 
       // A negative subshape on the detail means we don't have geometry.
-      const TSShape::Detail &detail = mDetails[0];     
+      const TSShape::Detail &detail = details[0];     
       if ( detail.subShapeNum < 0 )
          return NULL;
 
@@ -964,16 +964,16 @@ PhysicsCollision* TSShape::_buildColShapes( bool useVisibleMesh, const Point3F &
       polyList.setTransform( &MatrixF::Identity, scale );
 
       // Create the collision meshes.
-      S32 start = mSubShapeFirstObject[ detail.subShapeNum ];
-      S32 end = start + mSubShapeNumObjects[ detail.subShapeNum ];
+      S32 start = subShapeFirstObject[ detail.subShapeNum ];
+      S32 end = start + subShapeNumObjects[ detail.subShapeNum ];
       for ( S32 o=start; o < end; o++ )
       {
-         const TSShape::Object &object = mObjects[o];
+         const TSShape::Object &object = objects[o];
          if ( detail.objectDetailNum >= object.numMeshes )
             continue;
 
          // No mesh or no verts.... nothing to do.
-         TSMesh *mesh = mMeshes[ object.startMeshIndex + detail.objectDetailNum ];
+         TSMesh *mesh = meshes[ object.startMeshIndex + detail.objectDetailNum ];
          if ( !mesh || mesh->mNumVerts == 0 )
             continue;
 
@@ -1013,31 +1013,31 @@ PhysicsCollision* TSShape::_buildColShapes( bool useVisibleMesh, const Point3F &
    //
    // TODO: We need to support LOS collision for physics.
    //
-   for ( U32 i = 0; i < mDetails.size(); i++ )
+   for ( U32 i = 0; i < details.size(); i++ )
    {
-      const TSShape::Detail &detail = mDetails[i];
-      const String &name = mNames[detail.nameIndex];
+      const TSShape::Detail &detail = details[i];
+      const String &name = names[detail.nameIndex];
 
       // Is this a valid collision detail.
       if ( !dStrStartsWith( name, "Collision" ) || detail.subShapeNum < 0 )
          continue;
 
       // Now go thru the meshes for this detail.
-      S32 start = mSubShapeFirstObject[ detail.subShapeNum ];
-      S32 end = start + mSubShapeNumObjects[ detail.subShapeNum ];
+      S32 start = subShapeFirstObject[ detail.subShapeNum ];
+      S32 end = start + subShapeNumObjects[ detail.subShapeNum ];
       if ( start >= end )
          continue;         
 
       for ( S32 o=start; o < end; o++ )
       {
-         const TSShape::Object &object = mObjects[o];
-         const String &meshName = mNames[ object.nameIndex ];
+         const TSShape::Object &object = objects[o];
+         const String &meshName = names[ object.nameIndex ];
 
          if ( object.numMeshes <= detail.objectDetailNum )
             continue;
 
          // No mesh, a flat bounds, or no verts.... nothing to do.
-         TSMesh *mesh = mMeshes[ object.startMeshIndex + detail.objectDetailNum ];
+         TSMesh *mesh = meshes[ object.startMeshIndex + detail.objectDetailNum ];
          if ( !mesh || mesh->getBounds().isEmpty() || mesh->mNumVerts == 0 )
             continue;
 
@@ -1280,10 +1280,10 @@ bool TSMesh::buildConvexOpcode( const MatrixF &meshToObjectMat, const Box3F &nod
          if( chunkc->getObject() != TSStaticPolysoupConvex::smCurObject )
             continue;
                
-         if( chunkc->mMesh != this )
+         if( chunkc->mesh != this )
             continue;
 
-         if( chunkc->mIdx != curIdx )
+         if( chunkc->idx != curIdx )
             continue;
 
          // A match! Don't need to add it.
@@ -1315,18 +1315,18 @@ bool TSMesh::buildConvexOpcode( const MatrixF &meshToObjectMat, const Box3F &nod
       list->registerObject( cp );
       convex->addToWorkingList( cp );
 
-      cp->mMesh    = this;
-      cp->mIdx     = curIdx;
+      cp->mesh    = this;
+      cp->idx     = curIdx;
       cp->mObject = TSStaticPolysoupConvex::smCurObject;
 
-      cp->mNormal = p;
-      cp->mVerts[0] = a;
-      cp->mVerts[1] = b;
-      cp->mVerts[2] = c;
-      cp->mVerts[3] = peak;
+      cp->normal = p;
+      cp->verts[0] = a;
+      cp->verts[1] = b;
+      cp->verts[2] = c;
+      cp->verts[3] = peak;
 
       // Update the bounding box.
-      Box3F &bounds = cp->mBox;
+      Box3F &bounds = cp->box;
       bounds.minExtents.set( F32_MAX,  F32_MAX,  F32_MAX );
       bounds.maxExtents.set( -F32_MAX, -F32_MAX, -F32_MAX );
 
@@ -1364,9 +1364,9 @@ void TSMesh::prepOpcodeCollision()
    // Figure out how many triangles we have...
    U32 triCount = 0;
    const U32 base = 0;
-   for ( U32 i = 0; i < mPrimitives.size(); i++ )
+   for ( U32 i = 0; i < primitives.size(); i++ )
    {
-      TSDrawPrimitive & draw = mPrimitives[i];
+      TSDrawPrimitive & draw = primitives[i];
       const U32 start = draw.start;
 
       AssertFatal( draw.matIndex & TSDrawPrimitive::Indexed,"TSMesh::buildPolyList (1)" );
@@ -1377,16 +1377,16 @@ void TSMesh::prepOpcodeCollision()
       else
       {
          // Have to walk the tristrip to get a count... may have degenerates
-         U32 idx0 = base + mIndices[start + 0];
+         U32 idx0 = base + indices[start + 0];
          U32 idx1;
-         U32 idx2 = base + mIndices[start + 1];
+         U32 idx2 = base + indices[start + 1];
          U32 * nextIdx = &idx1;
          for ( S32 j = 2; j < draw.numElements; j++ )
          {
             *nextIdx = idx2;
             //            nextIdx = (j%2)==0 ? &idx0 : &idx1;
             nextIdx = (U32*) ( (dsize_t)nextIdx ^ (dsize_t)&idx0 ^ (dsize_t)&idx1);
-            idx2 = base + mIndices[start + j];
+            idx2 = base + indices[start + j];
             if ( idx0 == idx1 || idx0 == idx2 || idx1 == idx2 )
                continue;
 
@@ -1396,7 +1396,7 @@ void TSMesh::prepOpcodeCollision()
    }
 
    // Just do the first trilist for now.
-   mi->SetNbVertices( mVertexData.isReady() ? mNumVerts : mVerts.size() );
+   mi->SetNbVertices( mVertexData.isReady() ? mNumVerts : verts.size() );
    mi->SetNbTriangles( triCount );
 
    // Stuff everything into appropriate arrays.
@@ -1407,9 +1407,9 @@ void TSMesh::prepOpcodeCollision()
    mOpPoints = pts;
 
    // add the polys...
-   for ( U32 i = 0; i < mPrimitives.size(); i++ )
+   for ( U32 i = 0; i < primitives.size(); i++ )
    {
-      TSDrawPrimitive & draw = mPrimitives[i];
+      TSDrawPrimitive & draw = primitives[i];
       const U32 start = draw.start;
 
       AssertFatal( draw.matIndex & TSDrawPrimitive::Indexed,"TSMesh::buildPolyList (1)" );
@@ -1421,9 +1421,9 @@ void TSMesh::prepOpcodeCollision()
       {
          for ( S32 j = 0; j < draw.numElements; )
          {
-            curIts->mVRef[2] = base + mIndices[start + j + 0];
-            curIts->mVRef[1] = base + mIndices[start + j + 1];
-            curIts->mVRef[0] = base + mIndices[start + j + 2];
+            curIts->mVRef[2] = base + indices[start + j + 0];
+            curIts->mVRef[1] = base + indices[start + j + 1];
+            curIts->mVRef[0] = base + indices[start + j + 2];
             curIts->mMatIdx = matIndex;
             curIts++;
 
@@ -1434,16 +1434,16 @@ void TSMesh::prepOpcodeCollision()
       {
          AssertFatal( (draw.matIndex & TSDrawPrimitive::TypeMask) == TSDrawPrimitive::Strip,"TSMesh::buildPolyList (2)" );
 
-         U32 idx0 = base + mIndices[start + 0];
+         U32 idx0 = base + indices[start + 0];
          U32 idx1;
-         U32 idx2 = base + mIndices[start + 1];
+         U32 idx2 = base + indices[start + 1];
          U32 * nextIdx = &idx1;
          for ( S32 j = 2; j < draw.numElements; j++ )
          {
             *nextIdx = idx2;
             //            nextIdx = (j%2)==0 ? &idx0 : &idx1;
             nextIdx = (U32*) ( (dsize_t)nextIdx ^ (dsize_t)&idx0 ^ (dsize_t)&idx1);
-            idx2 = base + mIndices[start + j];
+            idx2 = base + indices[start + j];
             if ( idx0 == idx1 || idx0 == idx2 || idx1 == idx2 )
                continue;
 
@@ -1462,7 +1462,7 @@ void TSMesh::prepOpcodeCollision()
       if( mVertexData.isReady() )
          pts[i].Set( mVertexData[i].vert().x, mVertexData[i].vert().y, mVertexData[i].vert().z );
       else
-         pts[i].Set( mVerts[i].x, mVerts[i].y, mVerts[i].z );
+         pts[i].Set( verts[i].x, verts[i].y, verts[i].z );
 
    mi->SetPointers( its, pts );
 

--- a/Engine/source/ts/tsDump.cpp
+++ b/Engine/source/ts/tsDump.cpp
@@ -50,7 +50,7 @@ void TSShapeInstance::dumpNode(Stream & stream ,S32 level, S32 nodeIndex, Vector
    space[level*3] = '\0';
 
    const char *nodeName = "";
-   const TSShape::Node & node = mShape->mNodes[nodeIndex];
+   const TSShape::Node & node = mShape->nodes[nodeIndex];
    if (node.nameIndex != -1)
      nodeName = mShape->getName(node.nameIndex);
    dumpLine(avar("%s%s", space, nodeName));
@@ -93,7 +93,7 @@ void TSShapeInstance::dumpNode(Stream & stream ,S32 level, S32 nodeIndex, Vector
       for (S32 k=0; k<obj->object->numMeshes; k++)
       {
          S32 f = obj->object->startMeshIndex;
-         if (mShape->mMeshes[f+k])
+         if (mShape->meshes[f+k])
             dumpLine(avar(" %i",detailSizes[k]));
       }
 
@@ -108,9 +108,9 @@ void TSShapeInstance::dumpNode(Stream & stream ,S32 level, S32 nodeIndex, Vector
    }
 
    // search for children
-   for (S32 k=nodeIndex+1; k<mShape->mNodes.size(); k++)
+   for (S32 k=nodeIndex+1; k<mShape->nodes.size(); k++)
    {
-      if (mShape->mNodes[k].parentIndex == nodeIndex)
+      if (mShape->nodes[k].parentIndex == nodeIndex)
          // this is our child
          dumpNode(stream, level+1, k, detailSizes);
    }
@@ -126,9 +126,9 @@ void TSShapeInstance::dump(Stream & stream)
 
    dumpLine("\r\n   Details:\r\n");
 
-   for (i=0; i<mShape->mDetails.size(); i++)
+   for (i=0; i<mShape->details.size(); i++)
    {
-      const TSDetail & detail = mShape->mDetails[i];
+      const TSDetail & detail = mShape->details[i];
       name = mShape->getName(detail.nameIndex);
       ss = detail.subShapeNum;
       od = detail.objectDetailNum;
@@ -145,23 +145,23 @@ void TSShapeInstance::dump(Stream & stream)
 
    dumpLine("\r\n   Subtrees:\r\n");
 
-   for (i=0; i<mShape->mSubShapeFirstNode.size(); i++)
+   for (i=0; i<mShape->subShapeFirstNode.size(); i++)
    {
-      S32 a = mShape->mSubShapeFirstNode[i];
-      S32 b = a + mShape->mSubShapeNumNodes[i];
+      S32 a = mShape->subShapeFirstNode[i];
+      S32 b = a + mShape->subShapeNumNodes[i];
       dumpLine(avar("      Subtree %i\r\n",i));
 
       // compute detail sizes for each subshape
       Vector<S32> detailSizes;
-      for (S32 l=0;l<mShape->mDetails.size(); l++)
+      for (S32 l=0;l<mShape->details.size(); l++)
       {
-          if ((mShape->mDetails[l].subShapeNum==i) || (mShape->mDetails[l].subShapeNum==-1))
-              detailSizes.push_back((S32)mShape->mDetails[l].size);
+          if ((mShape->details[l].subShapeNum==i) || (mShape->details[l].subShapeNum==-1))
+              detailSizes.push_back((S32)mShape->details[l].size);
       }
 
       for (j=a; j<b; j++)
       {
-          const TSNode & node = mShape->mNodes[j];
+          const TSNode & node = mShape->nodes[j];
           // if the node has a parent, it'll get dumped via the parent
           if (node.parentIndex<0)
               dumpNode(stream,3,j,detailSizes);
@@ -169,22 +169,22 @@ void TSShapeInstance::dump(Stream & stream)
    }
 
    bool foundSkin = false;
-   for (i=0; i<mShape->mObjects.size(); i++)
+   for (i=0; i<mShape->objects.size(); i++)
    {
-      if (mShape->mObjects[i].nodeIndex<0) // must be a skin
+      if (mShape->objects[i].nodeIndex<0) // must be a skin
       {
          if (!foundSkin)
             dumpLine("\r\n   Skins:\r\n");
          foundSkin=true;
          const char * skinName = "";
-         S32 nameIndex = mShape->mObjects[i].nameIndex;
+         S32 nameIndex = mShape->objects[i].nameIndex;
          if (nameIndex>=0)
             skinName = mShape->getName(nameIndex);
          dumpLine(avar("      Skin %s with following details: ",skinName));
-         for (S32 num=0; num<mShape->mObjects[i].numMeshes; num++)
+         for (S32 num=0; num<mShape->objects[i].numMeshes; num++)
          {
-            if (mShape->mMeshes[mShape->mObjects[i].startMeshIndex + num])
-               dumpLine(avar(" %i",(S32)mShape->mDetails[num].size));
+            if (mShape->meshes[mShape->objects[i].startMeshIndex + num])
+               dumpLine(avar(" %i",(S32)mShape->details[num].size));
          }
          dumpLine("\r\n");
       }
@@ -193,19 +193,19 @@ void TSShapeInstance::dump(Stream & stream)
       dumpLine("\r\n");
 
    dumpLine("\r\n   Sequences:\r\n");
-   for (i = 0; i < mShape->mSequences.size(); i++)
+   for (i = 0; i < mShape->sequences.size(); i++)
    {
       const char *name = "(none)";
-      if (mShape->mSequences[i].nameIndex != -1)
-         name = mShape->getName(mShape->mSequences[i].nameIndex);
+      if (mShape->sequences[i].nameIndex != -1)
+         name = mShape->getName(mShape->sequences[i].nameIndex);
       dumpLine(avar("      %3d: %s%s%s\r\n", i, name,
-         mShape->mSequences[i].isCyclic() ? " (cyclic)" : "",
-         mShape->mSequences[i].isBlend() ? " (blend)" : ""));
+         mShape->sequences[i].isCyclic() ? " (cyclic)" : "",
+         mShape->sequences[i].isBlend() ? " (blend)" : ""));
    }
 
-   if (mShape->mMaterialList)
+   if (mShape->materialList)
    {
-      TSMaterialList * ml = mShape->mMaterialList;
+      TSMaterialList * ml = mShape->materialList;
       dumpLine("\r\n   Material list:\r\n");
       for (i=0; i<(S32)ml->size(); i++)
       {

--- a/Engine/source/ts/tsLastDetail.cpp
+++ b/Engine/source/ts/tsLastDetail.cpp
@@ -82,8 +82,8 @@ TSLastDetail::TSLastDetail(   TSShape *shape,
    mDl = dl;
    mDim = getMax( dim, (S32)32 );
 
-   mRadius = mShape->mRadius;
-   mCenter = mShape->mCenter;
+   mRadius = mShape->radius;
+   mCenter = mShape->center;
 
    mCachePath = cachePath;
 

--- a/Engine/source/ts/tsMesh.cpp
+++ b/Engine/source/ts/tsMesh.cpp
@@ -126,7 +126,7 @@ void TSMesh::innerRender( TSVertexBufferHandle &vb, GFXPrimitiveBufferHandle &pb
    GFX->setVertexBuffer( vb );
    GFX->setPrimitiveBuffer( pb );
    
-   for( U32 p = 0; p < mPrimitives.size(); p++ )
+   for( U32 p = 0; p < primitives.size(); p++ )
       GFX->drawPrimitive( p );
 }
 
@@ -152,7 +152,7 @@ void TSMesh::innerRender( TSMaterialList *materials, const TSRenderState &rdata,
 {
    PROFILE_SCOPE( TSMesh_InnerRender );
 
-   if( mVertsPerFrame <= 0 ) 
+   if( vertsPerFrame <= 0 ) 
       return;
 
    F32 meshVisibility = rdata.getFadeOverride() * mVisibility;
@@ -216,9 +216,9 @@ void TSMesh::innerRender( TSMaterialList *materials, const TSRenderState &rdata,
    // NOTICE: SFXBB is removed and refraction is disabled!
    //coreRI->backBuffTex = GFX->getSfxBackBuffer();
 
-   for ( S32 i = 0; i < mPrimitives.size(); i++ )
+   for ( S32 i = 0; i < primitives.size(); i++ )
    {
-      const TSDrawPrimitive &draw = mPrimitives[i];
+      const TSDrawPrimitive &draw = primitives[i];
 
       // We need to have a material.
       if ( draw.matIndex & TSDrawPrimitive::NoMaterial )
@@ -245,7 +245,7 @@ void TSMesh::innerRender( TSMaterialList *materials, const TSRenderState &rdata,
 #ifndef TORQUE_OS_MAC
 
       // Get the instancing material if this mesh qualifies.
-      if ( mMeshType != SkinMeshType && pb->mPrimitiveArray[i].numVertices < smMaxInstancingVerts )
+      if ( meshType != SkinMeshType && pb->mPrimitiveArray[i].numVertices < smMaxInstancingVerts )
          matInst = InstancingMaterialHook::getInstancingMat( matInst );
 
 #endif
@@ -283,14 +283,14 @@ const Point3F * TSMesh::getNormals( S32 firstVert )
 {
    if ( getFlags( UseEncodedNormals ) )
    {
-      gNormalStore.setSize( mVertsPerFrame );
-      for ( S32 i = 0; i < mEncodedNorms.size(); i++ )
-         gNormalStore[i] = decodeNormal( mEncodedNorms[ i + firstVert ] );
+      gNormalStore.setSize( vertsPerFrame );
+      for ( S32 i = 0; i < encodedNorms.size(); i++ )
+         gNormalStore[i] = decodeNormal( encodedNorms[ i + firstVert ] );
 
       return gNormalStore.address();
    }
 
-   return &mNorms[firstVert];
+   return &norms[firstVert];
 }
 
 //-----------------------------------------------------
@@ -299,10 +299,10 @@ const Point3F * TSMesh::getNormals( S32 firstVert )
 
 bool TSMesh::buildPolyList( S32 frame, AbstractPolyList *polyList, U32 &surfaceKey, TSMaterialList *materials )
 {
-   S32 firstVert  = mVertsPerFrame * frame, i, base = 0;
+   S32 firstVert  = vertsPerFrame * frame, i, base = 0;
 
    // add the verts...
-   if ( mVertsPerFrame )
+   if ( vertsPerFrame )
    {
       if ( mVertexData.isReady() )
       {
@@ -310,7 +310,7 @@ bool TSMesh::buildPolyList( S32 frame, AbstractPolyList *polyList, U32 &surfaceK
          if ( opList )
          {
             base = opList->mVertexList.size();
-            for ( i = 0; i < mVertsPerFrame; i++ )
+            for ( i = 0; i < vertsPerFrame; i++ )
             {
                // Don't use vertex() method as we want to retain the original indices
                OptimizedPolyList::VertIndex vert;
@@ -326,7 +326,7 @@ bool TSMesh::buildPolyList( S32 frame, AbstractPolyList *polyList, U32 &surfaceK
          else
          {
             base = polyList->addPointAndNormal( mVertexData[firstVert].vert(), mVertexData[firstVert].normal() );
-            for ( i = 1; i < mVertsPerFrame; i++ )
+            for ( i = 1; i < vertsPerFrame; i++ )
             {
                polyList->addPointAndNormal( mVertexData[ i + firstVert ].vert(), mVertexData[ i + firstVert ].normal() );
             }
@@ -338,32 +338,32 @@ bool TSMesh::buildPolyList( S32 frame, AbstractPolyList *polyList, U32 &surfaceK
          if ( opList )
          {
             base = opList->mVertexList.size();
-            for ( i = 0; i < mVertsPerFrame; i++ )
+            for ( i = 0; i < vertsPerFrame; i++ )
             {
                // Don't use vertex() method as we want to retain the original indices
                OptimizedPolyList::VertIndex vert;
-               vert.vertIdx   = opList->insertPoint( mVerts[ i + firstVert ] );
-               vert.normalIdx = opList->insertNormal( mNorms[ i + firstVert ] );
-               vert.uv0Idx    = opList->insertUV0( mTVerts[ i + firstVert ] );
+               vert.vertIdx   = opList->insertPoint( verts[ i + firstVert ] );
+               vert.normalIdx = opList->insertNormal( norms[ i + firstVert ] );
+               vert.uv0Idx    = opList->insertUV0( tverts[ i + firstVert ] );
                if ( mHasTVert2 )
-                  vert.uv1Idx = opList->insertUV1( mTVerts2[ i + firstVert ] );
+                  vert.uv1Idx = opList->insertUV1( tverts2[ i + firstVert ] );
 
                opList->mVertexList.push_back( vert );
             }
          }
          else
          {
-            base = polyList->addPointAndNormal( mVerts[firstVert], mNorms[firstVert] );
-            for ( i = 1; i < mVertsPerFrame; i++ )
-               polyList->addPointAndNormal( mVerts[ i + firstVert ], mNorms[ i + firstVert ] );
+            base = polyList->addPointAndNormal( verts[firstVert], norms[firstVert] );
+            for ( i = 1; i < vertsPerFrame; i++ )
+               polyList->addPointAndNormal( verts[ i + firstVert ], norms[ i + firstVert ] );
          }
       }
    }
 
    // add the polys...
-   for ( i = 0; i < mPrimitives.size(); i++ )
+   for ( i = 0; i < primitives.size(); i++ )
    {
-      TSDrawPrimitive & draw = mPrimitives[i];
+      TSDrawPrimitive & draw = primitives[i];
       U32 start = draw.start;
 
       AssertFatal( draw.matIndex & TSDrawPrimitive::Indexed,"TSMesh::buildPolyList (1)" );
@@ -376,9 +376,9 @@ bool TSMesh::buildPolyList( S32 frame, AbstractPolyList *polyList, U32 &surfaceK
       {
          for ( S32 j = 0; j < draw.numElements; )
          {
-            U32 idx0 = base + mIndices[start + j + 0];
-            U32 idx1 = base + mIndices[start + j + 1];
-            U32 idx2 = base + mIndices[start + j + 2];
+            U32 idx0 = base + indices[start + j + 0];
+            U32 idx1 = base + indices[start + j + 1];
+            U32 idx2 = base + indices[start + j + 2];
             polyList->begin(material,surfaceKey++);
             polyList->vertex( idx0 );
             polyList->vertex( idx1 );
@@ -392,16 +392,16 @@ bool TSMesh::buildPolyList( S32 frame, AbstractPolyList *polyList, U32 &surfaceK
       {
          AssertFatal( (draw.matIndex & TSDrawPrimitive::TypeMask) == TSDrawPrimitive::Strip,"TSMesh::buildPolyList (2)" );
 
-         U32 idx0 = base + mIndices[start + 0];
+         U32 idx0 = base + indices[start + 0];
          U32 idx1;
-         U32 idx2 = base + mIndices[start + 1];
+         U32 idx2 = base + indices[start + 1];
          U32 * nextIdx = &idx1;
          for ( S32 j = 2; j < draw.numElements; j++ )
          {
             *nextIdx = idx2;
             // nextIdx = (j%2)==0 ? &idx0 : &idx1;
             nextIdx = (U32*) ( (dsize_t)nextIdx ^ (dsize_t)&idx0 ^ (dsize_t)&idx1);
-            idx2 = base + mIndices[start + j];
+            idx2 = base + indices[start + j];
             if ( idx0 == idx1 || idx0 == idx2 || idx1 == idx2 )
                continue;
 
@@ -419,20 +419,20 @@ bool TSMesh::buildPolyList( S32 frame, AbstractPolyList *polyList, U32 &surfaceK
 
 bool TSMesh::getFeatures( S32 frame, const MatrixF& mat, const VectorF&, ConvexFeature* cf, U32& )
 {
-   S32 firstVert = mVertsPerFrame * frame;
+   S32 firstVert = vertsPerFrame * frame;
    S32 i;
    S32 base = cf->mVertexList.size();
 
-   for ( i = 0; i < mVertsPerFrame; i++ ) 
+   for ( i = 0; i < vertsPerFrame; i++ ) 
    {
       cf->mVertexList.increment();
       mat.mulP( mVertexData[firstVert + i].vert(), &cf->mVertexList.last() );
    }
 
    // add the polys...
-   for ( i = 0; i < mPrimitives.size(); i++ )
+   for ( i = 0; i < primitives.size(); i++ )
    {
-      TSDrawPrimitive & draw = mPrimitives[i];
+      TSDrawPrimitive & draw = primitives[i];
       U32 start = draw.start;
 
       AssertFatal( draw.matIndex & TSDrawPrimitive::Indexed,"TSMesh::buildPolyList (1)" );
@@ -442,22 +442,22 @@ bool TSMesh::getFeatures( S32 frame, const MatrixF& mat, const VectorF&, ConvexF
       {
          for ( S32 j = 0; j < draw.numElements; j += 3 )
          {
-            PlaneF plane( cf->mVertexList[base + mIndices[start + j + 0]],
-                          cf->mVertexList[base + mIndices[start + j + 1]],
-                          cf->mVertexList[base + mIndices[start + j + 2]]);
+            PlaneF plane( cf->mVertexList[base + indices[start + j + 0]],
+                          cf->mVertexList[base + indices[start + j + 1]],
+                          cf->mVertexList[base + indices[start + j + 2]]);
 
             cf->mFaceList.increment();
             cf->mFaceList.last().normal = plane;
 
-            cf->mFaceList.last().vertex[0] = base + mIndices[start + j + 0];
-            cf->mFaceList.last().vertex[1] = base + mIndices[start + j + 1];
-            cf->mFaceList.last().vertex[2] = base + mIndices[start + j + 2];
+            cf->mFaceList.last().vertex[0] = base + indices[start + j + 0];
+            cf->mFaceList.last().vertex[1] = base + indices[start + j + 1];
+            cf->mFaceList.last().vertex[2] = base + indices[start + j + 2];
 
             for ( U32 l = 0; l < 3; l++ ) 
             {
                U32 newEdge0, newEdge1;
-               U32 zero = base + mIndices[start + j + l];
-               U32 one  = base + mIndices[start + j + ((l+1)%3)];
+               U32 zero = base + indices[start + j + l];
+               U32 one  = base + indices[start + j + ((l+1)%3)];
                newEdge0 = getMin( zero, one );
                newEdge1 = getMax( zero, one );
                bool found = false;
@@ -484,15 +484,15 @@ bool TSMesh::getFeatures( S32 frame, const MatrixF& mat, const VectorF&, ConvexF
       {
          AssertFatal( (draw.matIndex & TSDrawPrimitive::TypeMask) == TSDrawPrimitive::Strip,"TSMesh::buildPolyList (2)" );
 
-         U32 idx0 = base + mIndices[start + 0];
+         U32 idx0 = base + indices[start + 0];
          U32 idx1;
-         U32 idx2 = base + mIndices[start + 1];
+         U32 idx2 = base + indices[start + 1];
          U32 * nextIdx = &idx1;
          for ( S32 j = 2; j < draw.numElements; j++ )
          {
             *nextIdx = idx2;
             nextIdx = (U32*) ( (dsize_t)nextIdx ^ (dsize_t)&idx0 ^ (dsize_t)&idx1);
-            idx2 = base + mIndices[start + j];
+            idx2 = base + indices[start + j];
             if ( idx0 == idx1 || idx0 == idx2 || idx1 == idx2 )
                continue;
 
@@ -578,23 +578,23 @@ bool TSMesh::getFeatures( S32 frame, const MatrixF& mat, const VectorF&, ConvexF
 
 void TSMesh::support( S32 frame, const Point3F &v, F32 *currMaxDP, Point3F *currSupport )
 {
-   if ( mVertsPerFrame == 0 )
+   if ( vertsPerFrame == 0 )
       return;
 
    U32 waterMark = FrameAllocator::getWaterMark();
-   F32* pDots = (F32*)FrameAllocator::alloc( sizeof(F32) * mVertsPerFrame );
+   F32* pDots = (F32*)FrameAllocator::alloc( sizeof(F32) * vertsPerFrame );
 
-   S32 firstVert = mVertsPerFrame * frame;
+   S32 firstVert = vertsPerFrame * frame;
    m_point3F_bulk_dot( &v.x,
                        &mVertexData[firstVert].vert().x,
-                       mVertsPerFrame,
+                       vertsPerFrame,
                        mVertexData.vertSize(),
                        pDots );
 
    F32 localdp = *currMaxDP;
    S32 index   = -1;
 
-   for ( S32 i = 0; i < mVertsPerFrame; i++ )
+   for ( S32 i = 0; i < vertsPerFrame; i++ )
    {
       if ( pDots[i] > localdp )
       {
@@ -614,7 +614,7 @@ void TSMesh::support( S32 frame, const Point3F &v, F32 *currMaxDP, Point3F *curr
 
 bool TSMesh::castRay( S32 frame, const Point3F & start, const Point3F & end, RayInfo * rayInfo, TSMaterialList* materials )
 {
-   if ( mPlaneNormals.empty() )
+   if ( planeNormals.empty() )
       buildConvexHull(); // if haven't done it yet...
 
    // Keep track of startTime and endTime.  They start out at just under 0 and just over 1, respectively.
@@ -644,15 +644,15 @@ bool TSMesh::castRay( S32 frame, const Point3F & start, const Point3F & end, Ray
    S32 * pplane = &curPlane;
    bool * pfound = &found;
 
-   S32 startPlane = frame * mPlanesPerFrame;
-   for ( S32  i = startPlane; i < startPlane + mPlanesPerFrame; i++ )
+   S32 startPlane = frame * planesPerFrame;
+   for ( S32  i = startPlane; i < startPlane + planesPerFrame; i++ )
    {
       // if start & end outside, no collision
       // if start & end inside, continue
       // if start outside, end inside, or visa versa, find intersection of line with plane
       //    then update intersection of line with hull (using startTime and endTime)
-      F32 dot1 = mDot( mPlaneNormals[i], start ) - mPlaneConstants[i];
-      F32 dot2 = mDot( mPlaneNormals[i], end) - mPlaneConstants[i];
+      F32 dot1 = mDot( planeNormals[i], start ) - planeConstants[i];
+      F32 dot2 = mDot( planeNormals[i], end) - planeConstants[i];
       if ( dot1 * dot2 > 0.0f )
       {
          // same side of the plane...which side -- dot==0 considered inside
@@ -734,10 +734,10 @@ bool TSMesh::castRay( S32 frame, const Point3F & start, const Point3F & end, Ray
    // setup rayInfo
    if ( found && rayInfo )
    {
-      curMaterial       = mPlaneMaterials[ curPlane - startPlane ];
+      curMaterial       = planeMaterials[ curPlane - startPlane ];
 
       rayInfo->t        = (F32)startNum/(F32)startDen; // finally divide...
-      rayInfo->normal   = mPlaneNormals[curPlane];
+      rayInfo->normal   = planeNormals[curPlane];
 
       if (materials && materials->size() > 0)
          rayInfo->material = materials->getMaterialInst( curMaterial );
@@ -758,13 +758,13 @@ bool TSMesh::castRay( S32 frame, const Point3F & start, const Point3F & end, Ray
 
 bool TSMesh::castRayRendered( S32 frame, const Point3F & start, const Point3F & end, RayInfo * rayInfo, TSMaterialList* materials )
 {
-   if( mVertsPerFrame <= 0 ) 
+   if( vertsPerFrame <= 0 ) 
       return false;
 
    if( mNumVerts == 0 )
       return false;
 
-   S32 firstVert  = mVertsPerFrame * frame;
+   S32 firstVert  = vertsPerFrame * frame;
 
 	bool found = false;
 	F32 best_t = F32_MAX;
@@ -772,9 +772,9 @@ bool TSMesh::castRayRendered( S32 frame, const Point3F & start, const Point3F & 
    BaseMatInstance* bestMaterial = NULL;
 	Point3F dir = end - start;
 
-   for ( S32 i = 0; i < mPrimitives.size(); i++ )
+   for ( S32 i = 0; i < primitives.size(); i++ )
    {
-      TSDrawPrimitive & draw = mPrimitives[i];
+      TSDrawPrimitive & draw = primitives[i];
       U32 drawStart = draw.start;
 
       AssertFatal( draw.matIndex & TSDrawPrimitive::Indexed,"TSMesh::castRayRendered (1)" );
@@ -789,9 +789,9 @@ bool TSMesh::castRayRendered( S32 frame, const Point3F & start, const Point3F & 
       {
          for ( S32 j = 0; j < draw.numElements-2; j += 3 )
          {
-            idx0 = mIndices[drawStart + j + 0];
-            idx1 = mIndices[drawStart + j + 1];
-            idx2 = mIndices[drawStart + j + 2];
+            idx0 = indices[drawStart + j + 0];
+            idx1 = indices[drawStart + j + 1];
+            idx2 = indices[drawStart + j + 2];
 
 			   F32 cur_t = 0;
 			   Point2F b;
@@ -815,15 +815,15 @@ bool TSMesh::castRayRendered( S32 frame, const Point3F & start, const Point3F & 
       {
          AssertFatal( (draw.matIndex & TSDrawPrimitive::TypeMask) == TSDrawPrimitive::Strip,"TSMesh::castRayRendered (2)" );
 
-         idx0 = mIndices[drawStart + 0];
-         idx2 = mIndices[drawStart + 1];
+         idx0 = indices[drawStart + 0];
+         idx2 = indices[drawStart + 1];
          U32 * nextIdx = &idx1;
          for ( S32 j = 2; j < draw.numElements; j++ )
          {
             *nextIdx = idx2;
             // nextIdx = (j%2)==0 ? &idx0 : &idx1;
             nextIdx = (U32*) ( (dsize_t)nextIdx ^ (dsize_t)&idx0 ^ (dsize_t)&idx1);
-            idx2 = mIndices[drawStart + j];
+            idx2 = indices[drawStart + j];
             if ( idx0 == idx1 || idx0 == idx2 || idx1 == idx2 )
                continue;
 
@@ -908,35 +908,35 @@ bool TSMesh::addToHull( U32 idx0, U32 idx1, U32 idx2 )
 
    normal.normalize();
    F32 k = mDot( normal, mVertexData[idx0].vert() );
-   for ( S32 i = 0; i < mPlaneNormals.size(); i++ ) 
+   for ( S32 i = 0; i < planeNormals.size(); i++ ) 
    {
-      if ( mDot( mPlaneNormals[i], normal ) > 0.99f && mFabs( k-mPlaneConstants[i] ) < 0.01f )
+      if ( mDot( planeNormals[i], normal ) > 0.99f && mFabs( k-planeConstants[i] ) < 0.01f )
          return false;          // this is a repeat...
    }
    // new plane, add it to the list...
-   mPlaneNormals.push_back( normal );
-   mPlaneConstants.push_back( k );
+   planeNormals.push_back( normal );
+   planeConstants.push_back( k );
    return true;
 }
 
 bool TSMesh::buildConvexHull()
 {
    // already done, return without error
-   if ( mPlaneNormals.size() )
+   if ( planeNormals.size() )
       return true;
 
    bool error = false;
 
    // should probably only have 1 frame, but just in case...
-   mPlanesPerFrame = 0;
+   planesPerFrame = 0;
    S32 frame, i, j;
-   for ( frame = 0; frame < mNumFrames; frame++ )
+   for ( frame = 0; frame < numFrames; frame++ )
    {
-      S32 firstVert  = mVertsPerFrame * frame;
-      S32 firstPlane = mPlaneNormals.size();
-      for ( i = 0; i < mPrimitives.size(); i++ )
+      S32 firstVert  = vertsPerFrame * frame;
+      S32 firstPlane = planeNormals.size();
+      for ( i = 0; i < primitives.size(); i++ )
       {
-         TSDrawPrimitive & draw = mPrimitives[i];
+         TSDrawPrimitive & draw = primitives[i];
          U32 start = draw.start;
 
          AssertFatal( draw.matIndex & TSDrawPrimitive::Indexed,"TSMesh::buildConvexHull (1)" );
@@ -945,71 +945,71 @@ bool TSMesh::buildConvexHull()
          if ( (draw.matIndex & TSDrawPrimitive::TypeMask) == TSDrawPrimitive::Triangles )
          {
             for ( j = 0;  j < draw.numElements; j += 3 )
-               if ( addToHull(   mIndices[start + j + 0] + firstVert, 
-                                 mIndices[start + j + 1] + firstVert, 
-                                 mIndices[start + j + 2] + firstVert ) && frame == 0 )
-                  mPlaneMaterials.push_back( draw.matIndex & TSDrawPrimitive::MaterialMask );
+               if ( addToHull(   indices[start + j + 0] + firstVert, 
+                                 indices[start + j + 1] + firstVert, 
+                                 indices[start + j + 2] + firstVert ) && frame == 0 )
+                  planeMaterials.push_back( draw.matIndex & TSDrawPrimitive::MaterialMask );
          }
          else
          {
             AssertFatal( (draw.matIndex&TSDrawPrimitive::Strip) == TSDrawPrimitive::Strip,"TSMesh::buildConvexHull (2)" );
 
-            U32 idx0 = mIndices[start + 0] + firstVert;
+            U32 idx0 = indices[start + 0] + firstVert;
             U32 idx1;
-            U32 idx2 = mIndices[start + 1] + firstVert;
+            U32 idx2 = indices[start + 1] + firstVert;
             U32 * nextIdx = &idx1;
             for ( j = 2; j < draw.numElements; j++ )
             {
                *nextIdx = idx2;
 //               nextIdx = (j%2)==0 ? &idx0 : &idx1;
                nextIdx = (U32*) ( (dsize_t)nextIdx ^ (dsize_t)&idx0 ^ (dsize_t)&idx1 );
-               idx2 = mIndices[start + j] + firstVert;
+               idx2 = indices[start + j] + firstVert;
                if ( addToHull( idx0, idx1, idx2 ) && frame == 0 )
-                  mPlaneMaterials.push_back( draw.matIndex & TSDrawPrimitive::MaterialMask );
+                  planeMaterials.push_back( draw.matIndex & TSDrawPrimitive::MaterialMask );
             }
          }
       }
       // make sure all the verts on this frame are inside all the planes
-      for ( i = 0; i < mVertsPerFrame; i++ )
-         for ( j = firstPlane; j < mPlaneNormals.size(); j++ )
-            if ( mDot( mVertexData[firstVert + i].vert(), mPlaneNormals[j] ) - mPlaneConstants[j] < 0.01 ) // .01 == a little slack
+      for ( i = 0; i < vertsPerFrame; i++ )
+         for ( j = firstPlane; j < planeNormals.size(); j++ )
+            if ( mDot( mVertexData[firstVert + i].vert(), planeNormals[j] ) - planeConstants[j] < 0.01 ) // .01 == a little slack
                error = true;
 
       if ( frame == 0 )
-         mPlanesPerFrame = mPlaneNormals.size();
+         planesPerFrame = planeNormals.size();
 
-      if ( (frame + 1) * mPlanesPerFrame != mPlaneNormals.size() )
+      if ( (frame + 1) * planesPerFrame != planeNormals.size() )
       {
          // eek, not all frames have same number of planes...
-         while ( (frame + 1) * mPlanesPerFrame > mPlaneNormals.size() )
+         while ( (frame + 1) * planesPerFrame > planeNormals.size() )
          {
             // we're short, duplicate last plane till we match
-            U32 sz = mPlaneNormals.size();
-            mPlaneNormals.increment();
-            mPlaneNormals.last() = mPlaneNormals[sz-1];
-            mPlaneConstants.increment();
-            mPlaneConstants.last() = mPlaneConstants[sz-1];
+            U32 sz = planeNormals.size();
+            planeNormals.increment();
+            planeNormals.last() = planeNormals[sz-1];
+            planeConstants.increment();
+            planeConstants.last() = planeConstants[sz-1];
          }
-         while ( (frame + 1) * mPlanesPerFrame < mPlaneNormals.size() )
+         while ( (frame + 1) * planesPerFrame < planeNormals.size() )
          {
             // harsh -- last frame has more than other frames
             // duplicate last plane in each frame
             for ( S32 k = frame - 1; k >= 0; k-- )
             {
-               mPlaneNormals.insert( k * mPlanesPerFrame + mPlanesPerFrame );
-               mPlaneNormals[k * mPlanesPerFrame + mPlanesPerFrame] = mPlaneNormals[k * mPlanesPerFrame + mPlanesPerFrame - 1];
-               mPlaneConstants.insert( k * mPlanesPerFrame + mPlanesPerFrame );
-               mPlaneConstants[k * mPlanesPerFrame + mPlanesPerFrame] = mPlaneConstants[k * mPlanesPerFrame + mPlanesPerFrame - 1];
+               planeNormals.insert( k * planesPerFrame + planesPerFrame );
+               planeNormals[k * planesPerFrame + planesPerFrame] = planeNormals[k * planesPerFrame + planesPerFrame - 1];
+               planeConstants.insert( k * planesPerFrame + planesPerFrame );
+               planeConstants[k * planesPerFrame + planesPerFrame] = planeConstants[k * planesPerFrame + planesPerFrame - 1];
                if ( k == 0 )
                {
-                  mPlaneMaterials.increment();
-                  mPlaneMaterials.last() = mPlaneMaterials[mPlaneMaterials.size() - 2];
+                  planeMaterials.increment();
+                  planeMaterials.last() = planeMaterials[planeMaterials.size() - 2];
                }
             }
-            mPlanesPerFrame++;
+            planesPerFrame++;
          }
       }
-      AssertFatal( (frame + 1) * mPlanesPerFrame == mPlaneNormals.size(),"TSMesh::buildConvexHull (3)" );
+      AssertFatal( (frame + 1) * planesPerFrame == planeNormals.size(),"TSMesh::buildConvexHull (3)" );
    }
    return !error;
 }
@@ -1039,21 +1039,21 @@ void TSMesh::computeBounds( const MatrixF &transform, Box3F &bounds, S32 frame, 
          numVerts = mNumVerts;
       else
       {
-         baseVert = &mVertexData[frame * mVertsPerFrame].vert();
-         numVerts = mVertsPerFrame;
+         baseVert = &mVertexData[frame * vertsPerFrame].vert();
+         numVerts = vertsPerFrame;
       }
    }
    else
    {
-      baseVert = mVerts.address();
+      baseVert = verts.address();
       stride = sizeof(Point3F);
 
       if ( frame < 0 )
-         numVerts = mVerts.size();
+         numVerts = verts.size();
       else
       {
-         baseVert += frame * mVertsPerFrame;
-         numVerts = mVertsPerFrame;
+         baseVert += frame * vertsPerFrame;
+         numVerts = vertsPerFrame;
       }
    }
    computeBounds( baseVert, numVerts, stride, transform, bounds, center, radius );
@@ -1110,27 +1110,27 @@ void TSMesh::computeBounds( const Point3F *v, S32 numVerts, S32 stride, const Ma
 S32 TSMesh::getNumPolys() const
 {
    S32 count = 0;
-   for ( S32 i = 0; i < mPrimitives.size(); i++ )
+   for ( S32 i = 0; i < primitives.size(); i++ )
    {
-      switch (mPrimitives[i].matIndex & TSDrawPrimitive::TypeMask)
+      switch (primitives[i].matIndex & TSDrawPrimitive::TypeMask)
       {
          case TSDrawPrimitive::Triangles:
-            count += mPrimitives[i].numElements / 3;
+            count += primitives[i].numElements / 3;
             break;
 
          case TSDrawPrimitive::Fan:
-            count += mPrimitives[i].numElements - 2;
+            count += primitives[i].numElements - 2;
             break;
 
          case TSDrawPrimitive::Strip:
             // Don't count degenerate triangles
-            for ( S32 j = mPrimitives[i].start;
-                  j < mPrimitives[i].start+mPrimitives[i].numElements-2;
+            for ( S32 j = primitives[i].start;
+                  j < primitives[i].start+primitives[i].numElements-2;
                   j++ )
             {
-               if ((mIndices[j] != mIndices[j+1]) &&
-                   (mIndices[j] != mIndices[j+2]) &&
-                   (mIndices[j+1] != mIndices[j+2]))
+               if ((indices[j] != indices[j+1]) &&
+                   (indices[j] != indices[j+2]) &&
+                   (indices[j+1] != indices[j+2]))
                   count++;
             }
             break;
@@ -1141,12 +1141,12 @@ S32 TSMesh::getNumPolys() const
 
 //-----------------------------------------------------
 
-TSMesh::TSMesh() : mMeshType( StandardMeshType )
+TSMesh::TSMesh() : meshType( StandardMeshType )
 {
-   VECTOR_SET_ASSOCIATION( mPlaneNormals );
-   VECTOR_SET_ASSOCIATION( mPlaneConstants );
-   VECTOR_SET_ASSOCIATION( mPlaneMaterials );
-   mParentMesh = -1;
+   VECTOR_SET_ASSOCIATION( planeNormals );
+   VECTOR_SET_ASSOCIATION( planeConstants );
+   VECTOR_SET_ASSOCIATION( planeMaterials );
+   parentMesh = -1;
 
    mOptTree = NULL;
    mOpMeshInterface = NULL;
@@ -1183,53 +1183,53 @@ void TSSkinMesh::updateSkin( const Vector<MatrixF> &transforms, TSVertexBufferHa
 {
    PROFILE_SCOPE( TSSkinMesh_UpdateSkin );
 
-   AssertFatal(mBatchDataInitialized, "Batch data not initialized. Call createBatchData() before any skin update is called.");
+   AssertFatal(batchDataInitialized, "Batch data not initialized. Call createBatchData() before any skin update is called.");
 
    // set arrays
 #if defined(TORQUE_MAX_LIB)
-   mVerts.setSize(mBatchData.initialVerts.size());
-   mNorms.setSize(mBatchData.initialNorms.size());
+   verts.setSize(batchData.initialVerts.size());
+   norms.setSize(batchData.initialNorms.size());
 #else
-   if ( !mBatchDataInitialized && mEncodedNorms.size() )
+   if ( !batchDataInitialized && encodedNorms.size() )
    {
       // we co-opt responsibility for updating encoded normals from mesh
-      gNormalStore.setSize( mVertsPerFrame );
-      for ( S32 i = 0; i < mVertsPerFrame; i++ )
-         gNormalStore[i] = decodeNormal( mEncodedNorms[i] );
+      gNormalStore.setSize( vertsPerFrame );
+      for ( S32 i = 0; i < vertsPerFrame; i++ )
+         gNormalStore[i] = decodeNormal( encodedNorms[i] );
 
-      mBatchData.initialNorms.set( gNormalStore.address(), mVertsPerFrame );
+      batchData.initialNorms.set( gNormalStore.address(), vertsPerFrame );
    }
 #endif
 
    static Vector<MatrixF> sBoneTransforms;
-   sBoneTransforms.setSize( mBatchData.nodeIndex.size() );
+   sBoneTransforms.setSize( batchData.nodeIndex.size() );
 
    // set up bone transforms
    PROFILE_START(TSSkinMesh_UpdateTransforms);
-   for( S32 i=0; i<mBatchData.nodeIndex.size(); i++ )
+   for( S32 i=0; i<batchData.nodeIndex.size(); i++ )
    {
-      S32 node = mBatchData.nodeIndex[i];
-      sBoneTransforms[i].mul( transforms[node], mBatchData.initialTransforms[i] );
+      S32 node = batchData.nodeIndex[i];
+      sBoneTransforms[i].mul( transforms[node], batchData.initialTransforms[i] );
    }
    const MatrixF * matrices = &sBoneTransforms[0];
    PROFILE_END();
 
    // Perform skinning
-   const bool bBatchByVert = !mBatchData.vertexBatchOperations.empty();
+   const bool bBatchByVert = !batchData.vertexBatchOperations.empty();
    if(bBatchByVert)
    {
-      const Point3F *inVerts = &mBatchData.initialVerts[0];
-      const Point3F *inNorms = &mBatchData.initialNorms[0];
+      const Point3F *inVerts = &batchData.initialVerts[0];
+      const Point3F *inNorms = &batchData.initialNorms[0];
 
       Point3F srcVtx, srcNrm;
 
-      AssertFatal( mBatchData.vertexBatchOperations.size() == mBatchData.initialVerts.size(), "Assumption failed!" );
+      AssertFatal( batchData.vertexBatchOperations.size() == batchData.initialVerts.size(), "Assumption failed!" );
 
       register Point3F skinnedVert;
       register Point3F skinnedNorm;
 
-      for( Vector<BatchData::BatchedVertex>::const_iterator itr = mBatchData.vertexBatchOperations.begin(); 
-         itr != mBatchData.vertexBatchOperations.end(); itr++ )
+      for( Vector<BatchData::BatchedVertex>::const_iterator itr = batchData.vertexBatchOperations.begin(); 
+         itr != batchData.vertexBatchOperations.end(); itr++ )
       {
          const BatchData::BatchedVertex &curVert = *itr;
 
@@ -1278,11 +1278,11 @@ void TSSkinMesh::updateSkin( const Vector<MatrixF> &transforms, TSVertexBufferHa
       zero_vert_normal_bulk(mNumVerts, outPtr, outStride);
 
       // Iterate over transforms, and perform batch transform x skin_vert
-      for(Vector<S32>::const_iterator itr = mBatchData.transformKeys.begin();
-          itr != mBatchData.transformKeys.end(); itr++)
+      for(Vector<S32>::const_iterator itr = batchData.transformKeys.begin();
+          itr != batchData.transformKeys.end(); itr++)
       {
          const S32 boneXfmIdx = *itr;
-         const BatchData::BatchedTransform &curTransform = *mBatchData.transformBatchOperations.retreive(boneXfmIdx);
+         const BatchData::BatchedTransform &curTransform = *batchData.transformBatchOperations.retreive(boneXfmIdx);
          const MatrixF &curBoneMat = matrices[boneXfmIdx];
          const S32 numVerts = curTransform.numElements;
 
@@ -1310,14 +1310,14 @@ S32 QSORT_CALLBACK _sort_BatchedVertWeight( const void *a, const void *b )
 
 void TSSkinMesh::createBatchData()
 {
-   if(mBatchDataInitialized)
+   if(batchDataInitialized)
       return;
 
-   mBatchDataInitialized = true;
-   S32 * curVtx = mVertexIndex.begin();
-   S32 * curBone = mBoneIndex.begin();
-   F32 * curWeight = mWeight.begin();
-   const S32 * endVtx = mVertexIndex.end();
+   batchDataInitialized = true;
+   S32 * curVtx = vertexIndex.begin();
+   S32 * curBone = boneIndex.begin();
+   F32 * curWeight = weight.begin();
+   const S32 * endVtx = vertexIndex.end();
 
    // Temp vector to build batch operations
    Vector<BatchData::BatchedVertex> batchOperations;
@@ -1411,7 +1411,7 @@ void TSSkinMesh::createBatchData()
 
 #ifdef _BATCH_BY_VERTEX
    // Copy data to member, and be done
-   mBatchData.vertexBatchOperations.set(batchOperations.address(), batchOperations.size());
+   batchData.vertexBatchOperations.set(batchOperations.address(), batchOperations.size());
 
    // Convert to batch-by-transform, which is better for CPU skinning, 
    // where-as GPU skinning would data for batch-by-vertex operation
@@ -1427,18 +1427,18 @@ void TSSkinMesh::createBatchData()
 
          // Find the proper batched transform, and add this vertex/weight to the
          // list of verts affected by the transform
-         BatchData::BatchedTransform *bt = mBatchData.transformBatchOperations.retreive(transformOp.transformIndex);
+         BatchData::BatchedTransform *bt = batchData.transformBatchOperations.retreive(transformOp.transformIndex);
          if(!bt)
          {
             bt = new BatchData::BatchedTransform;
-            mBatchData.transformBatchOperations.insert(bt, transformOp.transformIndex);
+            batchData.transformBatchOperations.insert(bt, transformOp.transformIndex);
             bt->_tmpVec = new Vector<BatchData::BatchedVertWeight>;
-            mBatchData.transformKeys.push_back(transformOp.transformIndex);
+            batchData.transformKeys.push_back(transformOp.transformIndex);
          }
 
          bt->_tmpVec->increment();
-         bt->_tmpVec->last().vert = mBatchData.initialVerts[curTransform.vertexIndex];
-         bt->_tmpVec->last().normal = mBatchData.initialNorms[curTransform.vertexIndex];
+         bt->_tmpVec->last().vert = batchData.initialVerts[curTransform.vertexIndex];
+         bt->_tmpVec->last().normal = batchData.initialNorms[curTransform.vertexIndex];
          bt->_tmpVec->last().weight = transformOp.weight;
          bt->_tmpVec->last().vidx = curTransform.vertexIndex;
       }
@@ -1446,10 +1446,10 @@ void TSSkinMesh::createBatchData()
 
    // Now iterate the resulting operations and convert the vectors to aligned
    // memory locations
-   const S32 numBatchOps = mBatchData.transformKeys.size();
+   const S32 numBatchOps = batchData.transformKeys.size();
    for(S32 i = 0; i < numBatchOps; i++)
    {
-      BatchData::BatchedTransform &curTransform = *mBatchData.transformBatchOperations.retreive(mBatchData.transformKeys[i]);
+      BatchData::BatchedTransform &curTransform = *batchData.transformBatchOperations.retreive(batchData.transformKeys[i]);
       const S32 numVerts = curTransform._tmpVec->size();
 
       // Allocate a chunk of aligned memory and copy in values
@@ -1467,7 +1467,7 @@ void TSSkinMesh::createBatchData()
    // Now sort the batch data so that the skin function writes close to linear output
    for(S32 i = 0; i < numBatchOps; i++)
    {
-      BatchData::BatchedTransform &curTransform = *mBatchData.transformBatchOperations.retreive(mBatchData.transformKeys[i]);
+      BatchData::BatchedTransform &curTransform = *batchData.transformBatchOperations.retreive(batchData.transformKeys[i]);
       dQsort(curTransform.alignedMem, curTransform.numElements, sizeof(BatchData::BatchedVertWeight), _sort_BatchedVertWeight);
    }
 #endif
@@ -1492,15 +1492,15 @@ void TSSkinMesh::render(   TSMaterialList *materials,
 
    // Initialize the vertex data if it needs it
    if(!mVertexData.isReady() )
-      _convertToAlignedMeshData(mVertexData, mBatchData.initialVerts, mBatchData.initialNorms);
+      _convertToAlignedMeshData(mVertexData, batchData.initialVerts, batchData.initialNorms);
    AssertFatal(mVertexData.size() == mNumVerts, "Vert # mismatch");
 
    // Initialize the skin batch if that isn't ready
-   if(!mBatchDataInitialized)
+   if(!batchDataInitialized)
       createBatchData();
 
    const bool vertsChanged = vertexBuffer.isNull() || vertexBuffer->mNumVerts != mNumVerts;
-   const bool primsChanged = primitiveBuffer.isNull() || primitiveBuffer->mIndexCount != mIndices.size();
+   const bool primsChanged = primitiveBuffer.isNull() || primitiveBuffer->mIndexCount != indices.size();
 
    if ( primsChanged || vertsChanged || isSkinDirty )
    {
@@ -1553,7 +1553,7 @@ void TSSkinMesh::computeBounds( const MatrixF &transform, Box3F &bounds, S32 fra
    if (frame < 0)
    {
       // Use unskinned verts
-      TSMesh::computeBounds( mBatchData.initialVerts.address(), mBatchData.initialVerts.size(), sizeof(Point3F), transform, bounds, center, radius );
+      TSMesh::computeBounds( batchData.initialVerts.address(), batchData.initialVerts.size(), sizeof(Point3F), transform, bounds, center, radius );
    }
    else
    {
@@ -2409,17 +2409,17 @@ void TSMesh::_createVBIB( TSVertexBufferHandle &vb, GFXPrimitiveBufferHandle &pb
    }
 #endif
 
-   const bool primsChanged = ( pb.isValid() && pb->mIndexCount != mIndices.size() );
+   const bool primsChanged = ( pb.isValid() && pb->mIndexCount != indices.size() );
    if( primsChanged || pb.isNull() )
    {
       // go through and create PrimitiveInfo array
       Vector <GFXPrimitive> piArray;
       GFXPrimitive pInfo;
 
-      U32 primitivesSize = mPrimitives.size();
+      U32 primitivesSize = primitives.size();
       for ( U32 i = 0; i < primitivesSize; i++ )
       {
-         const TSDrawPrimitive & draw = mPrimitives[i];
+         const TSDrawPrimitive & draw = primitives[i];
 
          GFXPrimitiveType drawType = getDrawType( draw.matIndex >> 30 );
 
@@ -2430,7 +2430,7 @@ void TSMesh::_createVBIB( TSVertexBufferHandle &vb, GFXPrimitiveBufferHandle &pb
             pInfo.numPrimitives = draw.numElements / 3;
             pInfo.startIndex = draw.start;
             // Use the first index to determine which 16-bit address space we are operating in
-            pInfo.startVertex = mIndices[draw.start] & 0xFFFF0000;
+            pInfo.startVertex = indices[draw.start] & 0xFFFF0000;
             pInfo.minIndex = 0; // minIndex are zero based index relative to startVertex. See @GFXDevice
             pInfo.numVertices = getMin((U32)0x10000, mNumVerts - pInfo.startVertex);
             break;
@@ -2441,7 +2441,7 @@ void TSMesh::_createVBIB( TSVertexBufferHandle &vb, GFXPrimitiveBufferHandle &pb
             pInfo.numPrimitives = draw.numElements - 2;
             pInfo.startIndex = draw.start;
             // Use the first index to determine which 16-bit address space we are operating in
-            pInfo.startVertex = mIndices[draw.start] & 0xFFFF0000;
+            pInfo.startVertex = indices[draw.start] & 0xFFFF0000;
             pInfo.minIndex = 0; // minIndex are zero based index relative to startVertex. See @GFXDevice
             pInfo.numVertices = getMin((U32)0x10000, mNumVerts - pInfo.startVertex);
             break;
@@ -2453,13 +2453,13 @@ void TSMesh::_createVBIB( TSVertexBufferHandle &vb, GFXPrimitiveBufferHandle &pb
          piArray.push_back( pInfo );
       }
 
-      pb.set( GFX, mIndices.size(), piArray.size(), GFXBufferTypeStatic );
+      pb.set( GFX, indices.size(), piArray.size(), GFXBufferTypeStatic );
 
       U16 *ibIndices = NULL;
       GFXPrimitive *piInput = NULL;
       pb.lock( &ibIndices, &piInput );
 
-      dCopyArray( ibIndices, mIndices.address(), mIndices.size() );
+      dCopyArray( ibIndices, indices.address(), indices.size() );
       dMemcpy( piInput, piArray.address(), piArray.size() * sizeof(GFXPrimitive) );
 
       pb.unlock();
@@ -2470,59 +2470,59 @@ void TSMesh::assemble( bool skip )
 {
    tsalloc.checkGuard();
 
-   mNumFrames = tsalloc.get32();
-   mNumMatFrames = tsalloc.get32();
-   mParentMesh = tsalloc.get32();
+   numFrames = tsalloc.get32();
+   numMatFrames = tsalloc.get32();
+   parentMesh = tsalloc.get32();
    tsalloc.get32( (S32*)&mBounds, 6 );
    tsalloc.get32( (S32*)&mCenter, 3 );
    mRadius = (F32)tsalloc.get32();
 
    S32 numVerts = tsalloc.get32();
-   S32 *ptr32 = getSharedData32( mParentMesh, 3 * numVerts, (S32**)smVertsList.address(), skip );
-   mVerts.set( (Point3F*)ptr32, numVerts );
+   S32 *ptr32 = getSharedData32( parentMesh, 3 * numVerts, (S32**)smVertsList.address(), skip );
+   verts.set( (Point3F*)ptr32, numVerts );
 
    S32 numTVerts = tsalloc.get32();
-   ptr32 = getSharedData32( mParentMesh, 2 * numTVerts, (S32**)smTVertsList.address(), skip );
-   mTVerts.set( (Point2F*)ptr32, numTVerts );
+   ptr32 = getSharedData32( parentMesh, 2 * numTVerts, (S32**)smTVertsList.address(), skip );
+   tverts.set( (Point2F*)ptr32, numTVerts );
 
    if ( TSShape::smReadVersion > 25 )
    {
       numTVerts = tsalloc.get32();
-      ptr32 = getSharedData32( mParentMesh, 2 * numTVerts, (S32**)smTVerts2List.address(), skip );
-      mTVerts2.set( (Point2F*)ptr32, numTVerts );
+      ptr32 = getSharedData32( parentMesh, 2 * numTVerts, (S32**)smTVerts2List.address(), skip );
+      tverts2.set( (Point2F*)ptr32, numTVerts );
 
       S32 numVColors = tsalloc.get32();
-      ptr32 = getSharedData32( mParentMesh, numVColors, (S32**)smColorsList.address(), skip );
-      mColors.set( (ColorI*)ptr32, numVColors );
+      ptr32 = getSharedData32( parentMesh, numVColors, (S32**)smColorsList.address(), skip );
+      colors.set( (ColorI*)ptr32, numVColors );
    }
 
    S8 *ptr8;
    if ( TSShape::smReadVersion > 21 && TSMesh::smUseEncodedNormals)
    {
       // we have encoded normals and we want to use them...
-      if ( mParentMesh < 0 )
+      if ( parentMesh < 0 )
          tsalloc.getPointer32( numVerts * 3 ); // advance past norms, don't use
-      mNorms.set( NULL, 0 );
+      norms.set( NULL, 0 );
 
-      ptr8 = getSharedData8( mParentMesh, numVerts, (S8**)smEncodedNormsList.address(), skip );
-      mEncodedNorms.set( ptr8, numVerts );
+      ptr8 = getSharedData8( parentMesh, numVerts, (S8**)smEncodedNormsList.address(), skip );
+      encodedNorms.set( ptr8, numVerts );
    }
    else if ( TSShape::smReadVersion > 21 )
    {
       // we have encoded normals but we don't want to use them...
-      ptr32 = getSharedData32( mParentMesh, 3 * numVerts, (S32**)smNormsList.address(), skip );
-      mNorms.set( (Point3F*)ptr32, numVerts );
+      ptr32 = getSharedData32( parentMesh, 3 * numVerts, (S32**)smNormsList.address(), skip );
+      norms.set( (Point3F*)ptr32, numVerts );
 
-      if ( mParentMesh < 0 )
+      if ( parentMesh < 0 )
          tsalloc.getPointer8( numVerts ); // advance past encoded normls, don't use
-      mEncodedNorms.set( NULL, 0 );
+      encodedNorms.set( NULL, 0 );
    }
    else
    {
       // no encoded normals...
-      ptr32 = getSharedData32( mParentMesh, 3 * numVerts, (S32**)smNormsList.address(), skip );
-      mNorms.set( (Point3F*)ptr32, numVerts );
-      mEncodedNorms.set( NULL, 0 );
+      ptr32 = getSharedData32( parentMesh, 3 * numVerts, (S32**)smNormsList.address(), skip );
+      norms.set( (Point3F*)ptr32, numVerts );
+      encodedNorms.set( NULL, 0 );
    }
 
    // copy the primitives and indices...how we do this depends on what
@@ -2596,8 +2596,8 @@ void TSMesh::assemble( bool skip )
    AssertFatal(chkPrim==szPrimOut && chkInd==szIndOut,"TSMesh::primitive conversion");
 
    // store output
-   mPrimitives.set(primOut, szPrimOut);
-   mIndices.set(indOut, szIndOut);
+   primitives.set(primOut, szPrimOut);
+   indices.set(indOut, szIndOut);
 
    // delete temporary arrays if necessary
    if (deleteInputArrays)
@@ -2610,9 +2610,9 @@ void TSMesh::assemble( bool skip )
    tsalloc.getPointer16( sz ); // skip deprecated merge indices
    tsalloc.align32();
 
-   mVertsPerFrame = tsalloc.get32();
+   vertsPerFrame = tsalloc.get32();
    U32 flags = (U32)tsalloc.get32();
-   if ( mEncodedNorms.size() )
+   if ( encodedNorms.size() )
       flags |= UseEncodedNormals;
    
    setFlags( flags );
@@ -2623,16 +2623,16 @@ void TSMesh::assemble( bool skip )
       computeBounds(); // only do this if we copied the data...
 
    if(getMeshType() != SkinMeshType)
-      createTangents(mVerts, mNorms);
+      createTangents(verts, norms);
 }
 
 void TSMesh::disassemble()
 {
    tsalloc.setGuard();
 
-   tsalloc.set32( mNumFrames );
-   tsalloc.set32( mNumMatFrames );
-   tsalloc.set32( mParentMesh );
+   tsalloc.set32( numFrames );
+   tsalloc.set32( numMatFrames );
+   tsalloc.set32( parentMesh );
    tsalloc.copyToBuffer32( (S32*)&mBounds, 6 );
    tsalloc.copyToBuffer32( (S32*)&mCenter, 3 );
    tsalloc.set32( (S32)mRadius );
@@ -2640,81 +2640,81 @@ void TSMesh::disassemble()
    // Re-create the vectors
    if(mVertexData.isReady())
    {
-      mVerts.setSize(mNumVerts);
-      mTVerts.setSize(mNumVerts);
-      mNorms.setSize(mNumVerts);
+      verts.setSize(mNumVerts);
+      tverts.setSize(mNumVerts);
+      norms.setSize(mNumVerts);
 
       if(mHasColor)
-         mColors.setSize(mNumVerts);
+         colors.setSize(mNumVerts);
       if(mHasTVert2)
-         mTVerts2.setSize(mNumVerts);
+         tverts2.setSize(mNumVerts);
 
       // Fill arrays
       for(U32 i = 0; i < mNumVerts; i++)
       {
          const __TSMeshVertexBase &cv = mVertexData[i];
-         mVerts[i] = cv.vert();
-         mTVerts[i] = cv.tvert();
-         mNorms[i] = cv.normal();
+         verts[i] = cv.vert();
+         tverts[i] = cv.tvert();
+         norms[i] = cv.normal();
 
          if(mHasColor)
-            cv.color().getColor(&mColors[i]);
+            cv.color().getColor(&colors[i]);
          if(mHasTVert2)
-            mTVerts2[i] = cv.tvert2();
+            tverts2[i] = cv.tvert2();
       }
    }
 
    // verts...
-   tsalloc.set32( mVerts.size() );
-   if ( mParentMesh < 0 )
-      tsalloc.copyToBuffer32( (S32*)mVerts.address(), 3 * mVerts.size() ); // if no parent mesh, then save off our verts
+   tsalloc.set32( verts.size() );
+   if ( parentMesh < 0 )
+      tsalloc.copyToBuffer32( (S32*)verts.address(), 3 * verts.size() ); // if no parent mesh, then save off our verts
 
    // tverts...
-   tsalloc.set32( mTVerts.size() );
-   if ( mParentMesh < 0 )
-      tsalloc.copyToBuffer32( (S32*)mTVerts.address(), 2 * mTVerts.size() ); // if no parent mesh, then save off our tverts
+   tsalloc.set32( tverts.size() );
+   if ( parentMesh < 0 )
+      tsalloc.copyToBuffer32( (S32*)tverts.address(), 2 * tverts.size() ); // if no parent mesh, then save off our tverts
 
    if (TSShape::smVersion > 25)
    {
       // tverts2...
-      tsalloc.set32( mTVerts2.size() );
-      if ( mParentMesh < 0 )
-         tsalloc.copyToBuffer32( (S32*)mTVerts2.address(), 2 * mTVerts2.size() ); // if no parent mesh, then save off our tverts
+      tsalloc.set32( tverts2.size() );
+      if ( parentMesh < 0 )
+         tsalloc.copyToBuffer32( (S32*)tverts2.address(), 2 * tverts2.size() ); // if no parent mesh, then save off our tverts
 
       // colors
-      tsalloc.set32( mColors.size() );
-      if ( mParentMesh < 0 )
-         tsalloc.copyToBuffer32( (S32*)mColors.address(), mColors.size() ); // if no parent mesh, then save off our tverts
+      tsalloc.set32( colors.size() );
+      if ( parentMesh < 0 )
+         tsalloc.copyToBuffer32( (S32*)colors.address(), colors.size() ); // if no parent mesh, then save off our tverts
    }
 
    // norms...
-   if ( mParentMesh < 0 ) // if no parent mesh, then save off our norms
-      tsalloc.copyToBuffer32( (S32*)mNorms.address(), 3 * mNorms.size() ); // norms.size()==verts.size() or error...
+   if ( parentMesh < 0 ) // if no parent mesh, then save off our norms
+      tsalloc.copyToBuffer32( (S32*)norms.address(), 3 * norms.size() ); // norms.size()==verts.size() or error...
 
    // encoded norms...
-   if ( mParentMesh < 0 )
+   if ( parentMesh < 0 )
    {
       // if no parent mesh, compute encoded normals and copy over
-      for ( S32 i = 0; i < mNorms.size(); i++ )
+      for ( S32 i = 0; i < norms.size(); i++ )
       {
-         U8 normIdx = mEncodedNorms.size() ? mEncodedNorms[i] : encodeNormal( mNorms[i] );
+         U8 normIdx = encodedNorms.size() ? encodedNorms[i] : encodeNormal( norms[i] );
          tsalloc.copyToBuffer8( (S8*)&normIdx, 1 );
       }
    }
 
    // optimize triangle draw order during disassemble
    {
-      FrameTemp<TriListOpt::IndexType> tmpIdxs(mIndices.size());
-      for ( S32 i = 0; i < mPrimitives.size(); i++ )
+      FrameTemp<TriListOpt::IndexType> tmpIdxs(indices.size());
+      for ( S32 i = 0; i < primitives.size(); i++ )
       {
-         const TSDrawPrimitive& prim = mPrimitives[i];
+         const TSDrawPrimitive& prim = primitives[i];
 
          // only optimize triangle lists (strips and fans are assumed to be already optimized)
          if ( (prim.matIndex & TSDrawPrimitive::TypeMask) == TSDrawPrimitive::Triangles )
          {
-            TriListOpt::OptimizeTriangleOrdering(mVerts.size(), prim.numElements,
-               mIndices.address() + prim.start, tmpIdxs.address());
-            dCopyArray(mIndices.address() + prim.start, tmpIdxs.address(), 
+            TriListOpt::OptimizeTriangleOrdering(verts.size(), prim.numElements,
+               indices.address() + prim.start, tmpIdxs.address());
+            dCopyArray(indices.address() + prim.start, tmpIdxs.address(), 
                prim.numElements);
          }
       }
@@ -2723,32 +2723,32 @@ void TSMesh::disassemble()
    if (TSShape::smVersion > 25)
    {
       // primitives...
-      tsalloc.set32( mPrimitives.size() );
-      tsalloc.copyToBuffer32((S32*)mPrimitives.address(),3*mPrimitives.size());
+      tsalloc.set32( primitives.size() );
+      tsalloc.copyToBuffer32((S32*)primitives.address(),3*primitives.size());
 
       // indices...
-      tsalloc.set32(mIndices.size());
-      tsalloc.copyToBuffer32((S32*)mIndices.address(),mIndices.size());
+      tsalloc.set32(indices.size());
+      tsalloc.copyToBuffer32((S32*)indices.address(),indices.size());
    }
    else
    {
       // primitives
-      tsalloc.set32( mPrimitives.size() );
-      for (S32 i=0; i<mPrimitives.size(); i++)
+      tsalloc.set32( primitives.size() );
+      for (S32 i=0; i<primitives.size(); i++)
       {
-         S16 start = (S16)mPrimitives[i].start;
-         S16 numElements = (S16)mPrimitives[i].numElements;
+         S16 start = (S16)primitives[i].start;
+         S16 numElements = (S16)primitives[i].numElements;
 
          tsalloc.copyToBuffer16(&start, 1);
          tsalloc.copyToBuffer16(&numElements, 1);
-         tsalloc.copyToBuffer32(&(mPrimitives[i].matIndex), 1);
+         tsalloc.copyToBuffer32(&(primitives[i].matIndex), 1);
       }
 
       // indices
-      tsalloc.set32(mIndices.size());
-      Vector<S16> s16_indices(mIndices.size());
-      for (S32 i=0; i<mIndices.size(); i++)
-         s16_indices.push_back((S16)mIndices[i]);
+      tsalloc.set32(indices.size());
+      Vector<S16> s16_indices(indices.size());
+      for (S32 i=0; i<indices.size(); i++)
+         s16_indices.push_back((S16)indices[i]);
       tsalloc.copyToBuffer16(s16_indices.address(), s16_indices.size());
    }
 
@@ -2756,7 +2756,7 @@ void TSMesh::disassemble()
    tsalloc.set32( 0 );
 
    // small stuff...
-   tsalloc.set32( mVertsPerFrame );
+   tsalloc.set32( vertsPerFrame );
    tsalloc.set32( getFlags() );
 
    tsalloc.setGuard();
@@ -2768,71 +2768,71 @@ void TSMesh::disassemble()
 void TSSkinMesh::assemble( bool skip )
 {
    // avoid a crash on computeBounds...
-   mBatchData.initialVerts.set( NULL, 0 );
+   batchData.initialVerts.set( NULL, 0 );
 
    TSMesh::assemble( skip );
 
    S32 sz = tsalloc.get32();
    S32 numVerts = sz;
-   S32 * ptr32 = getSharedData32( mParentMesh, 3 * numVerts, (S32**)smVertsList.address(), skip );
-   mBatchData.initialVerts.set( (Point3F*)ptr32, sz );
+   S32 * ptr32 = getSharedData32( parentMesh, 3 * numVerts, (S32**)smVertsList.address(), skip );
+   batchData.initialVerts.set( (Point3F*)ptr32, sz );
 
    S8 * ptr8;
    if ( TSShape::smReadVersion>21 && TSMesh::smUseEncodedNormals )
    {
       // we have encoded normals and we want to use them...
-      if ( mParentMesh < 0 )
+      if ( parentMesh < 0 )
          tsalloc.getPointer32( numVerts * 3 ); // advance past norms, don't use
-      mBatchData.initialNorms.set( NULL, 0 );
+      batchData.initialNorms.set( NULL, 0 );
 
-      ptr8 = getSharedData8( mParentMesh, numVerts, (S8**)smEncodedNormsList.address(), skip );
-      mEncodedNorms.set( ptr8, numVerts );
+      ptr8 = getSharedData8( parentMesh, numVerts, (S8**)smEncodedNormsList.address(), skip );
+      encodedNorms.set( ptr8, numVerts );
       // Note: we don't set the encoded normals flag because we handle them in updateSkin and
       //       hide the fact that we are using them from base class (TSMesh)
    }
    else if ( TSShape::smReadVersion > 21 )
    {
       // we have encoded normals but we don't want to use them...
-      ptr32 = getSharedData32( mParentMesh, 3 * numVerts, (S32**)smNormsList.address(), skip );
-      mBatchData.initialNorms.set( (Point3F*)ptr32, numVerts );
+      ptr32 = getSharedData32( parentMesh, 3 * numVerts, (S32**)smNormsList.address(), skip );
+      batchData.initialNorms.set( (Point3F*)ptr32, numVerts );
 
-      if ( mParentMesh < 0 )
+      if ( parentMesh < 0 )
          tsalloc.getPointer8( numVerts ); // advance past encoded normls, don't use
       
-      mEncodedNorms.set( NULL, 0 );
+      encodedNorms.set( NULL, 0 );
    }
    else
    {
       // no encoded normals...
-      ptr32 = getSharedData32( mParentMesh, 3 * numVerts, (S32**)smNormsList.address(), skip );
-      mBatchData.initialNorms.set( (Point3F*)ptr32, numVerts );
-      mEncodedNorms.set( NULL, 0 );
+      ptr32 = getSharedData32( parentMesh, 3 * numVerts, (S32**)smNormsList.address(), skip );
+      batchData.initialNorms.set( (Point3F*)ptr32, numVerts );
+      encodedNorms.set( NULL, 0 );
    }
 
    sz = tsalloc.get32();
-   ptr32 = getSharedData32( mParentMesh, 16 * sz, (S32**)smInitTransformList.address(), skip );
-   mBatchData.initialTransforms.set( ptr32, sz );
+   ptr32 = getSharedData32( parentMesh, 16 * sz, (S32**)smInitTransformList.address(), skip );
+   batchData.initialTransforms.set( ptr32, sz );
 
    sz = tsalloc.get32();
-   ptr32 = getSharedData32( mParentMesh, sz, (S32**)smVertexIndexList.address(), skip );
-   mVertexIndex.set( ptr32, sz );
+   ptr32 = getSharedData32( parentMesh, sz, (S32**)smVertexIndexList.address(), skip );
+   vertexIndex.set( ptr32, sz );
 
-   ptr32 = getSharedData32( mParentMesh, sz, (S32**)smBoneIndexList.address(), skip );
-   mBoneIndex.set( ptr32, sz );
+   ptr32 = getSharedData32( parentMesh, sz, (S32**)smBoneIndexList.address(), skip );
+   boneIndex.set( ptr32, sz );
 
-   ptr32 = getSharedData32( mParentMesh, sz, (S32**)smWeightList.address(), skip );
-   mWeight.set( (F32*)ptr32, sz );
+   ptr32 = getSharedData32( parentMesh, sz, (S32**)smWeightList.address(), skip );
+   weight.set( (F32*)ptr32, sz );
 
    sz = tsalloc.get32();
-   ptr32 = getSharedData32( mParentMesh, sz, (S32**)smNodeIndexList.address(), skip );
-   mBatchData.nodeIndex.set( ptr32, sz );
+   ptr32 = getSharedData32( parentMesh, sz, (S32**)smNodeIndexList.address(), skip );
+   batchData.nodeIndex.set( ptr32, sz );
 
    tsalloc.checkGuard();
 
    if ( tsalloc.allocShape32( 0 ) && TSShape::smReadVersion < 19 )
       TSMesh::computeBounds(); // only do this if we copied the data...
 
-   createTangents(mBatchData.initialVerts, mBatchData.initialNorms);
+   createTangents(batchData.initialVerts, batchData.initialNorms);
 }
 
 //-----------------------------------------------------------------------------
@@ -2842,49 +2842,49 @@ void TSSkinMesh::disassemble()
 {
    TSMesh::disassemble();
 
-   tsalloc.set32( mBatchData.initialVerts.size() );
+   tsalloc.set32( batchData.initialVerts.size() );
    // if we have no parent mesh, then save off our verts & norms
-   if ( mParentMesh < 0 )
+   if ( parentMesh < 0 )
    {
-      tsalloc.copyToBuffer32( (S32*)mBatchData.initialVerts.address(), 3 * mBatchData.initialVerts.size() );
+      tsalloc.copyToBuffer32( (S32*)batchData.initialVerts.address(), 3 * batchData.initialVerts.size() );
 
       // no longer do this here...let tsmesh handle this
-      tsalloc.copyToBuffer32( (S32*)mBatchData.initialNorms.address(), 3 * mBatchData.initialNorms.size() );
+      tsalloc.copyToBuffer32( (S32*)batchData.initialNorms.address(), 3 * batchData.initialNorms.size() );
 
       // if no parent mesh, compute encoded normals and copy over
-      for ( S32 i = 0; i < mBatchData.initialNorms.size(); i++ )
+      for ( S32 i = 0; i < batchData.initialNorms.size(); i++ )
       {
-         U8 normIdx = mEncodedNorms.size() ? mEncodedNorms[i] : encodeNormal( mBatchData.initialNorms[i] );
+         U8 normIdx = encodedNorms.size() ? encodedNorms[i] : encodeNormal( batchData.initialNorms[i] );
          tsalloc.copyToBuffer8( (S8*)&normIdx, 1 );
       }
    }
 
-   tsalloc.set32( mBatchData.initialTransforms.size() );
-   if ( mParentMesh < 0 )
-      tsalloc.copyToBuffer32( (S32*)mBatchData.initialTransforms.address(), mBatchData.initialTransforms.size() * 16 );
+   tsalloc.set32( batchData.initialTransforms.size() );
+   if ( parentMesh < 0 )
+      tsalloc.copyToBuffer32( (S32*)batchData.initialTransforms.address(), batchData.initialTransforms.size() * 16 );
 
-   tsalloc.set32( mVertexIndex.size() );
-   if ( mParentMesh < 0 )
+   tsalloc.set32( vertexIndex.size() );
+   if ( parentMesh < 0 )
    {
-      tsalloc.copyToBuffer32( (S32*)mVertexIndex.address(), mVertexIndex.size() );
+      tsalloc.copyToBuffer32( (S32*)vertexIndex.address(), vertexIndex.size() );
 
-      tsalloc.copyToBuffer32( (S32*)mBoneIndex.address(), mBoneIndex.size() );
+      tsalloc.copyToBuffer32( (S32*)boneIndex.address(), boneIndex.size() );
 
-      tsalloc.copyToBuffer32( (S32*)mWeight.address(), mWeight.size() );
+      tsalloc.copyToBuffer32( (S32*)weight.address(), weight.size() );
    }
 
-   tsalloc.set32( mBatchData.nodeIndex.size() );
-   if ( mParentMesh < 0 )
-      tsalloc.copyToBuffer32( (S32*)mBatchData.nodeIndex.address(), mBatchData.nodeIndex.size() );
+   tsalloc.set32( batchData.nodeIndex.size() );
+   if ( parentMesh < 0 )
+      tsalloc.copyToBuffer32( (S32*)batchData.nodeIndex.address(), batchData.nodeIndex.size() );
 
    tsalloc.setGuard();
 }
 
 TSSkinMesh::TSSkinMesh()
 {
-   mMeshType = SkinMeshType;
+   meshType = SkinMeshType;
    mDynamic = true;
-   mBatchDataInitialized = false;
+   batchDataInitialized = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -2901,9 +2901,9 @@ inline void TSMesh::findTangent( U32 index1,
    const Point3F &v2 = _verts[index2];
    const Point3F &v3 = _verts[index3];
 
-   const Point2F &w1 = mTVerts[index1];
-   const Point2F &w2 = mTVerts[index2];
-   const Point2F &w3 = mTVerts[index3];
+   const Point2F &w1 = tverts[index1];
+   const Point2F &w2 = tverts[index2];
+   const Point2F &w3 = tverts[index3];
 
    F32 x1 = v2.x - v1.x;
    F32 x2 = v3.x - v1.x;
@@ -2965,17 +2965,17 @@ void TSMesh::createTangents(const Vector<Point3F> &_verts, const Vector<Point3F>
    Point3F *tan1 = tan0.address() + numVerts;
    dMemset( tan0.address(), 0, sizeof(Point3F) * 2 * numVerts );
    
-   U32   numPrimatives = mPrimitives.size();
+   U32   numPrimatives = primitives.size();
 
    for (S32 i = 0; i < numPrimatives; i++ )
    {
-      const TSDrawPrimitive & draw = mPrimitives[i];
+      const TSDrawPrimitive & draw = primitives[i];
       GFXPrimitiveType drawType = getDrawType( draw.matIndex >> 30 );
 
       U32 p1Index = 0;
       U32 p2Index = 0;
 
-      U32 *baseIdx = &mIndices[draw.start];
+      U32 *baseIdx = &indices[draw.start];
 
       const U32 numElements = (U32)draw.numElements;
 
@@ -3017,7 +3017,7 @@ void TSMesh::createTangents(const Vector<Point3F> &_verts, const Vector<Point3F>
       }
    }
 
-   mTangents.setSize( numVerts );
+   tangents.setSize( numVerts );
 
    // fill out final info from accumulated basis data
    for( U32 i = 0; i < numVerts; i++ )
@@ -3028,26 +3028,26 @@ void TSMesh::createTangents(const Vector<Point3F> &_verts, const Vector<Point3F>
 
       Point3F tempPt = t - n * mDot( n, t );
       tempPt.normalize();
-      mTangents[i] = tempPt;
+      tangents[i] = tempPt;
 
       Point3F cp;
       mCross( n, t, &cp );
       
-      mTangents[i].w = (mDot( cp, b ) < 0.0f) ? -1.0f : 1.0f;
+      tangents[i].w = (mDot( cp, b ) < 0.0f) ? -1.0f : 1.0f;
    }
 }
 
 void TSMesh::convertToAlignedMeshData()
 {
    if(!mVertexData.isReady())
-      _convertToAlignedMeshData(mVertexData, mVerts, mNorms);
+      _convertToAlignedMeshData(mVertexData, verts, norms);
 }
 
 
 void TSSkinMesh::convertToAlignedMeshData()
 {
    if(!mVertexData.isReady())
-      _convertToAlignedMeshData(mVertexData, mBatchData.initialVerts, mBatchData.initialNorms);
+      _convertToAlignedMeshData(mVertexData, batchData.initialVerts, batchData.initialNorms);
 }
 
 void TSMesh::_convertToAlignedMeshData( TSMeshVertexArray &vertexData, const Vector<Point3F> &_verts, const Vector<Point3F> &_norms )
@@ -3078,7 +3078,7 @@ void TSMesh::_convertToAlignedMeshData( TSMeshVertexArray &vertexData, const Vec
 
    AssertFatal(!vertexData.isReady(), "Mesh already converted to aligned data! Re-check code!");
    AssertFatal(_verts.size() == _norms.size() &&
-               _verts.size() == mTangents.size(), 
+               _verts.size() == tangents.size(), 
                "Vectors: verts, norms, tangents must all be the same size");
    mNumVerts = _verts.size();
 
@@ -3089,11 +3089,11 @@ void TSMesh::_convertToAlignedMeshData( TSMeshVertexArray &vertexData, const Vec
    if(mNumVerts == 0)
       return;
 
-   mHasColor = !mColors.empty();
-   AssertFatal(!mHasColor || mColors.size() == _verts.size(), "Vector of color elements should be the same size as other vectors");
+   mHasColor = !colors.empty();
+   AssertFatal(!mHasColor || colors.size() == _verts.size(), "Vector of color elements should be the same size as other vectors");
 
-   mHasTVert2 = !mTVerts2.empty();
-   AssertFatal(!mHasTVert2 || mTVerts2.size() == _verts.size(), "Vector of tvert2 elements should be the same size as other vectors");
+   mHasTVert2 = !tverts2.empty();
+   AssertFatal(!mHasTVert2 || tverts2.size() == _verts.size(), "Vector of tvert2 elements should be the same size as other vectors");
 
    // Create the proper array type
    void *aligned_mem = dMalloc_aligned(mVertSize * mNumVerts, 16);
@@ -3107,21 +3107,21 @@ void TSMesh::_convertToAlignedMeshData( TSMeshVertexArray &vertexData, const Vec
       __TSMeshVertexBase &v = vertexData[i];
       v.vert(_verts[i]);
       v.normal(_norms[i]);
-      v.tangent(mTangents[i]);
+      v.tangent(tangents[i]);
 
-      if(i < mTVerts.size())
-         v.tvert(mTVerts[i]);
-      if(mHasTVert2 && i < mTVerts2.size())
-         v.tvert2(mTVerts2[i]);
-      if(mHasColor && i < mColors.size())
-         v.color(mColors[i]);
+      if(i < tverts.size())
+         v.tvert(tverts[i]);
+      if(mHasTVert2 && i < tverts2.size())
+         v.tvert2(tverts2[i]);
+      if(mHasColor && i < colors.size())
+         v.color(colors[i]);
    }
 
    // Now that the data is in the aligned struct, free the Vector memory
-   mVerts.free_memory();
-   mNorms.free_memory();
-   mTangents.free_memory();
-   mTVerts.free_memory();
-   mTVerts2.free_memory();
-   mColors.free_memory();
+   verts.free_memory();
+   norms.free_memory();
+   tangents.free_memory();
+   tverts.free_memory();
+   tverts2.free_memory();
+   colors.free_memory();
 }

--- a/Engine/source/ts/tsMesh.h
+++ b/Engine/source/ts/tsMesh.h
@@ -105,7 +105,7 @@ class TSMesh
    struct TSMeshVertexArray;
   protected:
 
-   U32 mMeshType;
+   U32 meshType;
    Box3F mBounds;
    Point3F mCenter;
    F32 mRadius;
@@ -140,17 +140,17 @@ class TSMesh
       FlagMask = Billboard|BillboardZAxis|HasDetailTexture|UseEncodedNormals
    };
 
-   U32 getMeshType() const { return mMeshType & TypeMask; }
-   void setFlags(U32 flag) { mMeshType |= flag; }
-   void clearFlags(U32 flag) { mMeshType &= ~flag; }
-   U32 getFlags( U32 flag = 0xFFFFFFFF ) const { return mMeshType & flag; }
+   U32 getMeshType() const { return meshType & TypeMask; }
+   void setFlags(U32 flag) { meshType |= flag; }
+   void clearFlags(U32 flag) { meshType &= ~flag; }
+   U32 getFlags( U32 flag = 0xFFFFFFFF ) const { return meshType & flag; }
 
    const Point3F* getNormals( S32 firstVert );
 
-   S32 mParentMesh; ///< index into shapes mesh list
-   S32 mNumFrames;
-   S32 mNumMatFrames;
-   S32 mVertsPerFrame;
+   S32 parentMesh; ///< index into shapes mesh list
+   S32 numFrames;
+   S32 numMatFrames;
+   S32 vertsPerFrame;
 
    /// @name Aligned Vertex Data 
    /// @{
@@ -244,34 +244,34 @@ class TSMesh
       FreeableVector<T>& operator=(const FreeableVector<T>& p) { Vector<T>::operator=(p); return *this; }
    };
 
-   FreeableVector<Point3F> mVerts;
-   FreeableVector<Point3F> mNorms;
-   FreeableVector<Point2F> mTVerts;
-   FreeableVector<Point4F> mTangents;
+   FreeableVector<Point3F> verts;
+   FreeableVector<Point3F> norms;
+   FreeableVector<Point2F> tverts;
+   FreeableVector<Point4F> tangents;
    
    // Optional second texture uvs.
-   FreeableVector<Point2F> mTVerts2;
+   FreeableVector<Point2F> tverts2;
 
    // Optional vertex colors data.
-   FreeableVector<ColorI> mColors;
+   FreeableVector<ColorI> colors;
    /// @}
 
-   Vector<TSDrawPrimitive> mPrimitives;
-   Vector<U8> mEncodedNorms;
-   Vector<U32> mIndices;
+   Vector<TSDrawPrimitive> primitives;
+   Vector<U8> encodedNorms;
+   Vector<U32> indices;
 
    /// billboard data
-   Point3F mBillboardAxis;
+   Point3F billboardAxis;
 
    /// @name Convex Hull Data
    /// Convex hulls are convex (no angles >= 180º) meshes used for collision
    /// @{
 
-   Vector<Point3F> mPlaneNormals;
-   Vector<F32>     mPlaneConstants;
-   Vector<U32>     mPlaneMaterials;
-   S32 mPlanesPerFrame;
-   U32 mMergeBufferStart;
+   Vector<Point3F> planeNormals;
+   Vector<F32>     planeConstants;
+   Vector<U32>     planeMaterials;
+   S32 planesPerFrame;
+   U32 mergeBufferStart;
    /// @}
 
    /// @name Render Methods
@@ -501,13 +501,13 @@ public:
    typedef TSMesh Parent;
 
    /// Structure containing data needed to batch skinning
-   BatchData mBatchData;
-   bool mBatchDataInitialized;
+   BatchData batchData;
+   bool batchDataInitialized;
    
    /// vectors that define the vertex, weight, bone tuples
-   Vector<F32> mWeight;
-   Vector<S32> mBoneIndex;
-   Vector<S32> mVertexIndex;
+   Vector<F32> weight;
+   Vector<S32> boneIndex;
+   Vector<S32> vertexIndex;
 
    /// set verts and normals...
    void updateSkin( const Vector<MatrixF> &transforms, TSVertexBufferHandle &instanceVB, GFXPrimitiveBufferHandle &instancePB );

--- a/Engine/source/ts/tsMeshFit.cpp
+++ b/Engine/source/ts/tsMeshFit.cpp
@@ -204,18 +204,18 @@ void MeshFit::initSourceGeometry( const String& target )
    {
       // Add all geometry in the highest detail level
       S32 dl = 0;
-      S32 ss = mShape->mDetails[dl].subShapeNum;
+      S32 ss = mShape->details[dl].subShapeNum;
       if ( ss < 0 )
          return;
 
-      S32 od = mShape->mDetails[dl].objectDetailNum;
-      S32 start = mShape->mSubShapeFirstObject[ss];
-      S32 end   = start + mShape->mSubShapeNumObjects[ss];
+      S32 od = mShape->details[dl].objectDetailNum;
+      S32 start = mShape->subShapeFirstObject[ss];
+      S32 end   = start + mShape->subShapeNumObjects[ss];
 
       for ( S32 i = start; i < end; i++ )
       {
-         const TSShape::Object &obj = mShape->mObjects[i];
-         const TSMesh* mesh = ( od < obj.numMeshes ) ? mShape->mMeshes[obj.startMeshIndex + od] : NULL;
+         const TSShape::Object &obj = mShape->objects[i];
+         const TSMesh* mesh = ( od < obj.numMeshes ) ? mShape->meshes[obj.startMeshIndex + od] : NULL;
          if ( mesh )
             addSourceMesh( obj, mesh );
       }
@@ -227,10 +227,10 @@ void MeshFit::initSourceGeometry( const String& target )
       if ( objIndex == -1 )
          return;
 
-      const TSShape::Object &obj = mShape->mObjects[objIndex];
+      const TSShape::Object &obj = mShape->objects[objIndex];
       for ( S32 i = 0; i < obj.numMeshes; i++ )
       {
-         const TSMesh* mesh = mShape->mMeshes[obj.startMeshIndex + i];
+         const TSMesh* mesh = mShape->meshes[obj.startMeshIndex + i];
          if ( mesh )
          {
             addSourceMesh( obj, mesh );
@@ -246,24 +246,24 @@ void MeshFit::addSourceMesh( const TSShape::Object& obj, const TSMesh* mesh )
 {
    // Add indices
    S32 indicesBase = mIndices.size();
-   for ( S32 i = 0; i < mesh->mPrimitives.size(); i++ )
+   for ( S32 i = 0; i < mesh->primitives.size(); i++ )
    {
-      const TSDrawPrimitive& draw = mesh->mPrimitives[i];
+      const TSDrawPrimitive& draw = mesh->primitives[i];
       if ( (draw.matIndex & TSDrawPrimitive::TypeMask) == TSDrawPrimitive::Triangles )
       {
-         mIndices.merge( &mesh->mIndices[draw.start], draw.numElements );
+         mIndices.merge( &mesh->indices[draw.start], draw.numElements );
       }
       else
       {
-         U32 idx0 = mesh->mIndices[draw.start + 0];
+         U32 idx0 = mesh->indices[draw.start + 0];
          U32 idx1;
-         U32 idx2 = mesh->mIndices[draw.start + 1];
+         U32 idx2 = mesh->indices[draw.start + 1];
          U32 *nextIdx = &idx1;
          for ( S32 j = 2; j < draw.numElements; j++ )
          {
             *nextIdx = idx2;
             nextIdx = (U32*) ( (dsize_t)nextIdx ^ (dsize_t)&idx0 ^ (dsize_t)&idx1);
-            idx2 = mesh->mIndices[draw.start + j];
+            idx2 = mesh->indices[draw.start + j];
             if ( idx0 == idx1 || idx0 == idx2 || idx1 == idx2 )
                continue;
 
@@ -290,9 +290,9 @@ void MeshFit::addSourceMesh( const TSShape::Object& obj, const TSMesh* mesh )
    }
    else
    {
-      count = mesh->mVerts.size();
+      count = mesh->verts.size();
       stride = sizeof(Point3F);
-      pVert = (U8*)mesh->mVerts.address();
+      pVert = (U8*)mesh->verts.address();
    }
 
    MatrixF objMat;
@@ -310,82 +310,82 @@ TSMesh* MeshFit::initMeshFromFile( const String& filename ) const
 {
    // Open the source shape file and make a copy of the mesh
    Resource<TSShape> hShape = ResourceManager::get().load(filename);
-   if (!bool(hShape) || !((TSShape*)hShape)->mMeshes.size())
+   if (!bool(hShape) || !((TSShape*)hShape)->meshes.size())
    {
       Con::errorf("TSShape::createMesh: Could not load source mesh from %s", filename.c_str());
       return NULL;
    }
 
-   TSMesh* srcMesh = ((TSShape*)hShape)->mMeshes[0];
+   TSMesh* srcMesh = ((TSShape*)hShape)->meshes[0];
    return mShape->copyMesh( srcMesh );
 }
 
 TSMesh* MeshFit::createTriMesh( F32* verts, S32 numVerts, U32* indices, S32 numTris ) const
 {
    TSMesh* mesh = mShape->copyMesh( NULL );
-   mesh->mNumFrames = 1;
-   mesh->mNumMatFrames = 1;
-   mesh->mVertsPerFrame = numVerts;
+   mesh->numFrames = 1;
+   mesh->numMatFrames = 1;
+   mesh->vertsPerFrame = numVerts;
    mesh->setFlags(0);
    mesh->mHasColor = false;
    mesh->mHasTVert2 = false;
    mesh->mNumVerts = numVerts;
 
-   mesh->mIndices.reserve( numTris * 3 );
+   mesh->indices.reserve( numTris * 3 );
    for ( S32 i = 0; i < numTris; i++ )
    {
-      mesh->mIndices.push_back( indices[i*3 + 0] );
-      mesh->mIndices.push_back( indices[i*3 + 2] );
-      mesh->mIndices.push_back( indices[i*3 + 1] );
+      mesh->indices.push_back( indices[i*3 + 0] );
+      mesh->indices.push_back( indices[i*3 + 2] );
+      mesh->indices.push_back( indices[i*3 + 1] );
    }
 
-   mesh->mVerts.set( verts, numVerts );
+   mesh->verts.set( verts, numVerts );
 
    // Compute mesh normals
-   mesh->mNorms.setSize( mesh->mVerts.size() );
-   for (S32 iNorm = 0; iNorm < mesh->mNorms.size(); iNorm++)
-      mesh->mNorms[iNorm] = Point3F::Zero;
+   mesh->norms.setSize( mesh->verts.size() );
+   for (S32 iNorm = 0; iNorm < mesh->norms.size(); iNorm++)
+      mesh->norms[iNorm] = Point3F::Zero;
 
    // Sum triangle normals for each vertex
-   for (S32 iInd = 0; iInd < mesh->mIndices.size(); iInd += 3)
+   for (S32 iInd = 0; iInd < mesh->indices.size(); iInd += 3)
    {
       // Compute the normal for this triangle
-      S32 idx0 = mesh->mIndices[iInd + 0];
-      S32 idx1 = mesh->mIndices[iInd + 1];
-      S32 idx2 = mesh->mIndices[iInd + 2];
+      S32 idx0 = mesh->indices[iInd + 0];
+      S32 idx1 = mesh->indices[iInd + 1];
+      S32 idx2 = mesh->indices[iInd + 2];
 
-      const Point3F& v0 = mesh->mVerts[idx0];
-      const Point3F& v1 = mesh->mVerts[idx1];
-      const Point3F& v2 = mesh->mVerts[idx2];
+      const Point3F& v0 = mesh->verts[idx0];
+      const Point3F& v1 = mesh->verts[idx1];
+      const Point3F& v2 = mesh->verts[idx2];
 
       Point3F n;
       mCross(v2 - v0, v1 - v0, &n);
       n.normalize();    // remove this to use 'weighted' normals (large triangles will have more effect)
 
-      mesh->mNorms[idx0] += n;
-      mesh->mNorms[idx1] += n;
-      mesh->mNorms[idx2] += n;
+      mesh->norms[idx0] += n;
+      mesh->norms[idx1] += n;
+      mesh->norms[idx2] += n;
    }
 
    // Normalize the vertex normals (this takes care of averaging the triangle normals)
-   for (S32 iNorm = 0; iNorm < mesh->mNorms.size(); iNorm++)
-      mesh->mNorms[iNorm].normalize();
+   for (S32 iNorm = 0; iNorm < mesh->norms.size(); iNorm++)
+      mesh->norms[iNorm].normalize();
 
    // Set some dummy UVs
-   mesh->mTVerts.setSize( numVerts );
-   for ( S32 j = 0; j < mesh->mTVerts.size(); j++ )
-      mesh->mTVerts[j].set( 0, 0 );
+   mesh->tverts.setSize( numVerts );
+   for ( S32 j = 0; j < mesh->tverts.size(); j++ )
+      mesh->tverts[j].set( 0, 0 );
 
    // Add a single triangle-list primitive
-   mesh->mPrimitives.increment();
-   mesh->mPrimitives.last().start = 0;
-   mesh->mPrimitives.last().numElements = mesh->mIndices.size();
-   mesh->mPrimitives.last().matIndex =  TSDrawPrimitive::Triangles |
+   mesh->primitives.increment();
+   mesh->primitives.last().start = 0;
+   mesh->primitives.last().numElements = mesh->indices.size();
+   mesh->primitives.last().matIndex =  TSDrawPrimitive::Triangles |
                                        TSDrawPrimitive::Indexed |
                                        TSDrawPrimitive::NoMaterial;
 
-   mesh->createTangents( mesh->mVerts, mesh->mNorms );
-   mesh->mEncodedNorms.set( NULL,0 );
+   mesh->createTangents( mesh->verts, mesh->norms );
+   mesh->encodedNorms.set( NULL,0 );
 
    return mesh;
 }
@@ -792,10 +792,10 @@ DefineTSShapeConstructorMethod( addPrimitive, bool, ( const char* meshName, cons
    }
    else
    {
-      for (S32 i = 0; i < mesh->mVerts.size(); i++)
+      for (S32 i = 0; i < mesh->verts.size(); i++)
       {
-         Point3F v(mesh->mVerts[i]);
-         mat.mulP( v, &mesh->mVerts[i] );
+         Point3F v(mesh->verts[i]);
+         mat.mulP( v, &mesh->verts[i] );
       }
    }
 

--- a/Engine/source/ts/tsPartInstance.cpp
+++ b/Engine/source/ts/tsPartInstance.cpp
@@ -97,9 +97,9 @@ void TSPartInstance::updateBounds()
 
 void TSPartInstance::breakShape(TSShapeInstance * shape, S32 subShape, Vector<TSPartInstance*> & partList, F32 * probShatter, F32 * probBreak, S32 probDepth)
 {
-   AssertFatal(subShape>=0 && subShape<shape->mShape->mSubShapeFirstNode.size(),"TSPartInstance::breakShape: subShape out of range.");
+   AssertFatal(subShape>=0 && subShape<shape->mShape->subShapeFirstNode.size(),"TSPartInstance::breakShape: subShape out of range.");
 
-   S32 start = shape->mShape->mSubShapeFirstNode[subShape];
+   S32 start = shape->mShape->subShapeFirstNode[subShape];
 
    TSPartInstance::breakShape(shape, NULL, start, partList, probShatter, probBreak, probDepth);
 
@@ -120,7 +120,7 @@ void TSPartInstance::breakShape(TSShapeInstance * shape, TSPartInstance * curren
 {
    AssertFatal( !probDepth || (probShatter && probBreak),"TSPartInstance::breakShape: probabilities improperly specified.");
 
-   const TSShape::Node * node = &shape->mShape->mNodes[currentNode];
+   const TSShape::Node * node = &shape->mShape->nodes[currentNode];
    S32 object = node->firstObject;
    S32 child  = node->firstChild;
 
@@ -155,14 +155,14 @@ void TSPartInstance::breakShape(TSShapeInstance * shape, TSPartInstance * curren
       {
          partList.increment();
          partList.last() = new TSPartInstance(shape,object);
-         object = shape->mShape->mObjects[object].nextSibling;
+         object = shape->mShape->objects[object].nextSibling;
       }
 
       // iterate through the child nodes, call ourselves on each one with currentPart = NULL
       while (child>=0)
       {
          TSPartInstance::breakShape(shape,NULL,child,partList,probShatter,probBreak,probDepth);
-         child = shape->mShape->mNodes[child].nextSibling;
+         child = shape->mShape->nodes[child].nextSibling;
       }
 
       return;
@@ -184,14 +184,14 @@ void TSPartInstance::breakShape(TSShapeInstance * shape, TSPartInstance * curren
    while (object>=0)
    {
       currentPart->addObject(object);
-      object = shape->mShape->mObjects[object].nextSibling;
+      object = shape->mShape->objects[object].nextSibling;
    }
 
    // iterate through child nodes, call ourselves on each one with currentPart as is
    while (child>=0)
    {
       TSPartInstance::breakShape(shape,currentPart,child,partList,probShatter,probBreak,probDepth);
-      child = shape->mShape->mNodes[child].nextSibling;
+      child = shape->mShape->nodes[child].nextSibling;
    }
 }
 
@@ -334,7 +334,7 @@ F32 TSPartInstance::getDetailSize(S32 dl) const
    else if (mSizeCutoffs && dl<mNumDetails)
       return mSizeCutoffs[dl];
    else if (!mSizeCutoffs && dl<=mSourceShape->getShape()->mSmallestVisibleDL)
-      return mSourceShape->getShape()->mDetails[dl].size;
+      return mSourceShape->getShape()->details[dl].size;
    else return 0;
 }
 

--- a/Engine/source/ts/tsShape.cpp
+++ b/Engine/source/ts/tsShape.cpp
@@ -62,7 +62,7 @@ bool TSShape::smInitOnRead = true;
 
 TSShape::TSShape()
 {
-   mMaterialList = NULL;
+   materialList = NULL;
    mReadVersion = -1; // -1 means constructed from scratch (e.g., in exporter or no read yet)
    mHasSkinMesh = false;
    mSequencesConstructed = false;
@@ -74,70 +74,70 @@ TSShape::TSShape()
    mDetailLevelLookup.setSize( 1 );
    mDetailLevelLookup[0].set( -1, 0 );
 
-   VECTOR_SET_ASSOCIATION(mSequences);
-   VECTOR_SET_ASSOCIATION(mNodeRotations);
-   VECTOR_SET_ASSOCIATION(mNodeTranslations);
-   VECTOR_SET_ASSOCIATION(mNodeUniformScales);
-   VECTOR_SET_ASSOCIATION(mNodeAlignedScales);
-   VECTOR_SET_ASSOCIATION(mNodeArbitraryScaleRots);
-   VECTOR_SET_ASSOCIATION(mNodeArbitraryScaleFactors);
-   VECTOR_SET_ASSOCIATION(mGroundRotations);
-   VECTOR_SET_ASSOCIATION(mGroundTranslations);
-   VECTOR_SET_ASSOCIATION(mTriggers);
-   VECTOR_SET_ASSOCIATION(mBillboardDetails);
-   VECTOR_SET_ASSOCIATION(mDetailCollisionAccelerators);
-   VECTOR_SET_ASSOCIATION(mNames);
+   VECTOR_SET_ASSOCIATION(sequences);
+   VECTOR_SET_ASSOCIATION(nodeRotations);
+   VECTOR_SET_ASSOCIATION(nodeTranslations);
+   VECTOR_SET_ASSOCIATION(nodeUniformScales);
+   VECTOR_SET_ASSOCIATION(nodeAlignedScales);
+   VECTOR_SET_ASSOCIATION(nodeArbitraryScaleRots);
+   VECTOR_SET_ASSOCIATION(nodeArbitraryScaleFactors);
+   VECTOR_SET_ASSOCIATION(groundRotations);
+   VECTOR_SET_ASSOCIATION(groundTranslations);
+   VECTOR_SET_ASSOCIATION(triggers);
+   VECTOR_SET_ASSOCIATION(billboardDetails);
+   VECTOR_SET_ASSOCIATION(detailCollisionAccelerators);
+   VECTOR_SET_ASSOCIATION(names);
 
-   VECTOR_SET_ASSOCIATION( mNodes );
-   VECTOR_SET_ASSOCIATION( mObjects );
-   VECTOR_SET_ASSOCIATION( mObjectStates );
-   VECTOR_SET_ASSOCIATION( mSubShapeFirstNode );
-   VECTOR_SET_ASSOCIATION( mSubShapeFirstObject );
-   VECTOR_SET_ASSOCIATION( mDetailFirstSkin );
-   VECTOR_SET_ASSOCIATION( mSubShapeNumNodes );
-   VECTOR_SET_ASSOCIATION( mSubShapeNumObjects );
-   VECTOR_SET_ASSOCIATION( mDetails );
-   VECTOR_SET_ASSOCIATION( mDefaultRotations );
-   VECTOR_SET_ASSOCIATION( mDefaultTranslations );
+   VECTOR_SET_ASSOCIATION( nodes );
+   VECTOR_SET_ASSOCIATION( objects );
+   VECTOR_SET_ASSOCIATION( objectStates );
+   VECTOR_SET_ASSOCIATION( subShapeFirstNode );
+   VECTOR_SET_ASSOCIATION( subShapeFirstObject );
+   VECTOR_SET_ASSOCIATION( detailFirstSkin );
+   VECTOR_SET_ASSOCIATION( subShapeNumNodes );
+   VECTOR_SET_ASSOCIATION( subShapeNumObjects );
+   VECTOR_SET_ASSOCIATION( details );
+   VECTOR_SET_ASSOCIATION( defaultRotations );
+   VECTOR_SET_ASSOCIATION( defaultTranslations );
 
-   VECTOR_SET_ASSOCIATION( mSubShapeFirstTranslucentObject );
-   VECTOR_SET_ASSOCIATION( mMeshes );
+   VECTOR_SET_ASSOCIATION( subShapeFirstTranslucentObject );
+   VECTOR_SET_ASSOCIATION( meshes );
 
-   VECTOR_SET_ASSOCIATION( mAlphaIn );
-   VECTOR_SET_ASSOCIATION( mAlphaOut );
+   VECTOR_SET_ASSOCIATION( alphaIn );
+   VECTOR_SET_ASSOCIATION( alphaOut );
 }
 
 TSShape::~TSShape()
 {
-   delete mMaterialList;
+   delete materialList;
 
    S32 i;
 
    // everything left over here is a legit mesh
-   for (i=0; i<mMeshes.size(); i++)
+   for (i=0; i<meshes.size(); i++)
    {
-      if (!mMeshes[i])
+      if (!meshes[i])
          continue;
 
       // Handle meshes that were either assembled with the shape or added later
-      if (((S8*)mMeshes[i] >= mShapeData) && ((S8*)mMeshes[i] < (mShapeData + mShapeDataSize)))
-         destructInPlace(mMeshes[i]);
+      if (((S8*)meshes[i] >= mShapeData) && ((S8*)meshes[i] < (mShapeData + mShapeDataSize)))
+         destructInPlace(meshes[i]);
       else
-         delete mMeshes[i];
+         delete meshes[i];
    }
 
-   for (i=0; i<mBillboardDetails.size(); i++)
+   for (i=0; i<billboardDetails.size(); i++)
    {
-      delete mBillboardDetails[i];
-      mBillboardDetails[i] = NULL;
+      delete billboardDetails[i];
+      billboardDetails[i] = NULL;
    }
-   mBillboardDetails.clear();
+   billboardDetails.clear();
 
    // Delete any generated accelerators
    S32 dca;
-   for (dca = 0; dca < mDetailCollisionAccelerators.size(); dca++)
+   for (dca = 0; dca < detailCollisionAccelerators.size(); dca++)
    {
-      ConvexHullAccelerator* accel = mDetailCollisionAccelerators[dca];
+      ConvexHullAccelerator* accel = detailCollisionAccelerators[dca];
       if (accel != NULL) {
          delete [] accel->vertexList;
          delete [] accel->normalList;
@@ -147,8 +147,8 @@ TSShape::~TSShape()
          delete accel;
       }
    }
-   for (dca = 0; dca < mDetailCollisionAccelerators.size(); dca++)
-      mDetailCollisionAccelerators[dca] = NULL;
+   for (dca = 0; dca < detailCollisionAccelerators.size(); dca++)
+      detailCollisionAccelerators[dca] = NULL;
 
    if( mShapeData )
       delete[] mShapeData;
@@ -156,44 +156,44 @@ TSShape::~TSShape()
 
 const String& TSShape::getName( S32 nameIndex ) const
 {
-   AssertFatal(nameIndex>=0 && nameIndex<mNames.size(),"TSShape::getName");
-   return mNames[nameIndex];
+   AssertFatal(nameIndex>=0 && nameIndex<names.size(),"TSShape::getName");
+   return names[nameIndex];
 }
 
 const String& TSShape::getMeshName( S32 meshIndex ) const
 {
-   S32 nameIndex = mObjects[meshIndex].nameIndex;
+   S32 nameIndex = objects[meshIndex].nameIndex;
    if ( nameIndex < 0 )
       return String::EmptyString;
 
-   return mNames[nameIndex];
+   return names[nameIndex];
 }
 
 const String& TSShape::getNodeName( S32 nodeIndex ) const
 {   
-   S32 nameIdx = mNodes[nodeIndex].nameIndex;
+   S32 nameIdx = nodes[nodeIndex].nameIndex;
    if ( nameIdx < 0 )
       return String::EmptyString;
 
-   return mNames[nameIdx];
+   return names[nameIdx];
 }
 
 const String& TSShape::getSequenceName( S32 seqIndex ) const
 {
-   AssertFatal(seqIndex >= 0 && seqIndex<mSequences.size(),"TSShape::getSequenceName index beyond range");
+   AssertFatal(seqIndex >= 0 && seqIndex<sequences.size(),"TSShape::getSequenceName index beyond range");
 
-   S32 nameIdx = mSequences[seqIndex].nameIndex;
+   S32 nameIdx = sequences[seqIndex].nameIndex;
    if ( nameIdx < 0 )
       return String::EmptyString;
 
-   return mNames[nameIdx];
+   return names[nameIdx];
 }
 
 S32 TSShape::findName(const String &name) const
 {
-   for (S32 i=0; i<mNames.size(); i++)
+   for (S32 i=0; i<names.size(); i++)
    {
-      if (mNames[i].equal( name, String::NoCase ))
+      if (names[i].equal( name, String::NoCase ))
          return i;
    }
   
@@ -202,12 +202,12 @@ S32 TSShape::findName(const String &name) const
 
 const String& TSShape::getTargetName( S32 mapToNameIndex ) const
 {
-	S32 targetCount = mMaterialList->getMaterialNameList().size();
+	S32 targetCount = materialList->getMaterialNameList().size();
 
 	if(mapToNameIndex < 0 || mapToNameIndex >= targetCount)
 		return String::EmptyString;
 
-	return mMaterialList->getMaterialNameList()[mapToNameIndex];
+	return materialList->getMaterialNameList()[mapToNameIndex];
 }
 
 S32 TSShape::getTargetCount() const
@@ -215,46 +215,46 @@ S32 TSShape::getTargetCount() const
 	if(!this)
 		return -1;
 
-	return mMaterialList->getMaterialNameList().size();
+	return materialList->getMaterialNameList().size();
 
 }
 
 S32 TSShape::findNode(S32 nameIndex) const
 {
-   for (S32 i=0; i<mNodes.size(); i++)
-      if (mNodes[i].nameIndex==nameIndex)
+   for (S32 i=0; i<nodes.size(); i++)
+      if (nodes[i].nameIndex==nameIndex)
          return i;
    return -1;
 }
 
 S32 TSShape::findObject(S32 nameIndex) const
 {
-   for (S32 i=0; i<mObjects.size(); i++)
-      if (mObjects[i].nameIndex==nameIndex)
+   for (S32 i=0; i<objects.size(); i++)
+      if (objects[i].nameIndex==nameIndex)
          return i;
    return -1;
 }
 
 S32 TSShape::findDetail(S32 nameIndex) const
 {
-   for (S32 i=0; i<mDetails.size(); i++)
-      if (mDetails[i].nameIndex==nameIndex)
+   for (S32 i=0; i<details.size(); i++)
+      if (details[i].nameIndex==nameIndex)
          return i;
    return -1;
 }
 
 S32 TSShape::findDetailBySize(S32 size) const
 {
-   for (S32 i=0; i<mDetails.size(); i++)
-      if (mDetails[i].size==size)
+   for (S32 i=0; i<details.size(); i++)
+      if (details[i].size==size)
          return i;
    return -1;
 }
 
 S32 TSShape::findSequence(S32 nameIndex) const
 {
-   for (S32 i=0; i<mSequences.size(); i++)
-      if (mSequences[i].nameIndex==nameIndex)
+   for (S32 i=0; i<sequences.size(); i++)
+      if (sequences[i].nameIndex==nameIndex)
          return i;
    return -1;
 }
@@ -269,7 +269,7 @@ bool TSShape::findMeshIndex(const String& meshName, S32& objIndex, S32& meshInde
 
    // Determine the subshape this object belongs to
    S32 subShapeIndex = getSubShapeForObject(objIndex);
-   AssertFatal(subShapeIndex < mSubShapeFirstObject.size(), "Could not find subshape for object!");
+   AssertFatal(subShapeIndex < subShapeFirstObject.size(), "Could not find subshape for object!");
 
    // Get the detail levels for the subshape
    Vector<S32> validDetails;
@@ -278,7 +278,7 @@ bool TSShape::findMeshIndex(const String& meshName, S32& objIndex, S32& meshInde
    // Find the detail with the correct size
    for (meshIndex = 0; meshIndex < validDetails.size(); meshIndex++)
    {
-      const TSShape::Detail& det = mDetails[validDetails[meshIndex]];
+      const TSShape::Detail& det = details[validDetails[meshIndex]];
       if (detailSize == det.size)
          return true;
    }
@@ -291,15 +291,15 @@ TSMesh* TSShape::findMesh(const String& meshName)
    S32 objIndex, meshIndex;
    if (!findMeshIndex(meshName, objIndex, meshIndex))
       return 0;
-   return mMeshes[mObjects[objIndex].startMeshIndex + meshIndex];
+   return meshes[objects[objIndex].startMeshIndex + meshIndex];
 }
 
 S32 TSShape::getSubShapeForNode(S32 nodeIndex)
 {
-   for (S32 i = 0; i < mSubShapeFirstNode.size(); i++)
+   for (S32 i = 0; i < subShapeFirstNode.size(); i++)
    {
-      S32 start = mSubShapeFirstNode[i];
-      S32 end = start + mSubShapeNumNodes[i];
+      S32 start = subShapeFirstNode[i];
+      S32 end = start + subShapeNumNodes[i];
       if ((nodeIndex >= start) && (nodeIndex < end))
          return i;;
    }
@@ -308,10 +308,10 @@ S32 TSShape::getSubShapeForNode(S32 nodeIndex)
 
 S32 TSShape::getSubShapeForObject(S32 objIndex)
 {
-   for (S32 i = 0; i < mSubShapeFirstObject.size(); i++)
+   for (S32 i = 0; i < subShapeFirstObject.size(); i++)
    {
-      S32 start = mSubShapeFirstObject[i];
-      S32 end = start + mSubShapeNumObjects[i];
+      S32 start = subShapeFirstObject[i];
+      S32 end = start + subShapeNumObjects[i];
       if ((objIndex >= start) && (objIndex < end))
          return i;
    }
@@ -321,10 +321,10 @@ S32 TSShape::getSubShapeForObject(S32 objIndex)
 void TSShape::getSubShapeDetails(S32 subShapeIndex, Vector<S32>& validDetails)
 {
    validDetails.clear();
-   for (S32 i = 0; i < mDetails.size(); i++)
+   for (S32 i = 0; i < details.size(); i++)
    {
-      if ((mDetails[i].subShapeNum == subShapeIndex) ||
-          (mDetails[i].subShapeNum < 0))
+      if ((details[i].subShapeNum == subShapeIndex) ||
+          (details[i].subShapeNum < 0))
           validDetails.push_back(i);
    }
 }
@@ -338,36 +338,36 @@ void TSShape::getNodeWorldTransform(S32 nodeIndex, MatrixF* mat) const
    else
    {
       // Calculate the world transform of the given node
-      mDefaultRotations[nodeIndex].getQuatF().setMatrix(mat);
-      mat->setPosition(mDefaultTranslations[nodeIndex]);
+      defaultRotations[nodeIndex].getQuatF().setMatrix(mat);
+      mat->setPosition(defaultTranslations[nodeIndex]);
 
-      S32 parentIndex = mNodes[nodeIndex].parentIndex;
+      S32 parentIndex = nodes[nodeIndex].parentIndex;
       while (parentIndex != -1)
       {
          MatrixF mat2(*mat);
-         mDefaultRotations[parentIndex].getQuatF().setMatrix(mat);
-         mat->setPosition(mDefaultTranslations[parentIndex]);
+         defaultRotations[parentIndex].getQuatF().setMatrix(mat);
+         mat->setPosition(defaultTranslations[parentIndex]);
          mat->mul(mat2);
 
-         parentIndex = mNodes[parentIndex].parentIndex;
+         parentIndex = nodes[parentIndex].parentIndex;
       }
    }
 }
 
 void TSShape::getNodeObjects(S32 nodeIndex, Vector<S32>& nodeObjects)
 {
-   for (S32 i = 0; i < mObjects.size(); i++)
+   for (S32 i = 0; i < objects.size(); i++)
    {
-      if ((nodeIndex == -1) || (mObjects[i].nodeIndex == nodeIndex))
+      if ((nodeIndex == -1) || (objects[i].nodeIndex == nodeIndex))
          nodeObjects.push_back(i);
    }
 }
 
 void TSShape::getNodeChildren(S32 nodeIndex, Vector<S32>& nodeChildren)
 {
-   for (S32 i = 0; i < mNodes.size(); i++)
+   for (S32 i = 0; i < nodes.size(); i++)
    {
-      if (mNodes[i].parentIndex == nodeIndex)
+      if (nodes[i].parentIndex == nodeIndex)
          nodeChildren.push_back(i);
    }
 }
@@ -379,101 +379,101 @@ void TSShape::getObjectDetails(S32 objIndex, Vector<S32>& objDetails)
    getSubShapeDetails(getSubShapeForObject(objIndex), validDetails);
 
    // Get the non-null details for this object
-   const TSShape::Object& obj = mObjects[objIndex];
+   const TSShape::Object& obj = objects[objIndex];
    for (S32 i = 0; i < obj.numMeshes; i++)
    {
-      if (mMeshes[obj.startMeshIndex + i])
+      if (meshes[obj.startMeshIndex + i])
          objDetails.push_back(validDetails[i]);
    }
 }
 
 void TSShape::init()
 {
-   S32 numSubShapes = mSubShapeFirstNode.size();
-   AssertFatal(numSubShapes==mSubShapeFirstObject.size(),"TSShape::init");
+   S32 numSubShapes = subShapeFirstNode.size();
+   AssertFatal(numSubShapes==subShapeFirstObject.size(),"TSShape::init");
 
    S32 i,j;
 
    // set up parent/child relationships on nodes and objects
-   for (i=0; i<mNodes.size(); i++)
-      mNodes[i].firstObject = mNodes[i].firstChild = mNodes[i].nextSibling = -1;
-   for (i=0; i<mNodes.size(); i++)
+   for (i=0; i<nodes.size(); i++)
+      nodes[i].firstObject = nodes[i].firstChild = nodes[i].nextSibling = -1;
+   for (i=0; i<nodes.size(); i++)
    {
-      S32 parentIndex = mNodes[i].parentIndex;
+      S32 parentIndex = nodes[i].parentIndex;
       if (parentIndex>=0)
       {
-         if (mNodes[parentIndex].firstChild<0)
-            mNodes[parentIndex].firstChild=i;
+         if (nodes[parentIndex].firstChild<0)
+            nodes[parentIndex].firstChild=i;
          else
          {
-            S32 child = mNodes[parentIndex].firstChild;
-            while (mNodes[child].nextSibling>=0)
-               child = mNodes[child].nextSibling;
-            mNodes[child].nextSibling = i;
+            S32 child = nodes[parentIndex].firstChild;
+            while (nodes[child].nextSibling>=0)
+               child = nodes[child].nextSibling;
+            nodes[child].nextSibling = i;
          }
       }
    }
-   for (i=0; i<mObjects.size(); i++)
+   for (i=0; i<objects.size(); i++)
    {
-      mObjects[i].nextSibling = -1;
+      objects[i].nextSibling = -1;
 
-      S32 nodeIndex = mObjects[i].nodeIndex;
+      S32 nodeIndex = objects[i].nodeIndex;
       if (nodeIndex>=0)
       {
-         if (mNodes[nodeIndex].firstObject<0)
-            mNodes[nodeIndex].firstObject = i;
+         if (nodes[nodeIndex].firstObject<0)
+            nodes[nodeIndex].firstObject = i;
          else
          {
-            S32 objectIndex = mNodes[nodeIndex].firstObject;
-            while (mObjects[objectIndex].nextSibling>=0)
-               objectIndex = mObjects[objectIndex].nextSibling;
-            mObjects[objectIndex].nextSibling = i;
+            S32 objectIndex = nodes[nodeIndex].firstObject;
+            while (objects[objectIndex].nextSibling>=0)
+               objectIndex = objects[objectIndex].nextSibling;
+            objects[objectIndex].nextSibling = i;
          }
       }
    }
 
    mFlags = 0;
-   for (i=0; i<mSequences.size(); i++)
+   for (i=0; i<sequences.size(); i++)
    {
-      if (!mSequences[i].animatesScale())
+      if (!sequences[i].animatesScale())
          continue;
 
       U32 curVal = mFlags & AnyScale;
-      U32 newVal = mSequences[i].flags & AnyScale;
+      U32 newVal = sequences[i].flags & AnyScale;
       mFlags &= ~(AnyScale);
       mFlags |= getMax(curVal,newVal); // take the larger value (can only convert upwards)
    }
 
    // set up alphaIn and alphaOut vectors...
-   mAlphaIn.setSize(mDetails.size());
-   mAlphaOut.setSize(mDetails.size());
+   alphaIn.setSize(details.size());
+   alphaOut.setSize(details.size());
 
-   for (i=0; i<mDetails.size(); i++)
+   for (i=0; i<details.size(); i++)
    {
-      if (mDetails[i].size<0)
+      if (details[i].size<0)
       {
          // we don't care...
-         mAlphaIn[i]  = 0.0f;
-         mAlphaOut[i] = 0.0f;
+         alphaIn[i]  = 0.0f;
+         alphaOut[i] = 0.0f;
       }
-      else if (i+1==mDetails.size() || mDetails[i+1].size<0)
+      else if (i+1==details.size() || details[i+1].size<0)
       {
-         mAlphaIn[i]  = 0.0f;
-         mAlphaOut[i] = smAlphaOutLastDetail;
+         alphaIn[i]  = 0.0f;
+         alphaOut[i] = smAlphaOutLastDetail;
       }
       else
       {
-         if (mDetails[i+1].subShapeNum<0)
+         if (details[i+1].subShapeNum<0)
          {
             // following detail is a billboard detail...treat special...
-            mAlphaIn[i]  = smAlphaInBillboard;
-            mAlphaOut[i] = smAlphaOutBillboard;
+            alphaIn[i]  = smAlphaInBillboard;
+            alphaOut[i] = smAlphaOutBillboard;
          }
          else
          {
             // next detail is normal detail
-            mAlphaIn[i] = smAlphaInDefault;
-            mAlphaOut[i] = smAlphaOutDefault;
+            alphaIn[i] = smAlphaInDefault;
+            alphaOut[i] = smAlphaOutDefault;
          }
       }
    }
@@ -486,50 +486,50 @@ void TSShape::init()
          // is larger than our cap...zap all the meshes and decals
          // associated with it and use the next detail level
          // instead...
-         S32 ss    = mDetails[i].subShapeNum;
-         S32 od    = mDetails[i].objectDetailNum;
+         S32 ss    = details[i].subShapeNum;
+         S32 od    = details[i].objectDetailNum;
 
-         if (ss==mDetails[i+1].subShapeNum && od==mDetails[i+1].objectDetailNum)
+         if (ss==details[i+1].subShapeNum && od==details[i+1].objectDetailNum)
             // doh! already done this one (init can be called multiple times on same shape due
             // to sequence importing).
             continue;
-         mDetails[i].subShapeNum = mDetails[i+1].subShapeNum;
-         mDetails[i].objectDetailNum = mDetails[i+1].objectDetailNum;
+         details[i].subShapeNum = details[i+1].subShapeNum;
+         details[i].objectDetailNum = details[i+1].objectDetailNum;
       }
    }
 
-   for (i=0; i<mDetails.size(); i++)
+   for (i=0; i<details.size(); i++)
    {
       S32 count = 0;
-      S32 ss = mDetails[i].subShapeNum;
-      S32 od = mDetails[i].objectDetailNum;
+      S32 ss = details[i].subShapeNum;
+      S32 od = details[i].objectDetailNum;
       if (ss<0)
       {
          // billboard detail...
-         mDetails[i].polyCount = 2;
+         details[i].polyCount = 2;
          continue;
       }
-      S32 start = mSubShapeFirstObject[ss];
-      S32 end   = start + mSubShapeNumObjects[ss];
+      S32 start = subShapeFirstObject[ss];
+      S32 end   = start + subShapeNumObjects[ss];
       for (j=start; j<end; j++)
       {
-         Object & obj = mObjects[j];
+         Object & obj = objects[j];
          if (od<obj.numMeshes)
          {
-            TSMesh * mesh = mMeshes[obj.startMeshIndex+od];
+            TSMesh * mesh = meshes[obj.startMeshIndex+od];
             count += mesh ? mesh->getNumPolys() : 0;
          }
       }
-      mDetails[i].polyCount = count;
+      details[i].polyCount = count;
    }
 
    // Init the collision accelerator array.  Note that we don't compute the
    //  accelerators until the app requests them
    {
       S32 dca;
-      for (dca = 0; dca < mDetailCollisionAccelerators.size(); dca++)
+      for (dca = 0; dca < detailCollisionAccelerators.size(); dca++)
       {
-         ConvexHullAccelerator* accel = mDetailCollisionAccelerators[dca];
+         ConvexHullAccelerator* accel = detailCollisionAccelerators[dca];
          if (accel != NULL) {
             delete [] accel->vertexList;
             delete [] accel->normalList;
@@ -540,9 +540,9 @@ void TSShape::init()
          }
       }
 
-      mDetailCollisionAccelerators.setSize(mDetails.size());
-      for (dca = 0; dca < mDetailCollisionAccelerators.size(); dca++)
-         mDetailCollisionAccelerators[dca] = NULL;
+      detailCollisionAccelerators.setSize(details.size());
+      for (dca = 0; dca < detailCollisionAccelerators.size(); dca++)
+         detailCollisionAccelerators[dca] = NULL;
    }
 
    initVertexFeatures();
@@ -554,8 +554,8 @@ void TSShape::initVertexFeatures()
    bool hasColors = false;
    bool hasTexcoord2 = false;
 
-   Vector<TSMesh*>::iterator iter = mMeshes.begin();
-   for ( ; iter != mMeshes.end(); iter++ )
+   Vector<TSMesh*>::iterator iter = meshes.begin();
+   for ( ; iter != meshes.end(); iter++ )
    {
       TSMesh *mesh = *iter;
       if (  mesh &&
@@ -569,8 +569,8 @@ void TSShape::initVertexFeatures()
          }
          else
          {
-            hasColors |= !mesh->mColors.empty();
-            hasTexcoord2 |= !mesh->mTVerts2.empty();
+            hasColors |= !mesh->colors.empty();
+            hasTexcoord2 |= !mesh->tverts2.empty();
          }
       }
    }
@@ -594,8 +594,8 @@ void TSShape::initVertexFeatures()
 
    // Go fix up meshes to include defaults for optional features
    // and initialize them if they're not a skin mesh.
-   iter = mMeshes.begin();
-   for ( ; iter != mMeshes.end(); iter++ )
+   iter = meshes.begin();
+   for ( ; iter != meshes.end(); iter++ )
    {
       TSMesh *mesh = *iter;
       if (  !mesh ||
@@ -621,20 +621,20 @@ void TSShape::setupBillboardDetails( const String &cachePath )
    // set up billboard details -- only do this once, meaning that
    // if we add a sequence to the shape we don't redo the billboard
    // details...
-   if ( !mBillboardDetails.empty() )
+   if ( !billboardDetails.empty() )
       return;
 
-   for ( U32 i=0; i < mDetails.size(); i++ )
+   for ( U32 i=0; i < details.size(); i++ )
    {
-      const Detail &det = mDetails[i];
+      const Detail &det = details[i];
 
       if ( det.subShapeNum >= 0 )
          continue; // not a billboard detail
 
-      while (mBillboardDetails.size() <= i )
-         mBillboardDetails.push_back(NULL);
+      while (billboardDetails.size() <= i )
+         billboardDetails.push_back(NULL);
 
-      mBillboardDetails[i] = new TSLastDetail(   this,
+      billboardDetails[i] = new TSLastDetail(   this,
                                                 cachePath,
                                                 det.bbEquatorSteps,
                                                 det.bbPolarSteps,
@@ -643,15 +643,15 @@ void TSShape::setupBillboardDetails( const String &cachePath )
                                                 det.bbDetailLevel,
                                                 det.bbDimension );
 
-      mBillboardDetails[i]->update();
+      billboardDetails[i]->update();
    }
 }
 
 void TSShape::initMaterialList()
 {
-   S32 numSubShapes = mSubShapeFirstObject.size();
+   S32 numSubShapes = subShapeFirstObject.size();
    #if defined(TORQUE_MAX_LIB)
-   mSubShapeFirstTranslucentObject.setSize(numSubShapes);
+   subShapeFirstTranslucentObject.setSize(numSubShapes);
    #endif
 
    mHasSkinMesh = false;
@@ -661,36 +661,36 @@ void TSShape::initMaterialList()
    // also, while we're at it, set mHasTranslucency
    for (S32 ss = 0; ss<numSubShapes; ss++)
    {
-      S32 start = mSubShapeFirstObject[ss];
-      S32 end = mSubShapeNumObjects[ss];
-      mSubShapeFirstTranslucentObject[ss] = end;
+      S32 start = subShapeFirstObject[ss];
+      S32 end = subShapeNumObjects[ss];
+      subShapeFirstTranslucentObject[ss] = end;
       for (i=start; i<end; i++)
       {
          // check to see if this object has translucency
-         Object & obj = mObjects[i];
+         Object & obj = objects[i];
          for (j=0; j<obj.numMeshes; j++)
          {
-            TSMesh * mesh = mMeshes[obj.startMeshIndex+j];
+            TSMesh * mesh = meshes[obj.startMeshIndex+j];
             if (!mesh)
                continue;
 
             mHasSkinMesh |= mesh->getMeshType() == TSMesh::SkinMeshType;
 
-            for (k=0; k<mesh->mPrimitives.size(); k++)
+            for (k=0; k<mesh->primitives.size(); k++)
             {
-               if (mesh->mPrimitives[k].matIndex & TSDrawPrimitive::NoMaterial)
+               if (mesh->primitives[k].matIndex & TSDrawPrimitive::NoMaterial)
                   continue;
-               S32 flags = mMaterialList->getFlags(mesh->mPrimitives[k].matIndex & TSDrawPrimitive::MaterialMask);
+               S32 flags = materialList->getFlags(mesh->primitives[k].matIndex & TSDrawPrimitive::MaterialMask);
                if (flags & TSMaterialList::AuxiliaryMap)
                   continue;
                if (flags & TSMaterialList::Translucent)
                {
                   mFlags |= HasTranslucency;
-                  mSubShapeFirstTranslucentObject[ss] = i;
+                  subShapeFirstTranslucentObject[ss] = i;
                   break;
                }
             }
-            if (k!=mesh->mPrimitives.size())
+            if (k!=mesh->primitives.size())
                break;
          }
          if (j!=obj.numMeshes)
@@ -704,26 +704,26 @@ void TSShape::initMaterialList()
 
 bool TSShape::preloadMaterialList(const Torque::Path &path)
 {
-   if (mMaterialList)
-      mMaterialList->setTextureLookupPath(path.getPath());
+   if (materialList)
+      materialList->setTextureLookupPath(path.getPath());
    return true;
 }
 
 bool TSShape::buildConvexHull(S32 dl) const
 {
-   AssertFatal(dl>=0 && dl<mDetails.size(),"TSShape::buildConvexHull: detail out of range");
+   AssertFatal(dl>=0 && dl<details.size(),"TSShape::buildConvexHull: detail out of range");
 
    bool ok = true;
 
-   const Detail & detail = mDetails[dl];
+   const Detail & detail = details[dl];
    S32 ss = detail.subShapeNum;
    S32 od = detail.objectDetailNum;
 
-   S32 start = mSubShapeFirstObject[ss];
-   S32 end   = mSubShapeNumObjects[ss];
+   S32 start = subShapeFirstObject[ss];
+   S32 end   = subShapeNumObjects[ss];
    for (S32 i=start; i<end; i++)
    {
-      TSMesh * mesh = mMeshes[mObjects[i].startMeshIndex+od];
+      TSMesh * mesh = meshes[objects[i].startMeshIndex+od];
       if (!mesh)
          continue;
       ok &= mesh->buildConvexHull();
@@ -739,10 +739,10 @@ void TSShape::computeBounds(S32 dl, Box3F & bounds) const
    if (dl==-1)
       return;
 
-   AssertFatal(dl>=0 && dl<mDetails.size(),"TSShapeInstance::computeBounds");
+   AssertFatal(dl>=0 && dl<details.size(),"TSShapeInstance::computeBounds");
 
    // get subshape and object detail
-   const TSDetail * detail = &mDetails[dl];
+   const TSDetail * detail = &details[dl];
    S32 ss = detail->subShapeNum;
    S32 od = detail->objectDetailNum;
 
@@ -753,16 +753,16 @@ void TSShape::computeBounds(S32 dl, Box3F & bounds) const
 
    // set up temporary storage for non-local transforms...
    S32 i;
-   S32 start = mSubShapeFirstNode[ss];
-   S32 end   = mSubShapeNumNodes[ss] + start;
+   S32 start = subShapeFirstNode[ss];
+   S32 end   = subShapeNumNodes[ss] + start;
    gTempNodeTransforms.setSize(end-start);
    for (i=start; i<end; i++)
    {
       MatrixF mat;
       QuatF q;
-      TSTransform::setMatrix(mDefaultRotations[i].getQuatF(&q),mDefaultTranslations[i],&mat);
-      if (mNodes[i].parentIndex>=0)
-         gTempNodeTransforms[i-start].mul(gTempNodeTransforms[mNodes[i].parentIndex-start],mat);
+      TSTransform::setMatrix(defaultRotations[i].getQuatF(&q),defaultTranslations[i],&mat);
+      if (nodes[i].parentIndex>=0)
+         gTempNodeTransforms[i-start].mul(gTempNodeTransforms[nodes[i].parentIndex-start],mat);
       else
          gTempNodeTransforms[i-start] = mat;
    }
@@ -771,12 +771,12 @@ void TSShape::computeBounds(S32 dl, Box3F & bounds) const
    bounds.minExtents.set( 10E30f, 10E30f, 10E30f);
    bounds.maxExtents.set(-10E30f,-10E30f,-10E30f);
    Box3F box;
-   start = mSubShapeFirstObject[ss];
-   end   = mSubShapeNumObjects[ss] + start;
+   start = subShapeFirstObject[ss];
+   end   = subShapeNumObjects[ss] + start;
    for (i=start; i<end; i++)
    {
-      const Object * object = &mObjects[i];
-      TSMesh * mesh = od<object->numMeshes ? mMeshes[object->startMeshIndex+od] : NULL;
+      const Object * object = &objects[i];
+      TSMesh * mesh = od<object->numMeshes ? meshes[object->startMeshIndex+od] : NULL;
       if (mesh)
       {
          static MatrixF idMat(true);
@@ -805,23 +805,23 @@ bool TSShape::checkSkip(S32 meshNum, S32 & curObject, S32 skipDL)
       return false;
 
    // skip detail level exists on this subShape
-   S32 skipSS = mDetails[skipDL].subShapeNum;
+   S32 skipSS = details[skipDL].subShapeNum;
 
-   if (curObject<mObjects.size())
+   if (curObject<objects.size())
    {
-      S32 start = mObjects[curObject].startMeshIndex;
+      S32 start = objects[curObject].startMeshIndex;
       if (meshNum>=start)
       {
          // we are either from this object, the next object, or a decal
-         if (meshNum < start + mObjects[curObject].numMeshes)
+         if (meshNum < start + objects[curObject].numMeshes)
          {
             // this object...
-            if (mSubShapeFirstObject[skipSS]>curObject)
+            if (subShapeFirstObject[skipSS]>curObject)
                // haven't reached this subshape yet
                return true;
-            if (skipSS+1==mSubShapeFirstObject.size() || curObject<mSubShapeFirstObject[skipSS+1])
+            if (skipSS+1==subShapeFirstObject.size() || curObject<subShapeFirstObject[skipSS+1])
                // curObject is on subshape of skip detail...make sure it's after skipDL
-               return (meshNum-start<mDetails[skipDL].objectDetailNum);
+               return (meshNum-start<details[skipDL].objectDetailNum);
             // if we get here, then curObject occurs on subShape after skip detail (so keep it)
             return false;
          }
@@ -884,16 +884,16 @@ void TSShape::assembleShape()
    tsalloc.checkGuard();
 
    // get bounds...
-   tsalloc.get32((S32*)&mRadius,1);
-   tsalloc.get32((S32*)&mTubeRadius,1);
-   tsalloc.get32((S32*)&mCenter,3);
-   tsalloc.get32((S32*)&mBounds,6);
+   tsalloc.get32((S32*)&radius,1);
+   tsalloc.get32((S32*)&tubeRadius,1);
+   tsalloc.get32((S32*)&center,3);
+   tsalloc.get32((S32*)&bounds,6);
 
    tsalloc.checkGuard();
 
    // copy various vectors...
    S32 * ptr32 = tsalloc.copyToShape32(numNodes*5);
-   mNodes.set(ptr32,numNodes);
+   nodes.set(ptr32,numNodes);
 
    tsalloc.checkGuard();
 
@@ -902,7 +902,7 @@ void TSShape::assembleShape()
       ptr32 = tsalloc.allocShape32(numSkins*6); // pre v23 shapes store skins and meshes separately...no longer
    else
       tsalloc.allocShape32(numSkins*6);
-   mObjects.set(ptr32,numObjects);
+   objects.set(ptr32,numObjects);
 
    tsalloc.checkGuard();
 
@@ -917,31 +917,31 @@ void TSShape::assembleShape()
    tsalloc.checkGuard();
 
    ptr32 = tsalloc.copyToShape32(numSubShapes,true);
-   mSubShapeFirstNode.set(ptr32,numSubShapes);
+   subShapeFirstNode.set(ptr32,numSubShapes);
    ptr32 = tsalloc.copyToShape32(numSubShapes,true);
-   mSubShapeFirstObject.set(ptr32,numSubShapes);
+   subShapeFirstObject.set(ptr32,numSubShapes);
    // DEPRECATED subShapeFirstDecal
    ptr32 = tsalloc.getPointer32(numSubShapes);
 
    tsalloc.checkGuard();
 
    ptr32 = tsalloc.copyToShape32(numSubShapes);
-   mSubShapeNumNodes.set(ptr32,numSubShapes);
+   subShapeNumNodes.set(ptr32,numSubShapes);
    ptr32 = tsalloc.copyToShape32(numSubShapes);
-   mSubShapeNumObjects.set(ptr32,numSubShapes);
+   subShapeNumObjects.set(ptr32,numSubShapes);
    // DEPRECATED subShapeNumDecals
    ptr32 = tsalloc.getPointer32(numSubShapes);
 
    tsalloc.checkGuard();
 
    ptr32 = tsalloc.allocShape32(numSubShapes);
-   mSubShapeFirstTranslucentObject.set(ptr32,numSubShapes);
+   subShapeFirstTranslucentObject.set(ptr32,numSubShapes);
 
    // get default translation and rotation
    S16 * ptr16 = tsalloc.allocShape16(0);
    for (i=0;i<numNodes;i++)
       tsalloc.copyToShape16(4);
-   mDefaultRotations.set(ptr16,numNodes);
+   defaultRotations.set(ptr16,numNodes);
    tsalloc.align32();
    ptr32 = tsalloc.allocShape32(0);
    for (i=0;i<numNodes;i++)
@@ -949,15 +949,15 @@ void TSShape::assembleShape()
       tsalloc.copyToShape32(3);
       tsalloc.copyToShape32(sizeof(Point3F)-12); // handle alignment issues w/ point3f
    }
-   mDefaultTranslations.set(ptr32,numNodes);
+   defaultTranslations.set(ptr32,numNodes);
 
    // get any node sequence data stored in shape
-   mNodeTranslations.setSize(numNodeTrans);
+   nodeTranslations.setSize(numNodeTrans);
    for (i=0;i<numNodeTrans;i++)
-      tsalloc.get32((S32*)&mNodeTranslations[i],3);
-   mNodeRotations.setSize(numNodeRots);
+      tsalloc.get32((S32*)&nodeTranslations[i],3);
+   nodeRotations.setSize(numNodeRots);
    for (i=0;i<numNodeRots;i++)
-      tsalloc.get16((S16*)&mNodeRotations[i],4);
+      tsalloc.get16((S16*)&nodeRotations[i],4);
    tsalloc.align32();
 
    tsalloc.checkGuard();
@@ -965,18 +965,18 @@ void TSShape::assembleShape()
    if (smReadVersion>21)
    {
       // more node sequence data...scale
-      mNodeUniformScales.setSize(numNodeUniformScales);
+      nodeUniformScales.setSize(numNodeUniformScales);
       for (i=0;i<numNodeUniformScales;i++)
-         tsalloc.get32((S32*)&mNodeUniformScales[i],1);
-      mNodeAlignedScales.setSize(numNodeAlignedScales);
+         tsalloc.get32((S32*)&nodeUniformScales[i],1);
+      nodeAlignedScales.setSize(numNodeAlignedScales);
       for (i=0;i<numNodeAlignedScales;i++)
-         tsalloc.get32((S32*)&mNodeAlignedScales[i],3);
-      mNodeArbitraryScaleFactors.setSize(numNodeArbitraryScales);
+         tsalloc.get32((S32*)&nodeAlignedScales[i],3);
+      nodeArbitraryScaleFactors.setSize(numNodeArbitraryScales);
       for (i=0;i<numNodeArbitraryScales;i++)
-         tsalloc.get32((S32*)&mNodeArbitraryScaleFactors[i],3);
-      mNodeArbitraryScaleRots.setSize(numNodeArbitraryScales);
+         tsalloc.get32((S32*)&nodeArbitraryScaleFactors[i],3);
+      nodeArbitraryScaleRots.setSize(numNodeArbitraryScales);
       for (i=0;i<numNodeArbitraryScales;i++)
-         tsalloc.get16((S16*)&mNodeArbitraryScaleRots[i],4);
+         tsalloc.get16((S16*)&nodeArbitraryScaleRots[i],4);
       tsalloc.align32();
 
       tsalloc.checkGuard();
@@ -985,17 +985,17 @@ void TSShape::assembleShape()
    // old shapes need ground transforms moved to ground arrays...but only do it once
    if (smReadVersion<22 && tsalloc.allocShape32(0))
    {
-      for (i=0; i<mSequences.size(); i++)
+      for (i=0; i<sequences.size(); i++)
       {
          // move ground transform data to ground vectors
-         Sequence & seq = mSequences[i];
-         S32 oldSz = mGroundTranslations.size();
-         mGroundTranslations.setSize(oldSz+seq.numGroundFrames);
-         mGroundRotations.setSize(oldSz+seq.numGroundFrames);
+         Sequence & seq = sequences[i];
+         S32 oldSz = groundTranslations.size();
+         groundTranslations.setSize(oldSz+seq.numGroundFrames);
+         groundRotations.setSize(oldSz+seq.numGroundFrames);
          for (S32 j=0;j<seq.numGroundFrames;j++)
          {
-            mGroundTranslations[j+oldSz] = mNodeTranslations[seq.firstGroundFrame+j-numNodes];
-            mGroundRotations[j+oldSz] = mNodeRotations[seq.firstGroundFrame+j-numNodes];
+            groundTranslations[j+oldSz] = nodeTranslations[seq.firstGroundFrame+j-numNodes];
+            groundRotations[j+oldSz] = nodeRotations[seq.firstGroundFrame+j-numNodes];
          }
          seq.firstGroundFrame = oldSz;
          seq.baseTranslation -= numNodes;
@@ -1008,12 +1008,12 @@ void TSShape::assembleShape()
    // earlier shapes is handled just above, so...
    if (smReadVersion>23)
    {
-      mGroundTranslations.setSize(numGroundFrames);
+      groundTranslations.setSize(numGroundFrames);
       for (i=0;i<numGroundFrames;i++)
-         tsalloc.get32((S32*)&mGroundTranslations[i],3);
-      mGroundRotations.setSize(numGroundFrames);
+         tsalloc.get32((S32*)&groundTranslations[i],3);
+      groundRotations.setSize(numGroundFrames);
       for (i=0;i<numGroundFrames;i++)
-         tsalloc.get16((S16*)&mGroundRotations[i],4);
+         tsalloc.get16((S16*)&groundRotations[i],4);
       tsalloc.align32();
 
       tsalloc.checkGuard();
@@ -1021,7 +1021,7 @@ void TSShape::assembleShape()
 
    // object states
    ptr32 = tsalloc.copyToShape32(numObjectStates*3);
-   mObjectStates.set(ptr32,numObjectStates);
+   objectStates.set(ptr32,numObjectStates);
    tsalloc.allocShape32(numSkins*3); // provide buffer after objectStates for older shapes
 
    tsalloc.checkGuard();
@@ -1033,8 +1033,8 @@ void TSShape::assembleShape()
 
    // frame triggers
    ptr32 = tsalloc.getPointer32(numTriggers*2);
-   mTriggers.setSize(numTriggers);
-   dMemcpy(mTriggers.address(),ptr32,sizeof(S32)*numTriggers*2);
+   triggers.setSize(numTriggers);
+   dMemcpy(triggers.address(),ptr32,sizeof(S32)*numTriggers*2);
 
    tsalloc.checkGuard();
 
@@ -1043,7 +1043,7 @@ void TSShape::assembleShape()
    {
       U32 alignedSize32 = sizeof( Detail ) / 4;
       ptr32 = tsalloc.copyToShape32( numDetails * alignedSize32, true );
-      mDetails.set( ptr32, numDetails );
+      details.set( ptr32, numDetails );
    }
    else
    {
@@ -1066,10 +1066,10 @@ void TSShape::assembleShape()
 
       ptr32 = tsalloc.copyToShape32( numDetails * 7, true );
 
-      mDetails.setSize( numDetails );
-      for ( U32 i = 0; i < mDetails.size(); i++, ptr32 += 7 )
+      details.setSize( numDetails );
+      for ( U32 i = 0; i < details.size(); i++, ptr32 += 7 )
       {
-         Detail *det = &(mDetails[i]);
+         Detail *det = &(details[i]);
 
          // Clear the struct... we don't want to leave 
          // garbage in the parts that are unfilled.
@@ -1097,12 +1097,12 @@ void TSShape::assembleShape()
    // Some DTS exporters (MAX - I'm looking at you!) write garbage into the
    // averageError and maxError values which stops LOD from working correctly.
    // Try to detect and fix it
-   for ( U32 i = 0; i < mDetails.size(); i++ )
+   for ( U32 i = 0; i < details.size(); i++ )
    {
-      if ( ( mDetails[i].averageError == 0 ) || ( mDetails[i].averageError > 10000 ) ||
-           ( mDetails[i].maxError == 0 ) || ( mDetails[i].maxError > 10000 ) )
+      if ( ( details[i].averageError == 0 ) || ( details[i].averageError > 10000 ) ||
+           ( details[i].maxError == 0 ) || ( details[i].maxError > 10000 ) )
       {
-         mDetails[i].averageError = mDetails[i].maxError = -1.0f;
+         details[i].averageError = details[i].maxError = -1.0f;
       }
    }
 
@@ -1172,32 +1172,32 @@ void TSShape::assembleShape()
       if (ptr32)
       {
          ptr32[i] = skip ?  0 : (intptr_t)mesh; // @todo 64bit
-         mMeshes.push_back(skip ?  0 : mesh);
+         meshes.push_back(skip ?  0 : mesh);
       }
 
       // fill in location of verts, tverts, and normals for detail levels
       if (mesh && meshType!=TSMesh::DecalMeshType)
       {
-         TSMesh::smVertsList[i]  = mesh->mVerts.address();
-         TSMesh::smTVertsList[i] = mesh->mTVerts.address();
+         TSMesh::smVertsList[i]  = mesh->verts.address();
+         TSMesh::smTVertsList[i] = mesh->tverts.address();
          if (smReadVersion >= 26)
          {
-            TSMesh::smTVerts2List[i] = mesh->mTVerts2.address();
-            TSMesh::smColorsList[i] = mesh->mColors.address();
+            TSMesh::smTVerts2List[i] = mesh->tverts2.address();
+            TSMesh::smColorsList[i] = mesh->colors.address();
          }
-         TSMesh::smNormsList[i]  = mesh->mNorms.address();
-         TSMesh::smEncodedNormsList[i] = mesh->mEncodedNorms.address();
+         TSMesh::smNormsList[i]  = mesh->norms.address();
+         TSMesh::smEncodedNormsList[i] = mesh->encodedNorms.address();
          TSMesh::smDataCopied[i] = !skip; // as long as we didn't skip this mesh, the data should be in shape now
          if (meshType==TSMesh::SkinMeshType)
          {
             TSSkinMesh * skin = (TSSkinMesh*)mesh;
-            TSMesh::smVertsList[i]  = skin->mBatchData.initialVerts.address();
-            TSMesh::smNormsList[i]  = skin->mBatchData.initialNorms.address();
-            TSSkinMesh::smInitTransformList[i] = skin->mBatchData.initialTransforms.address();
-            TSSkinMesh::smVertexIndexList[i] = skin->mVertexIndex.address();
-            TSSkinMesh::smBoneIndexList[i] = skin->mBoneIndex.address();
-            TSSkinMesh::smWeightList[i] = skin->mWeight.address();
-            TSSkinMesh::smNodeIndexList[i] = skin->mBatchData.nodeIndex.address();
+            TSMesh::smVertsList[i]  = skin->batchData.initialVerts.address();
+            TSMesh::smNormsList[i]  = skin->batchData.initialNorms.address();
+            TSSkinMesh::smInitTransformList[i] = skin->batchData.initialTransforms.address();
+            TSSkinMesh::smVertexIndexList[i] = skin->vertexIndex.address();
+            TSSkinMesh::smBoneIndexList[i] = skin->boneIndex.address();
+            TSSkinMesh::smWeightList[i] = skin->weight.address();
+            TSSkinMesh::smNodeIndexList[i] = skin->batchData.nodeIndex.address();
          }
       }
    }
@@ -1208,13 +1208,13 @@ void TSShape::assembleShape()
    char * nameBufferStart = (char*)tsalloc.getPointer8(0);
    char * name = nameBufferStart;
    S32 nameBufferSize = 0;
-   mNames.setSize(numNames);
+   names.setSize(numNames);
    for (i=0; i<numNames; i++)
    {
       for (j=0; name[j]; j++)
          ;
 
-      mNames[i] = name;
+      names[i] = name;
       nameBufferSize += j + 1;
       name += j + 1;
    }
@@ -1261,27 +1261,27 @@ void TSShape::assembleShape()
       {
          bool skip = i<detFirstSkin[skipDL];
          TSSkinMesh * skin = (TSSkinMesh*)TSMesh::assembleMesh(TSMesh::SkinMeshType,skip);
-         if (mMeshes.address())
+         if (meshes.address())
          {
             // add pointer to skin in shapes list of meshes
             // we reserved room for this above...
-            mMeshes.set(mMeshes.address(),mMeshes.size()+1);
-            mMeshes[mMeshes.size()-1] = skip ? NULL : skin;
+            meshes.set(meshes.address(),meshes.size()+1);
+            meshes[meshes.size()-1] = skip ? NULL : skin;
          }
 
          // fill in location of verts, tverts, and normals for shared detail levels
          if (skin)
          {
-            TSMesh::smVertsList[i]  = skin->mBatchData.initialVerts.address();
-            TSMesh::smTVertsList[i] = skin->mTVerts.address();
-            TSMesh::smNormsList[i]  = skin->mBatchData.initialNorms.address();
-            TSMesh::smEncodedNormsList[i]  = skin->mEncodedNorms.address();
+            TSMesh::smVertsList[i]  = skin->batchData.initialVerts.address();
+            TSMesh::smTVertsList[i] = skin->tverts.address();
+            TSMesh::smNormsList[i]  = skin->batchData.initialNorms.address();
+            TSMesh::smEncodedNormsList[i]  = skin->encodedNorms.address();
             TSMesh::smDataCopied[i] = !skip; // as long as we didn't skip this mesh, the data should be in shape now
-            TSSkinMesh::smInitTransformList[i] = skin->mBatchData.initialTransforms.address();
-            TSSkinMesh::smVertexIndexList[i] = skin->mVertexIndex.address();
-            TSSkinMesh::smBoneIndexList[i] = skin->mBoneIndex.address();
-            TSSkinMesh::smWeightList[i] = skin->mWeight.address();
-            TSSkinMesh::smNodeIndexList[i] = skin->mBatchData.nodeIndex.address();
+            TSSkinMesh::smInitTransformList[i] = skin->batchData.initialTransforms.address();
+            TSSkinMesh::smVertexIndexList[i] = skin->vertexIndex.address();
+            TSSkinMesh::smBoneIndexList[i] = skin->boneIndex.address();
+            TSSkinMesh::smWeightList[i] = skin->weight.address();
+            TSSkinMesh::smNodeIndexList[i] = skin->batchData.nodeIndex.address();
          }
       }
 
@@ -1293,9 +1293,9 @@ void TSShape::assembleShape()
 
    // allocate storage space for some arrays (filled in during Shape::init)...
    ptr32 = tsalloc.allocShape32(numDetails);
-   mAlphaIn.set(ptr32,numDetails);
+   alphaIn.set(ptr32,numDetails);
    ptr32 = tsalloc.allocShape32(numDetails);
-   mAlphaOut.set(ptr32,numDetails);
+   alphaOut.set(ptr32,numDetails);
 }
 
 void TSShape::disassembleShape()
@@ -1303,79 +1303,79 @@ void TSShape::disassembleShape()
    S32 i;
 
    // set counts...
-   S32 numNodes = tsalloc.set32(mNodes.size());
-   S32 numObjects = tsalloc.set32(mObjects.size());
+   S32 numNodes = tsalloc.set32(nodes.size());
+   S32 numObjects = tsalloc.set32(objects.size());
    tsalloc.set32(0); // DEPRECATED decals
-   S32 numSubShapes = tsalloc.set32(mSubShapeFirstNode.size());
+   S32 numSubShapes = tsalloc.set32(subShapeFirstNode.size());
    tsalloc.set32(0); // DEPRECATED ifl materials
-   S32 numNodeRotations = tsalloc.set32(mNodeRotations.size());
-   S32 numNodeTranslations = tsalloc.set32(mNodeTranslations.size());
-   S32 numNodeUniformScales = tsalloc.set32(mNodeUniformScales.size());
-   S32 numNodeAlignedScales = tsalloc.set32(mNodeAlignedScales.size());
-   S32 numNodeArbitraryScales = tsalloc.set32(mNodeArbitraryScaleFactors.size());
-   S32 numGroundFrames = tsalloc.set32(mGroundTranslations.size());
-   S32 numObjectStates = tsalloc.set32(mObjectStates.size());
+   S32 numNodeRotations = tsalloc.set32(nodeRotations.size());
+   S32 numNodeTranslations = tsalloc.set32(nodeTranslations.size());
+   S32 numNodeUniformScales = tsalloc.set32(nodeUniformScales.size());
+   S32 numNodeAlignedScales = tsalloc.set32(nodeAlignedScales.size());
+   S32 numNodeArbitraryScales = tsalloc.set32(nodeArbitraryScaleFactors.size());
+   S32 numGroundFrames = tsalloc.set32(groundTranslations.size());
+   S32 numObjectStates = tsalloc.set32(objectStates.size());
    tsalloc.set32(0); // DEPRECATED decals
-   S32 numTriggers = tsalloc.set32(mTriggers.size());
-   S32 numDetails = tsalloc.set32(mDetails.size());
-   S32 numMeshes = tsalloc.set32(mMeshes.size());
-   S32 numNames = tsalloc.set32(mNames.size());
+   S32 numTriggers = tsalloc.set32(triggers.size());
+   S32 numDetails = tsalloc.set32(details.size());
+   S32 numMeshes = tsalloc.set32(meshes.size());
+   S32 numNames = tsalloc.set32(names.size());
    tsalloc.set32((S32)mSmallestVisibleSize);
    tsalloc.set32(mSmallestVisibleDL);
 
    tsalloc.setGuard();
 
    // get bounds...
-   tsalloc.copyToBuffer32((S32*)&mRadius,1);
-   tsalloc.copyToBuffer32((S32*)&mTubeRadius,1);
-   tsalloc.copyToBuffer32((S32*)&mCenter,3);
-   tsalloc.copyToBuffer32((S32*)&mBounds,6);
+   tsalloc.copyToBuffer32((S32*)&radius,1);
+   tsalloc.copyToBuffer32((S32*)&tubeRadius,1);
+   tsalloc.copyToBuffer32((S32*)&center,3);
+   tsalloc.copyToBuffer32((S32*)&bounds,6);
 
    tsalloc.setGuard();
 
    // copy various vectors...
-   tsalloc.copyToBuffer32((S32*)mNodes.address(),numNodes*5);
+   tsalloc.copyToBuffer32((S32*)nodes.address(),numNodes*5);
    tsalloc.setGuard();
-   tsalloc.copyToBuffer32((S32*)mObjects.address(),numObjects*6);
+   tsalloc.copyToBuffer32((S32*)objects.address(),numObjects*6);
    tsalloc.setGuard();
    // DEPRECATED: no copy decals
    tsalloc.setGuard();
    tsalloc.copyToBuffer32(0,0); // DEPRECATED: ifl materials!
    tsalloc.setGuard();
-   tsalloc.copyToBuffer32((S32*)mSubShapeFirstNode.address(),numSubShapes);
-   tsalloc.copyToBuffer32((S32*)mSubShapeFirstObject.address(),numSubShapes);
+   tsalloc.copyToBuffer32((S32*)subShapeFirstNode.address(),numSubShapes);
+   tsalloc.copyToBuffer32((S32*)subShapeFirstObject.address(),numSubShapes);
    tsalloc.copyToBuffer32(0, numSubShapes); // DEPRECATED: no copy subShapeFirstDecal
    tsalloc.setGuard();
-   tsalloc.copyToBuffer32((S32*)mSubShapeNumNodes.address(),numSubShapes);
-   tsalloc.copyToBuffer32((S32*)mSubShapeNumObjects.address(),numSubShapes);
+   tsalloc.copyToBuffer32((S32*)subShapeNumNodes.address(),numSubShapes);
+   tsalloc.copyToBuffer32((S32*)subShapeNumObjects.address(),numSubShapes);
    tsalloc.copyToBuffer32(0, numSubShapes); // DEPRECATED: no copy subShapeNumDecals
    tsalloc.setGuard();
 
    // default transforms...
-   tsalloc.copyToBuffer16((S16*)mDefaultRotations.address(),numNodes*4);
-   tsalloc.copyToBuffer32((S32*)mDefaultTranslations.address(),numNodes*3);
+   tsalloc.copyToBuffer16((S16*)defaultRotations.address(),numNodes*4);
+   tsalloc.copyToBuffer32((S32*)defaultTranslations.address(),numNodes*3);
 
    // animated transforms...
-   tsalloc.copyToBuffer16((S16*)mNodeRotations.address(),numNodeRotations*4);
-   tsalloc.copyToBuffer32((S32*)mNodeTranslations.address(),numNodeTranslations*3);
+   tsalloc.copyToBuffer16((S16*)nodeRotations.address(),numNodeRotations*4);
+   tsalloc.copyToBuffer32((S32*)nodeTranslations.address(),numNodeTranslations*3);
 
    tsalloc.setGuard();
 
    // ...with scale
-   tsalloc.copyToBuffer32((S32*)mNodeUniformScales.address(),numNodeUniformScales);
-   tsalloc.copyToBuffer32((S32*)mNodeAlignedScales.address(),numNodeAlignedScales*3);
-   tsalloc.copyToBuffer32((S32*)mNodeArbitraryScaleFactors.address(),numNodeArbitraryScales*3);
-   tsalloc.copyToBuffer16((S16*)mNodeArbitraryScaleRots.address(),numNodeArbitraryScales*4);
+   tsalloc.copyToBuffer32((S32*)nodeUniformScales.address(),numNodeUniformScales);
+   tsalloc.copyToBuffer32((S32*)nodeAlignedScales.address(),numNodeAlignedScales*3);
+   tsalloc.copyToBuffer32((S32*)nodeArbitraryScaleFactors.address(),numNodeArbitraryScales*3);
+   tsalloc.copyToBuffer16((S16*)nodeArbitraryScaleRots.address(),numNodeArbitraryScales*4);
 
    tsalloc.setGuard();
 
-   tsalloc.copyToBuffer32((S32*)mGroundTranslations.address(),3*numGroundFrames);
-   tsalloc.copyToBuffer16((S16*)mGroundRotations.address(),4*numGroundFrames);
+   tsalloc.copyToBuffer32((S32*)groundTranslations.address(),3*numGroundFrames);
+   tsalloc.copyToBuffer16((S16*)groundRotations.address(),4*numGroundFrames);
 
    tsalloc.setGuard();
 
    // object states..
-   tsalloc.copyToBuffer32((S32*)mObjectStates.address(),numObjectStates*3);
+   tsalloc.copyToBuffer32((S32*)objectStates.address(),numObjectStates*3);
    tsalloc.setGuard();
 
    // decal states...
@@ -1383,21 +1383,21 @@ void TSShape::disassembleShape()
    tsalloc.setGuard();
 
    // frame triggers
-   tsalloc.copyToBuffer32((S32*)mTriggers.address(),numTriggers*2);
+   tsalloc.copyToBuffer32((S32*)triggers.address(),numTriggers*2);
    tsalloc.setGuard();
 
    // details
    if (TSShape::smVersion > 25)
    {
       U32 alignedSize32 = sizeof( Detail ) / 4;
-      tsalloc.copyToBuffer32((S32*)mDetails.address(),numDetails * alignedSize32 );
+      tsalloc.copyToBuffer32((S32*)details.address(),numDetails * alignedSize32 );
    }
    else
    {
       // Legacy details => no explicit autobillboard parameters
       U32 legacyDetailSize32 = 7;   // only store the first 7 4-byte values of each detail
-      for ( S32 i = 0; i < mDetails.size(); i++ )
-         tsalloc.copyToBuffer32( (S32*)&mDetails[i], legacyDetailSize32 );
+      for ( S32 i = 0; i < details.size(); i++ )
+         tsalloc.copyToBuffer32( (S32*)&details[i], legacyDetailSize32 );
    }
    tsalloc.setGuard();
 
@@ -1405,18 +1405,18 @@ void TSShape::disassembleShape()
    bool * isMesh = new bool[numMeshes]; // funny business because decals are pretend meshes (legacy issue)
    for (i=0;i<numMeshes;i++)
       isMesh[i]=false;
-   for (i=0; i<mObjects.size(); i++)
+   for (i=0; i<objects.size(); i++)
    {
-      for (S32 j=0; j<mObjects[i].numMeshes; j++)
+      for (S32 j=0; j<objects[i].numMeshes; j++)
          // even if an empty mesh, it's a mesh...
-         isMesh[mObjects[i].startMeshIndex+j]=true;
+         isMesh[objects[i].startMeshIndex+j]=true;
    }
    for (i=0; i<numMeshes; i++)
    {
       TSMesh * mesh = NULL;
       // decal mesh deprecated
       if (isMesh[i])
-         mesh = mMeshes[i];
+         mesh = meshes[i];
       tsalloc.set32( (mesh && mesh->getMeshType() != TSMesh::DecalMeshType) ? mesh->getMeshType() : TSMesh::NullMeshType);
       if (mesh)
          mesh->disassemble();
@@ -1426,7 +1426,7 @@ void TSShape::disassembleShape()
 
    // names
    for (i=0; i<numNames; i++)
-      tsalloc.copyToBuffer8((S8 *)(mNames[i].c_str()),mNames[i].length()+1);
+      tsalloc.copyToBuffer8((S8 *)(names[i].c_str()),names[i].length()+1);
 
    tsalloc.setGuard();
 }
@@ -1438,27 +1438,27 @@ void TSShape::disassembleShape()
 bool TSShape::canWriteOldFormat() const
 {
    // Cannot use old format if using autobillboard details
-   for (S32 i = 0; i < mDetails.size(); i++)
+   for (S32 i = 0; i < details.size(); i++)
    {
-      if (mDetails[i].subShapeNum < 0)
+      if (details[i].subShapeNum < 0)
          return false;
    }
 
-   for (S32 i = 0; i < mMeshes.size(); i++)
+   for (S32 i = 0; i < meshes.size(); i++)
    {
-      if (!mMeshes[i])
+      if (!meshes[i])
          continue;
 
       // Cannot use old format if using the new functionality (COLORs, 2nd UV set)
-      if (mMeshes[i]->mTVerts2.size() || mMeshes[i]->mColors.size())
+      if (meshes[i]->tverts2.size() || meshes[i]->colors.size())
          return false;
 
       // Cannot use old format if any primitive has too many triangles
       // (ie. cannot fit in a S16)
-      for (S32 j = 0; j < mMeshes[i]->mPrimitives.size(); j++)
+      for (S32 j = 0; j < meshes[i]->primitives.size(); j++)
       {
-         if ((mMeshes[i]->mPrimitives[j].start +
-               mMeshes[i]->mPrimitives[j].numElements) >= (1 << 15))
+         if ((meshes[i]->primitives[j].start +
+               meshes[i]->primitives[j].numElements) >= (1 << 15))
          {
             return false;
          }
@@ -1515,12 +1515,12 @@ void TSShape::write(Stream * s, bool saveOldFormat)
    s->write(size8 *4,buffer8);
 
    // write sequences - write will properly endian-flip.
-   s->write(mSequences.size());
-   for (S32 i=0; i<mSequences.size(); i++)
-      mSequences[i].write(s);
+   s->write(sequences.size());
+   for (S32 i=0; i<sequences.size(); i++)
+      sequences[i].write(s);
 
    // write material list - write will properly endian-flip.
-   mMaterialList->write(*s);
+   materialList->write(*s);
 
    delete [] buffer32;
    delete [] buffer16;
@@ -1587,20 +1587,20 @@ bool TSShape::read(Stream * s)
       // read sequences
       S32 numSequences;
       s->read(&numSequences);
-      mSequences.setSize(numSequences);
+      sequences.setSize(numSequences);
       for (i=0; i<numSequences; i++)
       {
-         mSequences[i].read(s);
+         sequences[i].read(s);
 
          // Store initial (empty) source data
-         mSequences[i].sourceData.total = mSequences[i].numKeyframes;
-         mSequences[i].sourceData.end = mSequences[i].sourceData.total - 1;
+         sequences[i].sourceData.total = sequences[i].numKeyframes;
+         sequences[i].sourceData.end = sequences[i].sourceData.total - 1;
       }
 
       // read material list
-      delete mMaterialList; // just in case...
-      mMaterialList = new TSMaterialList;
-      mMaterialList->read(*s);
+      delete materialList; // just in case...
+      materialList = new TSMaterialList;
+      materialList->read(*s);
    }
 
 	// since we read in the buffers, we need to endian-flip their entire contents...
@@ -1844,89 +1844,89 @@ bool TSShape::read(Stream * s)
 
 void TSShape::createEmptyShape()
 {
-   mNodes.set(dMalloc(1 * sizeof(Node)), 1);
-      mNodes[0].nameIndex = 1;
-      mNodes[0].parentIndex = -1;
-      mNodes[0].firstObject = 0;
-      mNodes[0].firstChild = -1;
-      mNodes[0].nextSibling = -1;
+   nodes.set(dMalloc(1 * sizeof(Node)), 1);
+      nodes[0].nameIndex = 1;
+      nodes[0].parentIndex = -1;
+      nodes[0].firstObject = 0;
+      nodes[0].firstChild = -1;
+      nodes[0].nextSibling = -1;
 
-   mObjects.set(dMalloc(1 * sizeof(Object)), 1);
-      mObjects[0].nameIndex = 2;
-      mObjects[0].numMeshes = 1;
-      mObjects[0].startMeshIndex = 0;
-      mObjects[0].nodeIndex = 0;
-      mObjects[0].nextSibling = -1;
-      mObjects[0].firstDecal = -1;
+   objects.set(dMalloc(1 * sizeof(Object)), 1);
+      objects[0].nameIndex = 2;
+      objects[0].numMeshes = 1;
+      objects[0].startMeshIndex = 0;
+      objects[0].nodeIndex = 0;
+      objects[0].nextSibling = -1;
+      objects[0].firstDecal = -1;
 
-   mObjectStates.set(dMalloc(1 * sizeof(ObjectState)), 1);
-      mObjectStates[0].vis = 1;
-      mObjectStates[0].frameIndex = 0;
-      mObjectStates[0].matFrameIndex = 0;
+   objectStates.set(dMalloc(1 * sizeof(ObjectState)), 1);
+      objectStates[0].vis = 1;
+      objectStates[0].frameIndex = 0;
+      objectStates[0].matFrameIndex = 0;
 
-   mSubShapeFirstNode.set(dMalloc(1 * sizeof(S32)), 1);
-      mSubShapeFirstNode[0] = 0;
+   subShapeFirstNode.set(dMalloc(1 * sizeof(S32)), 1);
+      subShapeFirstNode[0] = 0;
 
-   mSubShapeFirstObject.set(dMalloc(1 * sizeof(S32)), 1);
-      mSubShapeFirstObject[0] = 0;
+   subShapeFirstObject.set(dMalloc(1 * sizeof(S32)), 1);
+      subShapeFirstObject[0] = 0;
 
-   mDetailFirstSkin.set(NULL, 0);
+   detailFirstSkin.set(NULL, 0);
 
-   mSubShapeNumNodes.set(dMalloc(1 * sizeof(S32)), 1);
-      mSubShapeNumNodes[0] = 1;
+   subShapeNumNodes.set(dMalloc(1 * sizeof(S32)), 1);
+      subShapeNumNodes[0] = 1;
 
-   mSubShapeNumObjects.set(dMalloc(1 * sizeof(S32)), 1);
-      mSubShapeNumObjects[0] = 1;
+   subShapeNumObjects.set(dMalloc(1 * sizeof(S32)), 1);
+      subShapeNumObjects[0] = 1;
 
-   mDetails.set(dMalloc(1 * sizeof(Detail)), 1);
-      mDetails[0].nameIndex = 0;
-      mDetails[0].subShapeNum = 0;
-      mDetails[0].objectDetailNum = 0;
-      mDetails[0].size = 2.0f;
-      mDetails[0].averageError = -1.0f;
-      mDetails[0].maxError = -1.0f;
-      mDetails[0].polyCount = 0;
+   details.set(dMalloc(1 * sizeof(Detail)), 1);
+      details[0].nameIndex = 0;
+      details[0].subShapeNum = 0;
+      details[0].objectDetailNum = 0;
+      details[0].size = 2.0f;
+      details[0].averageError = -1.0f;
+      details[0].maxError = -1.0f;
+      details[0].polyCount = 0;
 
-   mDefaultRotations.set(dMalloc(1 * sizeof(Quat16)), 1);
-      mDefaultRotations[0].x = 0.0f;
-      mDefaultRotations[0].y = 0.0f;
-      mDefaultRotations[0].z = 0.0f;
-      mDefaultRotations[0].w = 0.0f;
+   defaultRotations.set(dMalloc(1 * sizeof(Quat16)), 1);
+      defaultRotations[0].x = 0.0f;
+      defaultRotations[0].y = 0.0f;
+      defaultRotations[0].z = 0.0f;
+      defaultRotations[0].w = 0.0f;
 
-   mDefaultTranslations.set(dMalloc(1 * sizeof(Point3F)), 1);
-      mDefaultTranslations[0].set(0.0f, 0.0f, 0.0f);
+   defaultTranslations.set(dMalloc(1 * sizeof(Point3F)), 1);
+      defaultTranslations[0].set(0.0f, 0.0f, 0.0f);
 
-   mSubShapeFirstTranslucentObject.set(dMalloc(1 * sizeof(S32)), 1);
-      mSubShapeFirstTranslucentObject[0] = 1;
+   subShapeFirstTranslucentObject.set(dMalloc(1 * sizeof(S32)), 1);
+      subShapeFirstTranslucentObject[0] = 1;
 
-   mAlphaIn.set(dMalloc(1 * sizeof(F32)), 1);
-      mAlphaIn[0] = 0;
+   alphaIn.set(dMalloc(1 * sizeof(F32)), 1);
+      alphaIn[0] = 0;
 
-   mAlphaOut.set(dMalloc(1 * sizeof(F32)), 1);
-      mAlphaOut[0] = -1;
+   alphaOut.set(dMalloc(1 * sizeof(F32)), 1);
+      alphaOut[0] = -1;
 
-   mSequences.set(NULL, 0);
-   mNodeRotations.set(NULL, 0);
-   mNodeTranslations.set(NULL, 0);
-   mNodeUniformScales.set(NULL, 0);
-   mNodeAlignedScales.set(NULL, 0);
-   mNodeArbitraryScaleRots.set(NULL, 0);
-   mNodeArbitraryScaleFactors.set(NULL, 0);
-   mGroundRotations.set(NULL, 0);
-   mGroundTranslations.set(NULL, 0);
-   mTriggers.set(NULL, 0);
-   mBillboardDetails.set(NULL, 0);
+   sequences.set(NULL, 0);
+   nodeRotations.set(NULL, 0);
+   nodeTranslations.set(NULL, 0);
+   nodeUniformScales.set(NULL, 0);
+   nodeAlignedScales.set(NULL, 0);
+   nodeArbitraryScaleRots.set(NULL, 0);
+   nodeArbitraryScaleFactors.set(NULL, 0);
+   groundRotations.set(NULL, 0);
+   groundTranslations.set(NULL, 0);
+   triggers.set(NULL, 0);
+   billboardDetails.set(NULL, 0);
 
-   mNames.setSize(3);
-      mNames[0] = StringTable->insert("Detail2");
-      mNames[1] = StringTable->insert("Mesh2");
-      mNames[2] = StringTable->insert("Mesh");
+   names.setSize(3);
+      names[0] = StringTable->insert("Detail2");
+      names[1] = StringTable->insert("Mesh2");
+      names[2] = StringTable->insert("Mesh");
 
-   mRadius = 0.866025f;
-   mTubeRadius = 0.707107f;
-   mCenter.set(0.0f, 0.5f, 0.0f);
-   mBounds.minExtents.set(-0.5f, 0.0f, -0.5f);
-   mBounds.maxExtents.set(0.5f, 1.0f, 0.5f);
+   radius = 0.866025f;
+   tubeRadius = 0.707107f;
+   center.set(0.0f, 0.5f, 0.0f);
+   bounds.minExtents.set(-0.5f, 0.0f, -0.5f);
+   bounds.maxExtents.set(0.5f, 1.0f, 0.5f);
 
    mExporterVersion = 124;
    mSmallestVisibleSize = 2;
@@ -1942,9 +1942,9 @@ void TSShape::createEmptyShape()
 
    // Init the collision accelerator array.  Note that we don't compute the
    //  accelerators until the app requests them
-   mDetailCollisionAccelerators.setSize(mDetails.size());
-   for (U32 i = 0; i < mDetailCollisionAccelerators.size(); i++)
-      mDetailCollisionAccelerators[i] = NULL;
+   detailCollisionAccelerators.setSize(details.size());
+   for (U32 i = 0; i < detailCollisionAccelerators.size(); i++)
+      detailCollisionAccelerators[i] = NULL;
 }
 
 void TSShape::fixEndian(S32 * buff32, S16 * buff16, S8 *, S32 count32, S32 count16, S32)
@@ -2047,27 +2047,27 @@ template<> ResourceBase::Signature  Resource<TSShape>::signature()
 
 TSShape::ConvexHullAccelerator* TSShape::getAccelerator(S32 dl)
 {
-   AssertFatal(dl < mDetails.size(), "Error, bad detail level!");
+   AssertFatal(dl < details.size(), "Error, bad detail level!");
    if (dl == -1)
       return NULL;
 
-   AssertFatal( mDetailCollisionAccelerators.size() == mDetails.size(), 
+   AssertFatal( detailCollisionAccelerators.size() == details.size(), 
       "TSShape::getAccelerator() - mismatched array sizes!" );
 
-   if (mDetailCollisionAccelerators[dl] == NULL)
+   if (detailCollisionAccelerators[dl] == NULL)
       computeAccelerator(dl);
 
-   AssertFatal(mDetailCollisionAccelerators[dl] != NULL, "This should be non-null after computing it!");
-   return mDetailCollisionAccelerators[dl];
+   AssertFatal(detailCollisionAccelerators[dl] != NULL, "This should be non-null after computing it!");
+   return detailCollisionAccelerators[dl];
 }
 
 
 void TSShape::computeAccelerator(S32 dl)
 {
-   AssertFatal(dl < mDetails.size(), "Error, bad detail level!");
+   AssertFatal(dl < details.size(), "Error, bad detail level!");
 
    // Have we already computed this?
-   if (mDetailCollisionAccelerators[dl] != NULL)
+   if (detailCollisionAccelerators[dl] != NULL)
       return;
 
    // Create a bogus features list...
@@ -2075,12 +2075,12 @@ void TSShape::computeAccelerator(S32 dl)
    MatrixF mat(true);
    Point3F n(0, 0, 1);
 
-   const TSDetail* detail = &mDetails[dl];
+   const TSDetail* detail = &details[dl];
    S32 ss = detail->subShapeNum;
    S32 od = detail->objectDetailNum;
 
-   S32 start = mSubShapeFirstObject[ss];
-   S32 end   = mSubShapeNumObjects[ss] + start;
+   S32 start = subShapeFirstObject[ss];
+   S32 end   = subShapeNumObjects[ss] + start;
    if (start < end)
    {
       // run through objects and collide
@@ -2089,10 +2089,10 @@ void TSShape::computeAccelerator(S32 dl)
       U32 surfaceKey = 0;
       for (S32 i = start; i < end; i++)
       {
-         const TSObject* obj = &mObjects[i];
+         const TSObject* obj = &objects[i];
 
          if (obj->numMeshes && od < obj->numMeshes) {
-            TSMesh* mesh = mMeshes[obj->startMeshIndex + od];
+            TSMesh* mesh = meshes[obj->startMeshIndex + od];
             if (mesh)
                mesh->getFeatures(0, mat, n, &cf, surfaceKey);
          }
@@ -2147,7 +2147,7 @@ void TSShape::computeAccelerator(S32 dl)
 
    // Ok, so now we have a vertex list.  Lets copy that out...
    ConvexHullAccelerator* accel = new ConvexHullAccelerator;
-   mDetailCollisionAccelerators[dl] = accel;
+   detailCollisionAccelerators[dl] = accel;
    accel->numVerts    = cf.mVertexList.size();
    accel->vertexList  = new Point3F[accel->numVerts];
    dMemcpy(accel->vertexList, cf.mVertexList.address(), sizeof(Point3F) * accel->numVerts);

--- a/Engine/source/ts/tsShape.h
+++ b/Engine/source/ts/tsShape.h
@@ -274,25 +274,25 @@ class TSShape
    /// @name Shape Vector Data
    /// @{
 
-   Vector<Node> mNodes;
-   Vector<Object> mObjects;
-   Vector<ObjectState> mObjectStates;
-   Vector<S32> mSubShapeFirstNode;
-   Vector<S32> mSubShapeFirstObject;
-   Vector<S32> mDetailFirstSkin;
-   Vector<S32> mSubShapeNumNodes;
-   Vector<S32> mSubShapeNumObjects;
-   Vector<Detail> mDetails;
-   Vector<Quat16> mDefaultRotations;
-   Vector<Point3F> mDefaultTranslations;
+   Vector<Node> nodes;
+   Vector<Object> objects;
+   Vector<ObjectState> objectStates;
+   Vector<S32> subShapeFirstNode;
+   Vector<S32> subShapeFirstObject;
+   Vector<S32> detailFirstSkin;
+   Vector<S32> subShapeNumNodes;
+   Vector<S32> subShapeNumObjects;
+   Vector<Detail> details;
+   Vector<Quat16> defaultRotations;
+   Vector<Point3F> defaultTranslations;
 
    /// @}
 
    /// These are set up at load time, but memory is allocated along with loaded data
    /// @{
 
-   Vector<S32> mSubShapeFirstTranslucentObject;
-   Vector<TSMesh*> mMeshes;
+   Vector<S32> subShapeFirstTranslucentObject;
+   Vector<TSMesh*> meshes;
 
    /// @}
 
@@ -306,39 +306,39 @@ class TSShape
    ///   - intraDL is at 0 when if shape were any farther away we'd be at dl+1
    /// @{
 
-   Vector<F32> mAlphaIn;
-   Vector<F32> mAlphaOut
+   Vector<F32> alphaIn;
+   Vector<F32> alphaOut
       ;
    /// @}
 
    /// @name Resizeable vectors
    /// @{
 
-   Vector<Sequence>                 mSequences;
-   Vector<Quat16>                   mNodeRotations;
-   Vector<Point3F>                  mNodeTranslations;
-   Vector<F32>                      mNodeUniformScales;
-   Vector<Point3F>                  mNodeAlignedScales;
-   Vector<Quat16>                   mNodeArbitraryScaleRots;
-   Vector<Point3F>                  mNodeArbitraryScaleFactors;
-   Vector<Quat16>                   mGroundRotations;
-   Vector<Point3F>                  mGroundTranslations;
-   Vector<Trigger>                  mTriggers;
-   Vector<TSLastDetail*>            mBillboardDetails;
-   Vector<ConvexHullAccelerator*>   mDetailCollisionAccelerators;
-   Vector<String>                   mNames;
+   Vector<Sequence>                 sequences;
+   Vector<Quat16>                   nodeRotations;
+   Vector<Point3F>                  nodeTranslations;
+   Vector<F32>                      nodeUniformScales;
+   Vector<Point3F>                  nodeAlignedScales;
+   Vector<Quat16>                   nodeArbitraryScaleRots;
+   Vector<Point3F>                  nodeArbitraryScaleFactors;
+   Vector<Quat16>                   groundRotations;
+   Vector<Point3F>                  groundTranslations;
+   Vector<Trigger>                  triggers;
+   Vector<TSLastDetail*>            billboardDetails;
+   Vector<ConvexHullAccelerator*>   detailCollisionAccelerators;
+   Vector<String>                   names;
 
    /// @}
 
-   TSMaterialList * mMaterialList;
+   TSMaterialList * materialList;
 
    /// @name Bounding
    /// @{
 
-   F32 mRadius;
-   F32 mTubeRadius;
-   Point3F mCenter;
-   Box3F mBounds;
+   F32 radius;
+   F32 tubeRadius;
+   Point3F center;
+   Box3F bounds;
 
    /// @}
 
@@ -348,7 +348,7 @@ class TSShape
    S32 mSmallestVisibleDL;    ///< @see mSmallestVisibleSize
    S32 mReadVersion;          ///< File version that this shape was read from.
    U32 mFlags;                ///< hasTranslucancy
-   U32 mData;                  ///< User-defined data storage.
+   U32 data;                  ///< User-defined data storage.
 
    /// If enabled detail selection will use the
    /// legacy screen error method for lod.
@@ -659,34 +659,34 @@ class TSShape
 
 inline QuatF & TSShape::getRotation(const Sequence & seq, S32 keyframeNum, S32 rotNum, QuatF * quat) const
 {
-   return mNodeRotations[seq.baseRotation + rotNum*seq.numKeyframes + keyframeNum].getQuatF(quat);
+   return nodeRotations[seq.baseRotation + rotNum*seq.numKeyframes + keyframeNum].getQuatF(quat);
 }
 
 inline const Point3F & TSShape::getTranslation(const Sequence & seq, S32 keyframeNum, S32 tranNum) const
 {
-   return mNodeTranslations[seq.baseTranslation + tranNum*seq.numKeyframes + keyframeNum];
+   return nodeTranslations[seq.baseTranslation + tranNum*seq.numKeyframes + keyframeNum];
 }
 
 inline F32 TSShape::getUniformScale(const Sequence & seq, S32 keyframeNum, S32 scaleNum) const
 {
-   return mNodeUniformScales[seq.baseScale + scaleNum*seq.numKeyframes + keyframeNum];
+   return nodeUniformScales[seq.baseScale + scaleNum*seq.numKeyframes + keyframeNum];
 }
 
 inline const Point3F & TSShape::getAlignedScale(const Sequence & seq, S32 keyframeNum, S32 scaleNum) const
 {
-   return mNodeAlignedScales[seq.baseScale + scaleNum*seq.numKeyframes + keyframeNum];
+   return nodeAlignedScales[seq.baseScale + scaleNum*seq.numKeyframes + keyframeNum];
 }
 
 inline TSScale & TSShape::getArbitraryScale(const Sequence & seq, S32 keyframeNum, S32 scaleNum, TSScale * scale) const
 {
-   mNodeArbitraryScaleRots[seq.baseScale + scaleNum*seq.numKeyframes + keyframeNum].getQuatF(&scale->mRotate);
-   scale->mScale = mNodeArbitraryScaleFactors[seq.baseScale + scaleNum*seq.numKeyframes + keyframeNum];
+   nodeArbitraryScaleRots[seq.baseScale + scaleNum*seq.numKeyframes + keyframeNum].getQuatF(&scale->mRotate);
+   scale->mScale = nodeArbitraryScaleFactors[seq.baseScale + scaleNum*seq.numKeyframes + keyframeNum];
    return *scale;
 }
 
 inline const TSShape::ObjectState & TSShape::getObjectState(const Sequence & seq, S32 keyframeNum, S32 objectNum) const
 {
-   return mObjectStates[seq.baseObjectState + objectNum*seq.numKeyframes + keyframeNum];
+   return objectStates[seq.baseObjectState + objectNum*seq.numKeyframes + keyframeNum];
 }
 
 #endif

--- a/Engine/source/ts/tsShapeConstruct.cpp
+++ b/Engine/source/ts/tsShapeConstruct.cpp
@@ -159,7 +159,7 @@ void TSShapeConstructor::initPersistFields()
    endGroup( "Media" );
 
    addGroup( "Collada" );
-   addField( "upAxis", TYPEID< domUpAxisType >(), Offset(mOptions.mUpAxis, TSShapeConstructor),
+   addField( "upAxis", TYPEID< domUpAxisType >(), Offset(mOptions.upAxis, TSShapeConstructor),
       "Override the <up_axis> element in the COLLADA (.dae) file. No effect for DTS files.\n"
       "Set to one of the following values:\n"
       "<dl><dt>X_AXIS</dt><dd>Positive X points up. Model will be rotated into Torque's coordinate system (Z up).</dd>"
@@ -167,7 +167,7 @@ void TSShapeConstructor::initPersistFields()
       "<dt>Z_AXIS</dt><dd>Positive Z points up. No rotation will be applied to the model.</dd>"
       "<dt>DEFAULT</dt><dd>The default value. Use the value in the .dae file (defaults to Z_AXIS if the <up_axis> element is not present).</dd></dl>" );
 
-   addField( "unit", TypeF32, Offset(mOptions.mUnit, TSShapeConstructor),
+   addField( "unit", TypeF32, Offset(mOptions.unit, TSShapeConstructor),
       "Override the <unit> element in the COLLADA (.dae) file. No effect for DTS files.\n"
       "COLLADA (.dae) files usually contain a <unit> element that indicates the "
       "'real world' units that the model is described in. It means you can work "
@@ -182,7 +182,7 @@ void TSShapeConstructor::initPersistFields()
       "Omit the field or set to -1 to use the value in the .dae file (1.0 if the "
       "<unit> element is not present)" );
 
-   addField( "lodType", TYPEID< ColladaUtils::ImportOptions::eLodType >(), Offset(mOptions.mLodType, TSShapeConstructor),
+   addField( "lodType", TYPEID< ColladaUtils::ImportOptions::eLodType >(), Offset(mOptions.lodType, TSShapeConstructor),
       "Control how the COLLADA (.dae) importer interprets LOD in the model. No effect for DTS files.\n"
       "Set to one of the following values:\n"
       "<dl><dt>DetectDTS</dt><dd>The default value. Instructs the importer to search for a 'baseXXX->startXXX' node hierarchy at the root level. If found, the importer acts as if ''TrailingNumber'' was set. Otherwise, all geometry is imported at a single detail size.</dd>"
@@ -190,16 +190,16 @@ void TSShapeConstructor::initPersistFields()
       "<dt>TrailingNumber</dt><dd>Numbers at the end of geometry node's name are interpreted as the detail size (similar to DTS exporting). Geometry instances with the same base name but different trailing number are grouped into the same object.</dd>"
       "<dt>DEFAULT</dt><dd>The default value. Use the value in the .dae file (defaults to Z_AXIS if the <up_axis> element is not present).</dd></dl>" );
 
-   addField( "singleDetailSize", TypeS32, Offset(mOptions.mSingleDetailSize, TSShapeConstructor),
+   addField( "singleDetailSize", TypeS32, Offset(mOptions.singleDetailSize, TSShapeConstructor),
       "Sets the detail size when lodType is set to SingleSize. No effect otherwise, and no effect for DTS files.\n"
       "@see lodType" );
 
-   addField( "matNamePrefix", TypeRealString, Offset(mOptions.mMatNamePrefix, TSShapeConstructor),
+   addField( "matNamePrefix", TypeRealString, Offset(mOptions.matNamePrefix, TSShapeConstructor),
       "Prefix to apply to all material map names in the COLLADA (.dae) file. No effect for DTS files.\n"
       "This field is useful to avoid material name clashes for exporters that generate generic material "
       "names like \"texture0\" or \"material1\"." );
 
-   addField( "alwaysImport", TypeRealString, Offset(mOptions.mAlwaysImport, TSShapeConstructor),
+   addField( "alwaysImport", TypeRealString, Offset(mOptions.alwaysImport, TSShapeConstructor),
       "TAB separated patterns of nodes to import even if in neverImport list. No effect for DTS files.\n"
       "Torque allows unwanted nodes in COLLADA (.dae) files to to be ignored "
       "during import. This field contains a TAB separated list of patterns to "
@@ -215,7 +215,7 @@ void TSShapeConstructor::initPersistFields()
       "}\n"
       "@endtsexample" );
 
-   addField( "neverImport", TypeRealString, Offset(mOptions.mNeverImport, TSShapeConstructor),
+   addField( "neverImport", TypeRealString, Offset(mOptions.neverImport, TSShapeConstructor),
       "TAB separated patterns of nodes to ignore on loading. No effect for DTS files.\n"
       "Torque allows unwanted nodes in COLLADA (.dae) files to to be ignored "
       "during import. This field contains a TAB separated list of patterns to "
@@ -223,7 +223,7 @@ void TSShapeConstructor::initPersistFields()
       "not be imported (unless it matches the alwaysImport list.\n"
       "@see alwaysImport" );
 
-   addField( "alwaysImportMesh", TypeRealString, Offset(mOptions.mAlwaysImportMesh, TSShapeConstructor),
+   addField( "alwaysImportMesh", TypeRealString, Offset(mOptions.alwaysImportMesh, TSShapeConstructor),
       "TAB separated patterns of meshes to import even if in neverImportMesh list. No effect for DTS files.\n"
       "Torque allows unwanted meshes in COLLADA (.dae) files to to be ignored "
       "during import. This field contains a TAB separated list of patterns to "
@@ -239,7 +239,7 @@ void TSShapeConstructor::initPersistFields()
       "}\n"
       "@endtsexample" );
 
-   addField( "neverImportMesh", TypeRealString, Offset(mOptions.mNeverImportMesh, TSShapeConstructor),
+   addField( "neverImportMesh", TypeRealString, Offset(mOptions.neverImportMesh, TSShapeConstructor),
       "TAB separated patterns of meshes to ignore on loading. No effect for DTS files.\n"
       "Torque allows unwanted meshes in COLLADA (.dae) files to to be ignored "
       "during import. This field contains a TAB separated list of patterns to "
@@ -247,21 +247,21 @@ void TSShapeConstructor::initPersistFields()
       "not be imported (unless it matches the alwaysImportMesh list.\n"
       "@see alwaysImportMesh" );
 
-   addField( "ignoreNodeScale", TypeBool, Offset(mOptions.mIgnoreNodeScale, TSShapeConstructor),
+   addField( "ignoreNodeScale", TypeBool, Offset(mOptions.ignoreNodeScale, TSShapeConstructor),
       "Ignore <scale> elements inside COLLADA <node>s. No effect for DTS files.\n"
       "This field is a workaround for certain exporters that generate bad node "
       "scaling, and is not usually required." );
 
-   addField( "adjustCenter", TypeBool, Offset(mOptions.mAdjustCenter, TSShapeConstructor),
+   addField( "adjustCenter", TypeBool, Offset(mOptions.adjustCenter, TSShapeConstructor),
       "Translate COLLADA model on import so the origin is at the center. No effect for DTS files." );
 
-   addField( "adjustFloor", TypeBool, Offset(mOptions.mAdjustFloor, TSShapeConstructor),
+   addField( "adjustFloor", TypeBool, Offset(mOptions.adjustFloor, TSShapeConstructor),
       "Translate COLLADA model on import so origin is at the (Z axis) bottom of the model. No effect for DTS files.\n"
       "This can be used along with adjustCenter to have the origin at the "
       "center of the bottom of the model.\n"
       "@see adjustCenter" );
 
-   addField( "forceUpdateMaterials", TypeBool, Offset(mOptions.mForceUpdateMaterials, TSShapeConstructor),
+   addField( "forceUpdateMaterials", TypeBool, Offset(mOptions.forceUpdateMaterials, TSShapeConstructor),
       "Forces update of the materials.cs file in the same folder as the COLLADA "
       "(.dae) file, even if Materials already exist. No effect for DTS files.\n"
       "Normally only Materials that are not already defined are written to materials.cs." );
@@ -482,7 +482,7 @@ bool TSShapeConstructor::writeField(StringTableEntry fieldname, const char *valu
          return ret;                                                 \
       }                                                              \
    }                                                                 \
-   TSShape::Node* var = var##Index < 0 ? NULL : &(mShape->mNodes[var##Index]); \
+   TSShape::Node* var = var##Index < 0 ? NULL : &(mShape->nodes[var##Index]); \
    TORQUE_UNUSED(var##Index);                                        \
    TORQUE_UNUSED(var)
 
@@ -495,7 +495,7 @@ bool TSShapeConstructor::writeField(StringTableEntry fieldname, const char *valu
          "node '%s'", name);                                         \
       return ret;                                                    \
    }                                                                 \
-   TSShape::Node* var = &(mShape->mNodes[var##Index]);                \
+   TSShape::Node* var = &(mShape->nodes[var##Index]);                \
    TORQUE_UNUSED(var##Index);                                        \
    TORQUE_UNUSED(var)
 
@@ -508,7 +508,7 @@ bool TSShapeConstructor::writeField(StringTableEntry fieldname, const char *valu
          "object '%s'", name);                                       \
       return ret;                                                    \
    }                                                                 \
-   TSShape::Object* var = &(mShape->mObjects[var##Index]);            \
+   TSShape::Object* var = &(mShape->objects[var##Index]);            \
    TORQUE_UNUSED(var##Index);                                        \
    TORQUE_UNUSED(var)
 
@@ -531,7 +531,7 @@ bool TSShapeConstructor::writeField(StringTableEntry fieldname, const char *valu
          "sequence named '%s'", name);                               \
       return ret;                                                    \
    }                                                                 \
-   TSShape::Sequence* var = &(mShape->mSequences[var##Index]);        \
+   TSShape::Sequence* var = &(mShape->sequences[var##Index]);        \
    TORQUE_UNUSED(var##Index);                                        \
    TORQUE_UNUSED(var);
 
@@ -695,7 +695,7 @@ DefineTSShapeConstructorMethod( getNodeCount, S32, (),,
    "%count = %this.getNodeCount();\n"
    "@endtsexample\n" )
 {
-   return mShape->mNodes.size();
+   return mShape->nodes.size();
 }}
 
 DefineTSShapeConstructorMethod( getNodeIndex, S32, ( const char* name ),,
@@ -723,8 +723,8 @@ DefineTSShapeConstructorMethod( getNodeName, const char*, ( S32 index ),,
    "   echo(%i SPC %this.getNodeName(%i));\n"
    "@endtsexample\n" )
 {
-   CHECK_INDEX_IN_RANGE( getNodeName, index, mShape->mNodes.size(), "" );
-   return mShape->getName( mShape->mNodes[index].nameIndex );
+   CHECK_INDEX_IN_RANGE( getNodeName, index, mShape->nodes.size(), "" );
+   return mShape->getName( mShape->nodes[index].nameIndex );
 }}
 
 DefineTSShapeConstructorMethod( getNodeParentName, const char*, ( const char* name ),,
@@ -742,7 +742,7 @@ DefineTSShapeConstructorMethod( getNodeParentName, const char*, ( const char* na
    if ( node->parentIndex < 0 )
       return "";
    else
-      return mShape->getName( mShape->mNodes[node->parentIndex].nameIndex );
+      return mShape->getName( mShape->nodes[node->parentIndex].nameIndex );
 }}
 
 DefineTSShapeConstructorMethod( setNodeParent, bool, ( const char* name, const char* parentName ),,
@@ -814,7 +814,7 @@ DefineTSShapeConstructorMethod( getNodeChildName, const char*, ( const char* nam
    mShape->getNodeChildren( nodeIndex, nodeChildren );
    CHECK_INDEX_IN_RANGE( getNodeChildName, index, nodeChildren.size(), "" );
 
-   return mShape->getName( mShape->mNodes[nodeChildren[index]].nameIndex );
+   return mShape->getName( mShape->nodes[nodeChildren[index]].nameIndex );
 }}
 
 DefineTSShapeConstructorMethod( getNodeObjectCount, S32, ( const char* name ),,
@@ -852,7 +852,7 @@ DefineTSShapeConstructorMethod( getNodeObjectName, const char*, ( const char* na
    mShape->getNodeObjects( nodeIndex, nodeObjects );
    CHECK_INDEX_IN_RANGE( getNodeObjectName, index, nodeObjects.size(), "" );
 
-   return mShape->getName( mShape->mObjects[nodeObjects[index]].nameIndex );
+   return mShape->getName( mShape->objects[nodeObjects[index]].nameIndex );
 }}
 
 DefineTSShapeConstructorMethod( getNodeTransform, TransformF, ( const char* name, bool isWorld ), ( false ),
@@ -884,8 +884,8 @@ DefineTSShapeConstructorMethod( getNodeTransform, TransformF, ( const char* name
    else
    {
       // Local transform
-      pos = mShape->mDefaultTranslations[nodeIndex];
-      const Quat16& q16 = mShape->mDefaultRotations[nodeIndex];
+      pos = mShape->defaultTranslations[nodeIndex];
+      const Quat16& q16 = mShape->defaultRotations[nodeIndex];
       aa.set( q16.getQuatF() );
    }
 
@@ -1067,7 +1067,7 @@ DefineTSShapeConstructorMethod( getObjectCount, S32, (),, (), 0,
    "%count = %this.getObjectCount();\n"
    "@endtsexample\n" )
 {
-   return mShape->mObjects.size();
+   return mShape->objects.size();
 }}
 
 DefineTSShapeConstructorMethod( getObjectName, const char*, ( S32 index ),,
@@ -1082,9 +1082,9 @@ DefineTSShapeConstructorMethod( getObjectName, const char*, ( S32 index ),,
    "   echo( %i SPC %this.getObjectName( %i ) );\n"
    "@endtsexample\n" )
 {
-   CHECK_INDEX_IN_RANGE( getObjectName, index, mShape->mObjects.size(), "" );
+   CHECK_INDEX_IN_RANGE( getObjectName, index, mShape->objects.size(), "" );
 
-   return mShape->getName( mShape->mObjects[index].nameIndex );
+   return mShape->getName( mShape->objects[index].nameIndex );
 }}
 
 DefineTSShapeConstructorMethod( getObjectIndex, S32, ( const char* name ),,
@@ -1113,7 +1113,7 @@ DefineTSShapeConstructorMethod( getObjectNode, const char*, ( const char* name )
    if ( obj->nodeIndex < 0 )
       return "";
    else
-      return mShape->getName( mShape->mNodes[obj->nodeIndex].nameIndex );
+      return mShape->getName( mShape->nodes[obj->nodeIndex].nameIndex );
 }}
 
 DefineTSShapeConstructorMethod( setObjectNode, bool, ( const char* objName, const char* nodeName ),,
@@ -1218,7 +1218,7 @@ DefineTSShapeConstructorMethod( getMeshName, const char*, ( const char* name, S3
 
    static const U32 bufSize = 256;
    char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer, bufSize, "%s %d", name, (S32)mShape->mDetails[objectDetails[index]].size);
+   dSprintf(returnBuffer, bufSize, "%s %d", name, (S32)mShape->details[objectDetails[index]].size);
    return returnBuffer;
 }}
 
@@ -1243,7 +1243,7 @@ DefineTSShapeConstructorMethod( getMeshSize, S32, ( const char* name, S32 index 
 
    CHECK_INDEX_IN_RANGE( getMeshName, index, objectDetails.size(), -1 );
 
-   return (S32)mShape->mDetails[objectDetails[index]].size;
+   return (S32)mShape->details[objectDetails[index]].size;
 }}
 
 DefineTSShapeConstructorMethod( setMeshSize, bool, ( const char* name, S32 size ),,
@@ -1327,9 +1327,9 @@ DefineTSShapeConstructorMethod( getMeshMaterial, const char*, ( const char* name
    GET_MESH( getMeshMaterial, mesh, name, "" );
 
    // Return the name of the first material attached to this mesh
-   S32 matIndex = mesh->mPrimitives[0].matIndex & TSDrawPrimitive::MaterialMask;
-   if ((matIndex >= 0) && (matIndex < mShape->mMaterialList->size()))
-      return mShape->mMaterialList->getMaterialName( matIndex );
+   S32 matIndex = mesh->primitives[0].matIndex & TSDrawPrimitive::MaterialMask;
+   if ((matIndex >= 0) && (matIndex < mShape->materialList->size()))
+      return mShape->materialList->getMaterialName( matIndex );
    else
       return "";
 }}
@@ -1351,23 +1351,23 @@ DefineTSShapeConstructorMethod( setMeshMaterial, bool, ( const char* meshName, c
 
    // Check if this material is already in the shape
    S32 matIndex;
-   for ( matIndex = 0; matIndex < mShape->mMaterialList->size(); matIndex++ )
+   for ( matIndex = 0; matIndex < mShape->materialList->size(); matIndex++ )
    {
-      if ( dStrEqual( matName, mShape->mMaterialList->getMaterialName( matIndex ) ) )
+      if ( dStrEqual( matName, mShape->materialList->getMaterialName( matIndex ) ) )
          break;
    }
-   if ( matIndex == mShape->mMaterialList->size() )
+   if ( matIndex == mShape->materialList->size() )
    {
       // Add a new material to the shape
       U32 flags = TSMaterialList::S_Wrap | TSMaterialList::T_Wrap;
-      mShape->mMaterialList->push_back( matName, flags );
+      mShape->materialList->push_back( matName, flags );
    }
 
    // Set this material for all primitives in the mesh
-   for ( S32 i = 0; i < mesh->mPrimitives.size(); i++ )
+   for ( S32 i = 0; i < mesh->primitives.size(); i++ )
    {
-      U32 matType = mesh->mPrimitives[i].matIndex & ( TSDrawPrimitive::TypeMask | TSDrawPrimitive::Indexed );
-      mesh->mPrimitives[i].matIndex = ( matType | matIndex );
+      U32 matType = mesh->primitives[i].matIndex & ( TSDrawPrimitive::TypeMask | TSDrawPrimitive::Indexed );
+      mesh->primitives[i].matIndex = ( matType | matIndex );
    }
 
    ADD_TO_CHANGE_SET();
@@ -1432,7 +1432,7 @@ DefineTSShapeConstructorMethod( getBounds, Box3F, (),,
    "Get the bounding box for the shape.\n"
    "@return Bounding box \"minX minY minZ maxX maxY maxZ\"" )
 {
-   return mShape->mBounds;
+   return mShape->bounds;
 }}
 
 DefineTSShapeConstructorMethod( setBounds, bool, ( Box3F bbox ),,
@@ -1444,10 +1444,10 @@ DefineTSShapeConstructorMethod( setBounds, bool, ( Box3F bbox ),,
    // Set shape bounds
    TSShape* shape = mShape;
 
-   shape->mBounds = bbox;
-   shape->mBounds.getCenter( &shape->mCenter );
-   shape->mRadius = ( shape->mBounds.maxExtents - shape->mCenter ).len();
-   shape->mTubeRadius = shape->mRadius;
+   shape->bounds = bbox;
+   shape->bounds.getCenter( &shape->center );
+   shape->radius = ( shape->bounds.maxExtents - shape->center ).len();
+   shape->tubeRadius = shape->radius;
 
    ADD_TO_CHANGE_SET();
    return true;
@@ -1459,7 +1459,7 @@ DefineTSShapeConstructorMethod( getDetailLevelCount, S32, (),, (), 0,
    "Get the total number of detail levels in the shape.\n"
    "@return the number of detail levels in the shape\n" )
 {
-   return mShape->mDetails.size();
+   return mShape->details.size();
 }}
 
 DefineTSShapeConstructorMethod( getDetailLevelName, const char*, ( S32 index ),,
@@ -1474,9 +1474,9 @@ DefineTSShapeConstructorMethod( getDetailLevelName, const char*, ( S32 index ),,
    "   echo( %i SPC %this.getDetailLevelName( %i ) );\n"
    "@endtsexample\n" )
 {
-   CHECK_INDEX_IN_RANGE( getDetailLevelName, index, mShape->mDetails.size(), "" );
+   CHECK_INDEX_IN_RANGE( getDetailLevelName, index, mShape->details.size(), "" );
 
-   return mShape->getName(mShape->mDetails[index].nameIndex);
+   return mShape->getName(mShape->details[index].nameIndex);
 }}
 
 DefineTSShapeConstructorMethod( getDetailLevelSize, S32, ( S32 index),,
@@ -1491,9 +1491,9 @@ DefineTSShapeConstructorMethod( getDetailLevelSize, S32, ( S32 index),,
    "   echo( \"Detail\" @ %i @ \" has size \" @ %this.getDetailLevelSize( %i ) );\n"
    "@endtsexample\n" )
 {
-   CHECK_INDEX_IN_RANGE( getDetailLevelSize, index, mShape->mDetails.size(), 0 );
+   CHECK_INDEX_IN_RANGE( getDetailLevelSize, index, mShape->details.size(), 0 );
 
-   return (S32)mShape->mDetails[index].size;
+   return (S32)mShape->details[index].size;
 }}
 
 DefineTSShapeConstructorMethod( getDetailLevelIndex, S32, ( S32 size ),,
@@ -1568,9 +1568,9 @@ DefineTSShapeConstructorMethod( getImposterDetailLevel, S32, (),, (), -1,
    "@return imposter detail level index, or -1 if the shape does not use "
    "imposters.\n\n" )
 {
-   for ( S32 i = 0; i < mShape->mDetails.size(); i++ )
+   for ( S32 i = 0; i < mShape->details.size(); i++ )
    {
-      if ( mShape->mDetails[i].subShapeNum < 0 )
+      if ( mShape->details[i].subShapeNum < 0 )
          return i;
    }
    return -1;
@@ -1598,10 +1598,10 @@ DefineTSShapeConstructorMethod( getImposterSettings, const char*, ( S32 index ),
    "   echo( \"Imposter settings: \" @ %this.getImposterSettings( %index ) );\n"
    "@endtsexample\n" )
 {
-   CHECK_INDEX_IN_RANGE( getImposterSettings, index, mShape->mDetails.size(), "" );
+   CHECK_INDEX_IN_RANGE( getImposterSettings, index, mShape->details.size(), "" );
 
    // Return information about the detail level
-   const TSShape::Detail& det = mShape->mDetails[index];
+   const TSShape::Detail& det = mShape->details[index];
 
    static const U32 bufSize = 512;
    char* returnBuffer = Con::getReturnBuffer(bufSize);
@@ -1672,7 +1672,7 @@ DefineTSShapeConstructorMethod( getSequenceCount, S32, (),, (), 0,
    "Get the total number of sequences in the shape.\n"
    "@return the number of sequences in the shape\n\n" )
 {
-   return mShape->mSequences.size();
+   return mShape->sequences.size();
 }}
 
 DefineTSShapeConstructorMethod( getSequenceIndex, S32, ( const char* name),,
@@ -1701,9 +1701,9 @@ DefineTSShapeConstructorMethod( getSequenceName, const char*, ( S32 index ),,
    "   echo( %i SPC %this.getSequenceName( %i ) );\n"
    "@endtsexample\n" )
 {
-   CHECK_INDEX_IN_RANGE( getSequenceName, index, mShape->mSequences.size(), "" );
+   CHECK_INDEX_IN_RANGE( getSequenceName, index, mShape->sequences.size(), "" );
 
-   return mShape->getName( mShape->mSequences[index].nameIndex );
+   return mShape->getName( mShape->sequences[index].nameIndex );
 }}
 
 DefineTSShapeConstructorMethod( getSequenceSource, const char*, ( const char* name ),,
@@ -1792,12 +1792,12 @@ DefineTSShapeConstructorMethod( getSequenceGroundSpeed, const char*, ( const cha
    Point3F trans(0,0,0), rot(0,0,0);
    if ( seq->numGroundFrames > 0 )
    {
-      const Point3F& p1 = mShape->mGroundTranslations[seq->firstGroundFrame];
-      const Point3F& p2 = mShape->mGroundTranslations[seq->firstGroundFrame + 1];
+      const Point3F& p1 = mShape->groundTranslations[seq->firstGroundFrame];
+      const Point3F& p2 = mShape->groundTranslations[seq->firstGroundFrame + 1];
       trans = p2 - p1;
 
-      QuatF r1 = mShape->mGroundRotations[seq->firstGroundFrame].getQuatF();
-      QuatF r2 = mShape->mGroundRotations[seq->firstGroundFrame + 1].getQuatF();
+      QuatF r1 = mShape->groundRotations[seq->firstGroundFrame].getQuatF();
+      QuatF r2 = mShape->groundRotations[seq->firstGroundFrame + 1].getQuatF();
       r2 -= r1;
 
       MatrixF mat;
@@ -2037,7 +2037,7 @@ DefineTSShapeConstructorMethod( getTrigger, const char*, ( const char* name, S32
 
    CHECK_INDEX_IN_RANGE( getTrigger, index, seq->numTriggers, "" );
 
-   const TSShape::Trigger& trig = mShape->mTriggers[seq->firstTrigger + index];
+   const TSShape::Trigger& trig = mShape->triggers[seq->firstTrigger + index];
    S32 frame = trig.pos * seq->numKeyframes;
    S32 state = getBinLog2(trig.state & TSShape::Trigger::StateMask) + 1;
    if (!(trig.state & TSShape::Trigger::StateOn))
@@ -2144,9 +2144,9 @@ void TSShapeConstructor::ChangeSet::write(TSShape* shape, Stream& stream, const 
    // Remove all __backup__ sequences (used during Shape Editing)
    if (shape)
    {
-      for (S32 i = 0; i < shape->mSequences.size(); i++)
+      for (S32 i = 0; i < shape->sequences.size(); i++)
       {
-         const char* seqName = shape->getName( shape->mSequences[i].nameIndex );
+         const char* seqName = shape->getName( shape->sequences[i].nameIndex );
          if ( dStrStartsWith( seqName, "__backup__" ) )
          {
             Command cmd( "removeSequence" );

--- a/Engine/source/ts/tsShapeEdit.cpp
+++ b/Engine/source/ts/tsShapeEdit.cpp
@@ -45,8 +45,8 @@ S32 TSShape::addName(const String& name)
    if (index >= 0)
       return index;
 
-   mNames.push_back(StringTable->insert(name));
-   return mNames.size()-1;
+   names.push_back(StringTable->insert(name));
+   return names.size()-1;
 }
 
 void TSShape::updateSmallestVisibleDL()
@@ -55,14 +55,14 @@ void TSShape::updateSmallestVisibleDL()
    mSmallestVisibleDL = -1;
    mSmallestVisibleSize = F32_MAX;
    F32 maxSize = 0.0f;
-   for (S32 i = 0; i < mDetails.size(); i++)
+   for (S32 i = 0; i < details.size(); i++)
    {
-      maxSize = getMax( maxSize, mDetails[i].size );
+      maxSize = getMax( maxSize, details[i].size );
 
-      if ((mDetails[i].size >= 0) && (mDetails[i].size < mSmallestVisibleSize))
+      if ((details[i].size >= 0) && (details[i].size < mSmallestVisibleSize))
       {
          mSmallestVisibleDL = i;
-         mSmallestVisibleSize = mDetails[i].size;
+         mSmallestVisibleSize = details[i].size;
       }
    }
 
@@ -73,20 +73,20 @@ void TSShape::updateSmallestVisibleDL()
       F32 pixelSize = (F32)l;
       S32 dl = -1;
 
-      for ( U32 d=0; d < mDetails.size(); d++ )
+      for ( U32 d=0; d < details.size(); d++ )
       {
          // Break when we get to hidden detail 
          // levels like collision shapes.
-         if ( mDetails[d].size < 0 )
+         if ( details[d].size < 0 )
             break;
 
-         if ( pixelSize > mDetails[d].size )
+         if ( pixelSize > details[d].size )
          {
             dl = d;
             break;
          }
 
-         if ( d + 1 >= mDetails.size() || mDetails[d+1].size < 0 )
+         if ( d + 1 >= details.size() || details[d+1].size < 0 )
          {
             // We've run out of details and haven't found anything?
             // Let's just grab this one.
@@ -99,8 +99,8 @@ void TSShape::updateSmallestVisibleDL()
       F32 intraDL = 0;
       if ( dl > -1 )
       {
-         F32 curSize = mDetails[dl].size;
-         F32 nextSize = dl == 0 ? 2.0f * curSize : mDetails[dl - 1].size;
+         F32 curSize = details[dl].size;
+         F32 nextSize = dl == 0 ? 2.0f * curSize : details[dl - 1].size;
          intraDL = mClampF( nextSize - curSize > 0.01f ? (pixelSize - curSize) / (nextSize - curSize) : 1.0f, 0, 1 );
       }
 
@@ -113,7 +113,7 @@ void TSShape::updateSmallestVisibleDL()
    // See setDetailFromDistance().
    //
    mUseDetailFromScreenError =   mSmallestVisibleDL >= 0 && 
-                                 mDetails.first().maxError >= 0;
+                                 details.first().maxError >= 0;
 }
 
 S32 TSShape::addDetail(const String& dname, S32 size, S32 subShapeNum)
@@ -122,20 +122,20 @@ S32 TSShape::addDetail(const String& dname, S32 size, S32 subShapeNum)
 
    // Check if this detail size has already been added
    S32 index;
-   for (index = 0; index < mDetails.size(); index++)
+   for (index = 0; index < details.size(); index++)
    {
-      if ((mDetails[index].size == size) &&
-         (mDetails[index].subShapeNum == subShapeNum) &&
-         (mDetails[index].nameIndex == nameIndex))
+      if ((details[index].size == size) &&
+         (details[index].subShapeNum == subShapeNum) &&
+         (details[index].nameIndex == nameIndex))
          return index;
-      if (mDetails[index].size < size)
+      if (details[index].size < size)
          break;
    }
 
    // Create a new detail level at the right index, so array
    // remains sorted by detail size (from largest to smallest)
-   mDetails.insert(index);
-   TSShape::Detail &detail = mDetails[index];
+   details.insert(index);
+   TSShape::Detail &detail = details[index];
 
    // Clear the detail to ensure no garbage values
    // are left in any vars we don't set.
@@ -151,15 +151,15 @@ S32 TSShape::addDetail(const String& dname, S32 size, S32 subShapeNum)
    detail.polyCount = 0;
 
    // Resize alpha vectors
-   mAlphaIn.increment();
-   mAlphaOut.increment();
+   alphaIn.increment();
+   alphaOut.increment();
 
    // Fixup objectDetailNum in other detail levels
-   for (S32 i = index+1; i < mDetails.size(); i++)
+   for (S32 i = index+1; i < details.size(); i++)
    {
-      if ((mDetails[i].subShapeNum >= 0) &&
-         ((subShapeNum == -1) || (mDetails[i].subShapeNum == subShapeNum)))
-         mDetails[i].objectDetailNum++;
+      if ((details[i].subShapeNum >= 0) &&
+         ((subShapeNum == -1) || (details[i].subShapeNum == subShapeNum)))
+         details[i].objectDetailNum++;
    }
 
    // Update smallest visible detail
@@ -179,7 +179,7 @@ S32 TSShape::addImposter(const String& cachePath, S32 size, S32 numEquatorSteps,
    {
       // Size is in use. If the detail is already an imposter, we can just change
       // the settings, otherwise quit
-      if ( mDetails[detIndex].subShapeNum >= 0 )
+      if ( details[detIndex].subShapeNum >= 0 )
       {
          Con::errorf( "TSShape::addImposter: A non-billboard detail already "
             "exists at size %d", size );
@@ -190,16 +190,16 @@ S32 TSShape::addImposter(const String& cachePath, S32 size, S32 numEquatorSteps,
    {
       // Size is not in use. If an imposter already exists, change its size, otherwise
       // create a new detail
-      for ( detIndex = 0; detIndex < mDetails.size(); ++detIndex )
+      for ( detIndex = 0; detIndex < details.size(); ++detIndex )
       {
-         if ( mDetails[detIndex].subShapeNum < 0 )
+         if ( details[detIndex].subShapeNum < 0 )
          {
             // Change the imposter detail size
-            setDetailSize( mDetails[detIndex].size, size );
+            setDetailSize( details[detIndex].size, size );
             break;
          }
       }
-      if ( detIndex == mDetails.size() )
+      if ( detIndex == details.size() )
       {
          isNewDetail = true;
          detIndex = addDetail( "bbDetail", size, -1 );
@@ -207,7 +207,7 @@ S32 TSShape::addImposter(const String& cachePath, S32 size, S32 numEquatorSteps,
    }
 
    // Now set the billboard properties.
-   Detail &detail = mDetails[detIndex];
+   Detail &detail = details[detIndex];
 
    // In prior to DTS version 26 we would pack the autobillboard
    // into this single 32bit value.  This was prone to overflows
@@ -228,14 +228,14 @@ S32 TSShape::addImposter(const String& cachePath, S32 size, S32 numEquatorSteps,
    if ( isNewDetail )
    {
       // Add NULL meshes for this detail
-      for ( S32 iObj = 0; iObj < mObjects.size(); ++iObj )
+      for ( S32 iObj = 0; iObj < objects.size(); ++iObj )
       {
-         if ( detIndex < mObjects[iObj].numMeshes )
+         if ( detIndex < objects[iObj].numMeshes )
          {
-            mObjects[iObj].numMeshes++;
-            mMeshes.insert( mObjects[iObj].startMeshIndex + detIndex, NULL );
-            for (S32 j = iObj + 1; j < mObjects.size(); ++j )
-               mObjects[j].startMeshIndex++;
+            objects[iObj].numMeshes++;
+            meshes.insert( objects[iObj].startMeshIndex + detIndex, NULL );
+            for (S32 j = iObj + 1; j < objects.size(); ++j )
+               objects[j].startMeshIndex++;
          }
       }
 
@@ -243,15 +243,15 @@ S32 TSShape::addImposter(const String& cachePath, S32 size, S32 numEquatorSteps,
       if ( GFXDevice::devicePresent() )
          setupBillboardDetails( cachePath );
 
-      while ( mDetailCollisionAccelerators.size() < mDetails.size() )
-         mDetailCollisionAccelerators.push_back( NULL );
+      while ( detailCollisionAccelerators.size() < details.size() )
+         detailCollisionAccelerators.push_back( NULL );
    }
    else
    {
-      if ( mBillboardDetails.size() && GFXDevice::devicePresent() )
+      if ( billboardDetails.size() && GFXDevice::devicePresent() )
       {
-         delete mBillboardDetails[detIndex];
-         mBillboardDetails[detIndex] = new TSLastDetail(
+         delete billboardDetails[detIndex];
+         billboardDetails[detIndex] = new TSLastDetail(
                                           this,
                                           cachePath,
                                           detail.bbEquatorSteps,
@@ -261,7 +261,7 @@ S32 TSShape::addImposter(const String& cachePath, S32 size, S32 numEquatorSteps,
                                           detail.bbDetailLevel,
                                           detail.bbDimension );
 
-         mBillboardDetails[detIndex]->update( true );
+         billboardDetails[detIndex]->update( true );
       }
    }
 
@@ -272,41 +272,41 @@ bool TSShape::removeImposter()
 {
    // Find the imposter detail level
    S32 detIndex;
-   for ( detIndex = 0; detIndex < mDetails.size(); ++detIndex )
+   for ( detIndex = 0; detIndex < details.size(); ++detIndex )
    {
-      if ( mDetails[detIndex].subShapeNum < 0 )
+      if ( details[detIndex].subShapeNum < 0 )
          break;
    }
 
-   if ( detIndex == mDetails.size() )
+   if ( detIndex == details.size() )
    {
       Con::errorf( "TSShape::removeImposter: No imposter detail level found in shape" );
       return false;
    }
 
    // Remove the detail level
-   mDetails.erase( detIndex );
+   details.erase( detIndex );
 
-   if ( detIndex < mBillboardDetails.size() )
+   if ( detIndex < billboardDetails.size() )
    {
       // Delete old textures
-      TSLastDetail* bb = mBillboardDetails[detIndex];
+      TSLastDetail* bb = billboardDetails[detIndex];
       bb->deleteImposterCacheTextures();
-      delete mBillboardDetails[detIndex];
+      delete billboardDetails[detIndex];
    }
-   mBillboardDetails.clear();
+   billboardDetails.clear();
 
-   mDetailCollisionAccelerators.erase( detIndex );
+   detailCollisionAccelerators.erase( detIndex );
 
    // Remove the (NULL) meshes from each object
-   for ( S32 iObj = 0; iObj < mObjects.size(); ++iObj )
+   for ( S32 iObj = 0; iObj < objects.size(); ++iObj )
    {
-      if ( detIndex < mObjects[iObj].numMeshes )
+      if ( detIndex < objects[iObj].numMeshes )
       {
-         mObjects[iObj].numMeshes--;
-         mMeshes.erase( mObjects[iObj].startMeshIndex + detIndex );
-         for (S32 j = iObj + 1; j < mObjects.size(); ++j )
-            mObjects[j].startMeshIndex--;
+         objects[iObj].numMeshes--;
+         meshes.erase( objects[iObj].startMeshIndex + detIndex );
+         for (S32 j = iObj + 1; j < objects.size(); ++j )
+            objects[j].startMeshIndex--;
       }
    }
 
@@ -339,19 +339,19 @@ bool TSShape::removeName(const String& name)
 {
    // Check if the name is still in use
    S32 nameIndex = findName(name);
-   if ((findByName(mNodes, nameIndex) >= 0)      ||
-       (findByName(mObjects, nameIndex) >= 0)    ||
-       (findByName(mSequences, nameIndex) >= 0)  ||
-       (findByName(mDetails, nameIndex) >= 0))
+   if ((findByName(nodes, nameIndex) >= 0)      ||
+       (findByName(objects, nameIndex) >= 0)    ||
+       (findByName(sequences, nameIndex) >= 0)  ||
+       (findByName(details, nameIndex) >= 0))
        return false;
 
    // Remove the name, then update nameIndex for affected elements
-   mNames.erase(nameIndex);
+   names.erase(nameIndex);
 
-   adjustForNameRemoval(mNodes, nameIndex);
-   adjustForNameRemoval(mObjects, nameIndex);
-   adjustForNameRemoval(mSequences, nameIndex);
-   adjustForNameRemoval(mDetails, nameIndex);
+   adjustForNameRemoval(nodes, nameIndex);
+   adjustForNameRemoval(objects, nameIndex);
+   adjustForNameRemoval(sequences, nameIndex);
+   adjustForNameRemoval(details, nameIndex);
 
    return true;
 }
@@ -387,22 +387,22 @@ template<class T> bool doRename(TSShape* shape, Vector<T>& group, const String& 
 
 bool TSShape::renameNode(const String& oldName, const String& newName)
 {
-   return doRename(this, mNodes, oldName, newName);
+   return doRename(this, nodes, oldName, newName);
 }
 
 bool TSShape::renameObject(const String& oldName, const String& newName)
 {
-   return doRename(this, mObjects, oldName, newName);
+   return doRename(this, objects, oldName, newName);
 }
 
 bool TSShape::renameDetail(const String& oldName, const String& newName)
 {
-   return doRename(this, mDetails, oldName, newName);
+   return doRename(this, details, oldName, newName);
 }
 
 bool TSShape::renameSequence(const String& oldName, const String& newName)
 {
-   return doRename(this, mSequences, oldName, newName);
+   return doRename(this, sequences, oldName, newName);
 }
 
 //-----------------------------------------------------------------------------
@@ -410,7 +410,7 @@ bool TSShape::renameSequence(const String& oldName, const String& newName)
 bool TSShape::addNode(const String& name, const String& parentName, const Point3F& pos, const QuatF& rot)
 {
    // Check that adding this node would not exceed the maximum count
-   if (mNodes.size() >= MAX_TS_SET_SIZE)
+   if (nodes.size() >= MAX_TS_SET_SIZE)
    {
       Con::errorf("TSShape::addNode: Cannot add node, shape already has maximum (%d) nodes", MAX_TS_SET_SIZE);
       return false;
@@ -437,18 +437,18 @@ bool TSShape::addNode(const String& name, const String& parentName, const Point3
 
    // Insert node at the end of the subshape
    S32 subShapeIndex = (parentIndex >= 0) ? getSubShapeForNode(parentIndex) : 0;
-   S32 nodeIndex = mSubShapeNumNodes[subShapeIndex];
+   S32 nodeIndex = subShapeNumNodes[subShapeIndex];
 
    // Adjust subshape node indices
-   mSubShapeNumNodes[subShapeIndex]++;
-   for (S32 i = subShapeIndex + 1; i < mSubShapeFirstNode.size(); i++)
-      mSubShapeFirstNode[i]++;
+   subShapeNumNodes[subShapeIndex]++;
+   for (S32 i = subShapeIndex + 1; i < subShapeFirstNode.size(); i++)
+      subShapeFirstNode[i]++;
 
    // Update animation sequences
-   for (S32 iSeq = 0; iSeq < mSequences.size(); iSeq++)
+   for (S32 iSeq = 0; iSeq < sequences.size(); iSeq++)
    {
       // Update animation matters arrays (new node is not animated)
-      TSShape::Sequence& seq = mSequences[iSeq];
+      TSShape::Sequence& seq = sequences[iSeq];
       seq.translationMatters.insert(nodeIndex, false);
       seq.rotationMatters.insert(nodeIndex, false);
       seq.scaleMatters.insert(nodeIndex, false);
@@ -461,34 +461,34 @@ bool TSShape::addNode(const String& name, const String& parentName, const Point3
    node.firstChild = -1;
    node.firstObject = -1;
    node.nextSibling = -1;
-   mNodes.insert(nodeIndex, node);
+   nodes.insert(nodeIndex, node);
 
    // Insert node default translation and rotation
    Quat16 rot16;
    rot16.set(rot);
-   mDefaultTranslations.insert(nodeIndex, pos);
-   mDefaultRotations.insert(nodeIndex, rot16);
+   defaultTranslations.insert(nodeIndex, pos);
+   defaultRotations.insert(nodeIndex, rot16);
 
    // Fixup node indices
-   for (S32 i = 0; i < mNodes.size(); i++)
+   for (S32 i = 0; i < nodes.size(); i++)
    {
-      if (mNodes[i].parentIndex >= nodeIndex)
-         mNodes[i].parentIndex++;
+      if (nodes[i].parentIndex >= nodeIndex)
+         nodes[i].parentIndex++;
    }
-   for (S32 i = 0; i < mObjects.size(); i++)
+   for (S32 i = 0; i < objects.size(); i++)
    {
-      if (mObjects[i].nodeIndex >= nodeIndex)
-         mObjects[i].nodeIndex++;
+      if (objects[i].nodeIndex >= nodeIndex)
+         objects[i].nodeIndex++;
    }
-   for (S32 i = 0; i < mMeshes.size(); i++)
+   for (S32 i = 0; i < meshes.size(); i++)
    {
-      if (mMeshes[i] && (mMeshes[i]->getMeshType() == TSMesh::SkinMeshType))
+      if (meshes[i] && (meshes[i]->getMeshType() == TSMesh::SkinMeshType))
       {
-         TSSkinMesh* skin = dynamic_cast<TSSkinMesh*>(mMeshes[i]);
-         for (S32 j = 0; j < skin->mBatchData.nodeIndex.size(); j++)
+         TSSkinMesh* skin = dynamic_cast<TSSkinMesh*>(meshes[i]);
+         for (S32 j = 0; j < skin->batchData.nodeIndex.size(); j++)
          {
-            if (skin->mBatchData.nodeIndex[j] >= nodeIndex)
-               skin->mBatchData.nodeIndex[j]++;
+            if (skin->batchData.nodeIndex[j] >= nodeIndex)
+               skin->batchData.nodeIndex[j]++;
          }
       }
    }
@@ -536,7 +536,7 @@ bool TSShape::removeNode(const String& name)
       return false;
    }
 
-   S32 nodeParentIndex = mNodes[nodeIndex].parentIndex;
+   S32 nodeParentIndex = nodes[nodeIndex].parentIndex;
 
    // Warn if there are objects attached to this node
    Vector<S32> nodeObjects;
@@ -545,30 +545,30 @@ bool TSShape::removeNode(const String& name)
    {
       Con::warnf("TSShape::removeNode: Node '%s' has %d objects attached, these "
          "will be reassigned to the node's parent ('%s')", name.c_str(), nodeObjects.size(),
-         ((nodeParentIndex >= 0) ? getName(mNodes[nodeParentIndex].nameIndex).c_str() : "null"));
+         ((nodeParentIndex >= 0) ? getName(nodes[nodeParentIndex].nameIndex).c_str() : "null"));
    }
 
    // Update animation sequences
-   for (S32 iSeq = 0; iSeq < mSequences.size(); iSeq++)
+   for (S32 iSeq = 0; iSeq < sequences.size(); iSeq++)
    {
-      TSShape::Sequence& seq = mSequences[iSeq];
+      TSShape::Sequence& seq = sequences[iSeq];
 
       // Remove animated node transforms
       if (seq.translationMatters.test(nodeIndex))
-         eraseStates(mNodeTranslations, seq.translationMatters, seq.baseTranslation, seq.numKeyframes, nodeIndex);
+         eraseStates(nodeTranslations, seq.translationMatters, seq.baseTranslation, seq.numKeyframes, nodeIndex);
       if (seq.rotationMatters.test(nodeIndex))
-         eraseStates(mNodeRotations, seq.rotationMatters, seq.baseRotation, seq.numKeyframes, nodeIndex);
+         eraseStates(nodeRotations, seq.rotationMatters, seq.baseRotation, seq.numKeyframes, nodeIndex);
       if (seq.scaleMatters.test(nodeIndex))
       {
          if (seq.flags & TSShape::ArbitraryScale)
          {
-            eraseStates(mNodeArbitraryScaleRots, seq.scaleMatters, seq.baseScale, seq.numKeyframes, nodeIndex);
-            eraseStates(mNodeArbitraryScaleFactors, seq.scaleMatters, seq.baseScale, seq.numKeyframes, nodeIndex);
+            eraseStates(nodeArbitraryScaleRots, seq.scaleMatters, seq.baseScale, seq.numKeyframes, nodeIndex);
+            eraseStates(nodeArbitraryScaleFactors, seq.scaleMatters, seq.baseScale, seq.numKeyframes, nodeIndex);
          }
          else if (seq.flags & TSShape::AlignedScale)
-            eraseStates(mNodeAlignedScales, seq.scaleMatters, seq.baseScale, seq.numKeyframes, nodeIndex);
+            eraseStates(nodeAlignedScales, seq.scaleMatters, seq.baseScale, seq.numKeyframes, nodeIndex);
          else
-            eraseStates(mNodeUniformScales, seq.scaleMatters, seq.baseScale, seq.numKeyframes, nodeIndex);
+            eraseStates(nodeUniformScales, seq.scaleMatters, seq.baseScale, seq.numKeyframes, nodeIndex);
       }
 
       seq.translationMatters.erase(nodeIndex);
@@ -577,48 +577,48 @@ bool TSShape::removeNode(const String& name)
    }
 
    // Remove the node
-   mNodes.erase(nodeIndex);
-   mDefaultTranslations.erase(nodeIndex);
-   mDefaultRotations.erase(nodeIndex);
+   nodes.erase(nodeIndex);
+   defaultTranslations.erase(nodeIndex);
+   defaultRotations.erase(nodeIndex);
 
    // Adjust subshape node indices
    S32 subShapeIndex = getSubShapeForNode(nodeIndex);
-   mSubShapeNumNodes[subShapeIndex]--;
-   for (S32 i = subShapeIndex + 1; i < mSubShapeFirstNode.size(); i++)
-      mSubShapeFirstNode[i]--;
+   subShapeNumNodes[subShapeIndex]--;
+   for (S32 i = subShapeIndex + 1; i < subShapeFirstNode.size(); i++)
+      subShapeFirstNode[i]--;
 
    // Fixup node parent indices
-   for (S32 i = 0; i < mNodes.size(); i++)
+   for (S32 i = 0; i < nodes.size(); i++)
    {
-      if (mNodes[i].parentIndex == nodeIndex)
-         mNodes[i].parentIndex = -1;
-      else if (mNodes[i].parentIndex > nodeIndex)
-         mNodes[i].parentIndex--;
+      if (nodes[i].parentIndex == nodeIndex)
+         nodes[i].parentIndex = -1;
+      else if (nodes[i].parentIndex > nodeIndex)
+         nodes[i].parentIndex--;
    }
    if (nodeParentIndex > nodeIndex)
       nodeParentIndex--;
 
    // Fixup object node indices, and re-assign attached objects to node's parent
-   for (S32 i = 0; i < mObjects.size(); i++)
+   for (S32 i = 0; i < objects.size(); i++)
    {
-      if (mObjects[i].nodeIndex == nodeIndex)
-         mObjects[i].nodeIndex = nodeParentIndex;
-      if (mObjects[i].nodeIndex > nodeIndex)
-         mObjects[i].nodeIndex--;
+      if (objects[i].nodeIndex == nodeIndex)
+         objects[i].nodeIndex = nodeParentIndex;
+      if (objects[i].nodeIndex > nodeIndex)
+         objects[i].nodeIndex--;
    }
 
    // Fixup skin weight node indices, and re-assign weights for deleted node to its parent
-   for (S32 i = 0; i < mMeshes.size(); i++)
+   for (S32 i = 0; i < meshes.size(); i++)
    {
-      if (mMeshes[i] && (mMeshes[i]->getMeshType() == TSMesh::SkinMeshType))
+      if (meshes[i] && (meshes[i]->getMeshType() == TSMesh::SkinMeshType))
       {
-         TSSkinMesh* skin = dynamic_cast<TSSkinMesh*>(mMeshes[i]);
-         for (S32 j = 0; j < skin->mBatchData.nodeIndex.size(); j++)
+         TSSkinMesh* skin = dynamic_cast<TSSkinMesh*>(meshes[i]);
+         for (S32 j = 0; j < skin->batchData.nodeIndex.size(); j++)
          {
-            if (skin->mBatchData.nodeIndex[j] == nodeIndex)
-               skin->mBatchData.nodeIndex[j] = nodeParentIndex;
-            if (skin->mBatchData.nodeIndex[j] > nodeIndex)
-               skin->mBatchData.nodeIndex[j]--;
+            if (skin->batchData.nodeIndex[j] == nodeIndex)
+               skin->batchData.nodeIndex[j] = nodeParentIndex;
+            if (skin->batchData.nodeIndex[j] > nodeIndex)
+               skin->batchData.nodeIndex[j]--;
          }
       }
    }
@@ -645,8 +645,8 @@ bool TSShape::setNodeTransform(const String& name, const Point3F& pos, const Qua
    }
 
    // Update initial node position and rotation
-   mDefaultTranslations[nodeIndex] = pos;
-   mDefaultRotations[nodeIndex].set(rot);
+   defaultTranslations[nodeIndex] = pos;
+   defaultRotations[nodeIndex].set(rot);
 
    return true;
 }
@@ -655,39 +655,39 @@ bool TSShape::setNodeTransform(const String& name, const Point3F& pos, const Qua
 
 S32 TSShape::addObject(const String& objName, S32 subShapeIndex)
 {
-   S32 objIndex = mSubShapeNumObjects[subShapeIndex];
+   S32 objIndex = subShapeNumObjects[subShapeIndex];
 
    // Add object to subshape
-   mSubShapeNumObjects[subShapeIndex]++;
-   for (S32 i = subShapeIndex + 1; i < mSubShapeFirstObject.size(); i++)
-      mSubShapeFirstObject[i]++;
+   subShapeNumObjects[subShapeIndex]++;
+   for (S32 i = subShapeIndex + 1; i < subShapeFirstObject.size(); i++)
+      subShapeFirstObject[i]++;
 
    TSShape::Object obj;
    obj.nameIndex = addName(objName);
    obj.nodeIndex = 0;
    obj.numMeshes = 0;
-   obj.startMeshIndex = (objIndex == 0) ? 0 : mObjects[objIndex-1].startMeshIndex + mObjects[objIndex-1].numMeshes;
+   obj.startMeshIndex = (objIndex == 0) ? 0 : objects[objIndex-1].startMeshIndex + objects[objIndex-1].numMeshes;
    obj.firstDecal = 0;
    obj.nextSibling = 0;
-   mObjects.insert(objIndex, obj);
+   objects.insert(objIndex, obj);
 
    // Add default object state
    TSShape::ObjectState state;
    state.frameIndex = 0;
    state.matFrameIndex = 0;
    state.vis = 1.0f;
-   mObjectStates.insert(objIndex, state);
+   objectStates.insert(objIndex, state);
 
    // Fixup sequences
-   for (S32 i = 0; i < mSequences.size(); i++)
-      mSequences[i].baseObjectState++;
+   for (S32 i = 0; i < sequences.size(); i++)
+      sequences[i].baseObjectState++;
 
    return objIndex;
 }
 
 void TSShape::addMeshToObject(S32 objIndex, S32 meshIndex, TSMesh* mesh)
 {
-   TSShape::Object& obj = mObjects[objIndex];
+   TSShape::Object& obj = objects[objIndex];
 
    // Pad with NULLs if required
    S32 oldNumMeshes = obj.numMeshes;
@@ -695,13 +695,13 @@ void TSShape::addMeshToObject(S32 objIndex, S32 meshIndex, TSMesh* mesh)
    {
       for (S32 i = obj.numMeshes; i < meshIndex; i++)
       {
-         mMeshes.insert(obj.startMeshIndex + i, NULL);
+         meshes.insert(obj.startMeshIndex + i, NULL);
          obj.numMeshes++;
       }
    }
 
    // Insert the new mesh
-   mMeshes.insert(obj.startMeshIndex + meshIndex, mesh);
+   meshes.insert(obj.startMeshIndex + meshIndex, mesh);
    obj.numMeshes++;
 
    // Skinned meshes are not attached to any node
@@ -709,26 +709,26 @@ void TSShape::addMeshToObject(S32 objIndex, S32 meshIndex, TSMesh* mesh)
       obj.nodeIndex = -1;
 
    // Fixup mesh indices for other objects
-   for (S32 i = 0; i < mObjects.size(); i++)
+   for (S32 i = 0; i < objects.size(); i++)
    {
-      if ((i != objIndex) && (mObjects[i].startMeshIndex >= obj.startMeshIndex))
-         mObjects[i].startMeshIndex += (obj.numMeshes - oldNumMeshes);
+      if ((i != objIndex) && (objects[i].startMeshIndex >= obj.startMeshIndex))
+         objects[i].startMeshIndex += (obj.numMeshes - oldNumMeshes);
    }
 }
 
 void TSShape::removeMeshFromObject(S32 objIndex, S32 meshIndex)
 {
-   TSShape::Object& obj = mObjects[objIndex];
+   TSShape::Object& obj = objects[objIndex];
 
    // Remove the mesh, but do not destroy it (this must be done by the caller)
-   mMeshes[obj.startMeshIndex + meshIndex] = NULL;
+   meshes[obj.startMeshIndex + meshIndex] = NULL;
 
    // Check if there are any objects remaining that have a valid mesh at this
    // detail size
    bool removeDetail = true;
-   for (S32 i = 0; i < mObjects.size(); i++)
+   for (S32 i = 0; i < objects.size(); i++)
    {
-      if ((meshIndex < mObjects[i].numMeshes) && mMeshes[mObjects[i].startMeshIndex + meshIndex])
+      if ((meshIndex < objects[i].numMeshes) && meshes[objects[i].startMeshIndex + meshIndex])
       {
          removeDetail = false;
          break;
@@ -738,17 +738,17 @@ void TSShape::removeMeshFromObject(S32 objIndex, S32 meshIndex)
    // Remove detail level if possible
    if (removeDetail)
    {
-      for (S32 i = 0; i < mObjects.size(); i++)
+      for (S32 i = 0; i < objects.size(); i++)
       {
-         if (meshIndex < mObjects[i].numMeshes)
+         if (meshIndex < objects[i].numMeshes)
          {
-            mMeshes.erase(mObjects[i].startMeshIndex + meshIndex);
-            mObjects[i].numMeshes--;
+            meshes.erase(objects[i].startMeshIndex + meshIndex);
+            objects[i].numMeshes--;
 
-            for (S32 j = 0; j < mObjects.size(); j++)
+            for (S32 j = 0; j < objects.size(); j++)
             {
-               if (mObjects[j].startMeshIndex > mObjects[i].startMeshIndex)
-                  mObjects[j].startMeshIndex--;
+               if (objects[j].startMeshIndex > objects[i].startMeshIndex)
+                  objects[j].startMeshIndex--;
             }
          }
       }
@@ -758,27 +758,27 @@ void TSShape::removeMeshFromObject(S32 objIndex, S32 meshIndex)
 
       for (S32 i = 0; i < validDetails.size(); i++)
       {
-         TSShape::Detail& detail = mDetails[validDetails[i]];
+         TSShape::Detail& detail = details[validDetails[i]];
          if (detail.objectDetailNum > meshIndex)
             detail.objectDetailNum--;
       }
 
-      mDetails.erase(validDetails[meshIndex]);
+      details.erase(validDetails[meshIndex]);
    }
 
    // Remove trailing NULL meshes from the object
    S32 oldNumMeshes = obj.numMeshes;
-   while (obj.numMeshes && !mMeshes[obj.startMeshIndex + obj.numMeshes - 1])
+   while (obj.numMeshes && !meshes[obj.startMeshIndex + obj.numMeshes - 1])
    {
-      mMeshes.erase(obj.startMeshIndex + obj.numMeshes - 1);
+      meshes.erase(obj.startMeshIndex + obj.numMeshes - 1);
       obj.numMeshes--;
    }
 
    // Fixup mesh indices for other objects
-   for (S32 i = 0; i < mObjects.size(); i++)
+   for (S32 i = 0; i < objects.size(); i++)
    {
-      if (mObjects[i].startMeshIndex > obj.startMeshIndex)
-         mObjects[i].startMeshIndex -= (oldNumMeshes - obj.numMeshes);
+      if (objects[i].startMeshIndex > obj.startMeshIndex)
+         objects[i].startMeshIndex -= (oldNumMeshes - obj.numMeshes);
    }
 }
 
@@ -805,7 +805,7 @@ bool TSShape::setObjectNode(const String& objName, const String& nodeName)
       }
    }
 
-   mObjects[objIndex].nodeIndex = nodeIndex;
+   objects[objIndex].nodeIndex = nodeIndex;
 
    return true;
 }
@@ -821,31 +821,31 @@ bool TSShape::removeObject(const String& name)
    }
 
    // Destroy all meshes in the object
-   TSShape::Object& obj = mObjects[objIndex];
+   TSShape::Object& obj = objects[objIndex];
    while ( obj.numMeshes )
    {
-      destructInPlace(mMeshes[obj.startMeshIndex + obj.numMeshes - 1]);
+      destructInPlace(meshes[obj.startMeshIndex + obj.numMeshes - 1]);
       removeMeshFromObject(objIndex, obj.numMeshes - 1);
    }
 
    // Remove the object from the shape
-   mObjects.erase(objIndex);
+   objects.erase(objIndex);
    S32 subShapeIndex = getSubShapeForObject(objIndex);
-   mSubShapeNumObjects[subShapeIndex]--;
-   for (S32 i = subShapeIndex + 1; i < mSubShapeFirstObject.size(); i++)
-      mSubShapeFirstObject[i]--;
+   subShapeNumObjects[subShapeIndex]--;
+   for (S32 i = subShapeIndex + 1; i < subShapeFirstObject.size(); i++)
+      subShapeFirstObject[i]--;
 
    // Remove the object from all sequences
-   for (S32 i = 0; i < mSequences.size(); i++)
+   for (S32 i = 0; i < sequences.size(); i++)
    {
-      TSShape::Sequence& seq = mSequences[i];
+      TSShape::Sequence& seq = sequences[i];
 
       TSIntegerSet objMatters(seq.frameMatters);
       objMatters.overlap(seq.matFrameMatters);
       objMatters.overlap(seq.visMatters);
 
       if (objMatters.test(objIndex))
-         eraseStates(mObjectStates, objMatters, seq.baseObjectState, seq.numKeyframes, objIndex);
+         eraseStates(objectStates, objMatters, seq.baseObjectState, seq.numKeyframes, objIndex);
 
       seq.frameMatters.erase(objIndex);
       seq.matFrameMatters.erase(objIndex);
@@ -876,14 +876,14 @@ TSMesh* TSShape::copyMesh( const TSMesh* srcMesh ) const
 
       // Copy skin elements
       const TSSkinMesh *srcSkin = dynamic_cast<const TSSkinMesh*>(srcMesh);
-      skin->mWeight = srcSkin->mWeight;
-      skin->mVertexIndex = srcSkin->mVertexIndex;
-      skin->mBoneIndex = srcSkin->mBoneIndex;
+      skin->weight = srcSkin->weight;
+      skin->vertexIndex = srcSkin->vertexIndex;
+      skin->boneIndex = srcSkin->boneIndex;
 
-      skin->mBatchData.nodeIndex = srcSkin->mBatchData.nodeIndex;
-      skin->mBatchData.initialTransforms = srcSkin->mBatchData.initialTransforms;
-      skin->mBatchData.initialVerts = srcSkin->mBatchData.initialVerts;
-      skin->mBatchData.initialNorms = srcSkin->mBatchData.initialNorms;
+      skin->batchData.nodeIndex = srcSkin->batchData.nodeIndex;
+      skin->batchData.initialTransforms = srcSkin->batchData.initialTransforms;
+      skin->batchData.initialVerts = srcSkin->batchData.initialVerts;
+      skin->batchData.initialNorms = srcSkin->batchData.initialNorms;
 
       mesh = static_cast<TSMesh*>(skin);
    }
@@ -900,11 +900,11 @@ TSMesh* TSShape::copyMesh( const TSMesh* srcMesh ) const
       return mesh;      // return an empty mesh
 
    // Copy mesh elements
-   mesh->mIndices = srcMesh->mIndices;
-   mesh->mPrimitives = srcMesh->mPrimitives;
-   mesh->mNumFrames = srcMesh->mNumFrames;
-   mesh->mNumMatFrames = srcMesh->mNumMatFrames;
-   mesh->mVertsPerFrame = srcMesh->mVertsPerFrame;
+   mesh->indices = srcMesh->indices;
+   mesh->primitives = srcMesh->primitives;
+   mesh->numFrames = srcMesh->numFrames;
+   mesh->numMatFrames = srcMesh->numMatFrames;
+   mesh->vertsPerFrame = srcMesh->vertsPerFrame;
    mesh->setFlags(srcMesh->getFlags());
    mesh->mHasColor = srcMesh->mHasColor;
    mesh->mHasTVert2 = srcMesh->mHasTVert2;
@@ -936,14 +936,14 @@ TSMesh* TSShape::copyMesh( const TSMesh* srcMesh ) const
    }
    else
    {
-      mesh->mVerts = srcMesh->mVerts;
-      mesh->mTVerts = srcMesh->mTVerts;
-      mesh->mTVerts2 = srcMesh->mTVerts2;
-      mesh->mColors = srcMesh->mColors;
-      mesh->mNorms = srcMesh->mNorms;
+      mesh->verts = srcMesh->verts;
+      mesh->tverts = srcMesh->tverts;
+      mesh->tverts2 = srcMesh->tverts2;
+      mesh->colors = srcMesh->colors;
+      mesh->norms = srcMesh->norms;
 
-      mesh->createTangents(mesh->mVerts, mesh->mNorms);
-      mesh->mEncodedNorms.set(NULL,0);
+      mesh->createTangents(mesh->verts, mesh->norms);
+      mesh->encodedNorms.set(NULL,0);
 
       mesh->convertToAlignedMeshData();
    }
@@ -966,11 +966,11 @@ bool TSShape::addMesh(TSMesh* mesh, const String& meshName)
    S32 objIndex = findObject(objName);
    if (objIndex < 0)
       objIndex = addObject(objName, 0);
-   AssertFatal(objIndex >= 0 && objIndex < mObjects.size(), "Invalid object index!");
+   AssertFatal(objIndex >= 0 && objIndex < objects.size(), "Invalid object index!");
 
    // Determine the subshape this object belongs to
    S32 subShapeIndex = getSubShapeForObject(objIndex);
-   AssertFatal(subShapeIndex < mSubShapeFirstObject.size(), "Could not find subshape for object!");
+   AssertFatal(subShapeIndex < subShapeFirstObject.size(), "Could not find subshape for object!");
 
    // Get the existing detail levels for the subshape
    Vector<S32> validDetails;
@@ -981,7 +981,7 @@ bool TSShape::addMesh(TSMesh* mesh, const String& meshName)
    bool newDetail = true;
    for (detIndex = 0; detIndex < validDetails.size(); detIndex++)
    {
-      const TSShape::Detail& det = mDetails[validDetails[detIndex]];
+      const TSShape::Detail& det = details[validDetails[detIndex]];
       if (detailSize >= det.size)
       {
          newDetail = (det.size != detailSize);
@@ -1002,7 +1002,7 @@ bool TSShape::addMesh(TSMesh* mesh, const String& meshName)
          detailName = "detail";
 
       S32 index = addDetail(detailName, detailSize, subShapeIndex);
-      mDetails[index].objectDetailNum = detIndex;
+      details[index].objectDetailNum = detIndex;
    }
 
    // Adding a new mesh or detail level is a bit tricky, since each
@@ -1020,10 +1020,10 @@ bool TSShape::addMesh(TSMesh* mesh, const String& meshName)
    // 2        |           |           |  2
 
    // Add meshes as required for each object
-   for (S32 i = 0; i < mSubShapeNumObjects[subShapeIndex]; i++)
+   for (S32 i = 0; i < subShapeNumObjects[subShapeIndex]; i++)
    {
-      S32 index = mSubShapeFirstObject[subShapeIndex] + i;
-      const TSShape::Object& obj = mObjects[index];
+      S32 index = subShapeFirstObject[subShapeIndex] + i;
+      const TSShape::Object& obj = objects[index];
 
       if (index == objIndex)
       {
@@ -1031,9 +1031,9 @@ bool TSShape::addMesh(TSMesh* mesh, const String& meshName)
          // if required.
          if (!newDetail && (detIndex < obj.numMeshes))
          {
-            if ( mMeshes[obj.startMeshIndex + detIndex] )
-               destructInPlace(mMeshes[obj.startMeshIndex + detIndex]);
-            mMeshes[obj.startMeshIndex + detIndex] = mesh;
+            if ( meshes[obj.startMeshIndex + detIndex] )
+               destructInPlace(meshes[obj.startMeshIndex + detIndex]);
+            meshes[obj.startMeshIndex + detIndex] = mesh;
          }
          else
             addMeshToObject(index, detIndex, mesh);
@@ -1069,16 +1069,16 @@ bool TSShape::addMesh(TSShape* srcShape, const String& srcMeshName, const String
       TSSkinMesh *srcSkin = dynamic_cast<TSSkinMesh*>(srcMesh);
 
       // Check that the source skin is compatible with our skeleton
-      Vector<S32> nodeMap(srcShape->mNodes.size());
-      for (S32 i = 0; i < srcShape->mNodes.size(); i++)
-         nodeMap.push_back( findNode( srcShape->getName(srcShape->mNodes[i].nameIndex) ) );
+      Vector<S32> nodeMap(srcShape->nodes.size());
+      for (S32 i = 0; i < srcShape->nodes.size(); i++)
+         nodeMap.push_back( findNode( srcShape->getName(srcShape->nodes[i].nameIndex) ) );
 
-      for (S32 i = 0; i < srcSkin->mBoneIndex.size(); i++)
+      for (S32 i = 0; i < srcSkin->boneIndex.size(); i++)
       {
-         S32 srcNode = srcSkin->mBoneIndex[i];
+         S32 srcNode = srcSkin->boneIndex[i];
          if (nodeMap[srcNode] == -1)
          {
-            const char* name = srcShape->getName(srcShape->mNodes[srcNode].nameIndex).c_str();
+            const char* name = srcShape->getName(srcShape->nodes[srcNode].nameIndex).c_str();
             Con::errorf("TSShape::addMesh: Skin is weighted to node (%s) that "
                "does not exist in this shape", name);
             return false;
@@ -1088,9 +1088,9 @@ bool TSShape::addMesh(TSShape* srcShape, const String& srcMeshName, const String
       TSSkinMesh *skin = dynamic_cast<TSSkinMesh*>(mesh);
 
       // Remap node indices
-      skin->mBatchData.nodeIndex = srcSkin->mBatchData.nodeIndex;
-      for (S32 i = 0; i < skin->mBatchData.nodeIndex.size(); i++)
-         skin->mBatchData.nodeIndex[i] = nodeMap[skin->mBatchData.nodeIndex[i]];
+      skin->batchData.nodeIndex = srcSkin->batchData.nodeIndex;
+      for (S32 i = 0; i < skin->batchData.nodeIndex.size(); i++)
+         skin->batchData.nodeIndex[i] = nodeMap[skin->batchData.nodeIndex[i]];
    }
 
    // Add the copied mesh to the shape
@@ -1103,23 +1103,23 @@ bool TSShape::addMesh(TSShape* srcShape, const String& srcMeshName, const String
    // Copy materials used by the source mesh (only if from a different shape)
    if (srcShape != this)
    {
-      for (S32 i = 0; i < mesh->mPrimitives.size(); i++)
+      for (S32 i = 0; i < mesh->primitives.size(); i++)
       {
-         if (!(mesh->mPrimitives[i].matIndex & TSDrawPrimitive::NoMaterial))
+         if (!(mesh->primitives[i].matIndex & TSDrawPrimitive::NoMaterial))
          {
-            S32 drawType = (mesh->mPrimitives[i].matIndex & (~TSDrawPrimitive::MaterialMask));
-            S32 srcMatIndex = mesh->mPrimitives[i].matIndex & TSDrawPrimitive::MaterialMask;
-            const String& matName = srcShape->mMaterialList->getMaterialName(srcMatIndex);
+            S32 drawType = (mesh->primitives[i].matIndex & (~TSDrawPrimitive::MaterialMask));
+            S32 srcMatIndex = mesh->primitives[i].matIndex & TSDrawPrimitive::MaterialMask;
+            const String& matName = srcShape->materialList->getMaterialName(srcMatIndex);
 
             // Add the material if it does not already exist
-            S32 destMatIndex = mMaterialList->getMaterialNameList().find_next(matName);
+            S32 destMatIndex = materialList->getMaterialNameList().find_next(matName);
             if (destMatIndex < 0)
             {
-               destMatIndex = mMaterialList->size();
-               mMaterialList->push_back(matName, srcShape->mMaterialList->getFlags(srcMatIndex));
+               destMatIndex = materialList->size();
+               materialList->push_back(matName, srcShape->materialList->getFlags(srcMatIndex));
             }
 
-            mesh->mPrimitives[i].matIndex = drawType | destMatIndex;
+            mesh->primitives[i].matIndex = drawType | destMatIndex;
          }
       }
    }
@@ -1131,15 +1131,15 @@ bool TSShape::setMeshSize(const String& meshName, S32 size)
 {
    S32 objIndex, meshIndex;
    if (!findMeshIndex(meshName, objIndex, meshIndex) ||
-      !mMeshes[mObjects[objIndex].startMeshIndex + meshIndex])
+      !meshes[objects[objIndex].startMeshIndex + meshIndex])
    {
       Con::errorf("TSShape::setMeshSize: Could not find mesh '%s'", meshName.c_str());
       return false;
    }
 
    // Remove the mesh from the object, but don't destroy it
-   TSShape::Object& obj = mObjects[objIndex];
-   TSMesh* mesh = mMeshes[obj.startMeshIndex + meshIndex];
+   TSShape::Object& obj = objects[objIndex];
+   TSMesh* mesh = meshes[obj.startMeshIndex + meshIndex];
    removeMeshFromObject(objIndex, meshIndex);
 
    // Add the mesh back at the new position
@@ -1158,15 +1158,15 @@ bool TSShape::removeMesh(const String& meshName)
 {
    S32 objIndex, meshIndex;
    if (!findMeshIndex(meshName, objIndex, meshIndex) ||
-      !mMeshes[mObjects[objIndex].startMeshIndex + meshIndex])
+      !meshes[objects[objIndex].startMeshIndex + meshIndex])
    {
       Con::errorf("TSShape::removeMesh: Could not find mesh '%s'", meshName.c_str());
       return false;
    }
 
    // Destroy and remove the mesh
-   TSShape::Object& obj = mObjects[objIndex];
-   destructInPlace(mMeshes[obj.startMeshIndex + meshIndex]);
+   TSShape::Object& obj = objects[objIndex];
+   destructInPlace(meshes[obj.startMeshIndex + meshIndex]);
    removeMeshFromObject(objIndex, meshIndex);
 
    // Remove the object if there are no meshes left
@@ -1226,20 +1226,20 @@ S32 TSShape::setDetailSize(S32 oldSize, S32 newSize)
    }
 
    // Remove this detail from the list
-   TSShape::Detail tmpDetail = mDetails[oldIndex];
+   TSShape::Detail tmpDetail = details[oldIndex];
    tmpDetail.size = newSize;
-   mDetails.erase(oldIndex);
+   details.erase(oldIndex);
 
    // Determine the new position for the detail (details are sorted by size)
    S32 newIndex = 0;
-   for ( newIndex = 0; newIndex < mDetails.size(); ++newIndex )
+   for ( newIndex = 0; newIndex < details.size(); ++newIndex )
    {
-      if ( newSize > mDetails[newIndex].size )
+      if ( newSize > details[newIndex].size )
          break;
    }
 
    // Add the detail at its new position
-   mDetails.insert( newIndex, tmpDetail );
+   details.insert( newIndex, tmpDetail );
 
    // Rename the detail so its trailing size value is correct
    {
@@ -1253,38 +1253,38 @@ S32 TSShape::setDetailSize(S32 oldSize, S32 newSize)
    if ( newIndex != oldIndex )
    {
       // Fixup details
-      for ( S32 iDet = 0; iDet < mDetails.size(); iDet++ )
+      for ( S32 iDet = 0; iDet < details.size(); iDet++ )
       {
-         if ( mDetails[iDet].subShapeNum < 0 )
+         if ( details[iDet].subShapeNum < 0 )
          {
-            if ( mDetails[iDet].bbDetailLevel == oldIndex )
-               mDetails[iDet].bbDetailLevel = newIndex;
+            if ( details[iDet].bbDetailLevel == oldIndex )
+               details[iDet].bbDetailLevel = newIndex;
          }
          else
          {
-            mDetails[iDet].objectDetailNum = iDet;
+            details[iDet].objectDetailNum = iDet;
          }
       }
 
       // Fixup Billboard details
-      _PadMoveAndTrim( mBillboardDetails, 0, mBillboardDetails.size(),
-                        mDetails.size(), oldIndex, newIndex );
+      _PadMoveAndTrim( billboardDetails, 0, billboardDetails.size(),
+                        details.size(), oldIndex, newIndex );
 
       // Now move the mesh for each object in the subshape (adding and removing
       // NULLs as appropriate)
-      for ( S32 iObj = 0; iObj < mObjects.size(); ++iObj )
+      for ( S32 iObj = 0; iObj < objects.size(); ++iObj )
       {
-         TSShape::Object& obj = mObjects[iObj];
-         S32 oldMeshCount = mMeshes.size();
+         TSShape::Object& obj = objects[iObj];
+         S32 oldMeshCount = meshes.size();
 
-         _PadMoveAndTrim( mMeshes, obj.startMeshIndex, obj.numMeshes,
-                           mDetails.size(), oldIndex, newIndex );
+         _PadMoveAndTrim( meshes, obj.startMeshIndex, obj.numMeshes,
+                           details.size(), oldIndex, newIndex );
 
-         obj.numMeshes += ( mMeshes.size() - oldMeshCount );
+         obj.numMeshes += ( meshes.size() - oldMeshCount );
 
          // Fixup startMeshIndex for remaining objects
-         for ( S32 j = iObj + 1; j < mObjects.size(); ++j )
-            mObjects[j].startMeshIndex += ( mMeshes.size() - oldMeshCount );
+         for ( S32 j = iObj + 1; j < objects.size(); ++j )
+            objects[j].startMeshIndex += ( meshes.size() - oldMeshCount );
       }
    }
 
@@ -1301,20 +1301,20 @@ bool TSShape::removeDetail( S32 size )
 {
    S32 dl = findDetailBySize( size );
 
-   if ( ( dl < 0 ) || ( dl >= mDetails.size() ) )
+   if ( ( dl < 0 ) || ( dl >= details.size() ) )
    {
       Con::errorf( "TSShape::removeDetail: Invalid detail index (%d)", dl );
       return false;
    }
 
    // Destroy and remove each mesh in the detail level
-   for ( S32 objIndex = mObjects.size()-1; objIndex >= 0; objIndex-- )
+   for ( S32 objIndex = objects.size()-1; objIndex >= 0; objIndex-- )
    {
-      TSShape::Object& obj = mObjects[objIndex];
+      TSShape::Object& obj = objects[objIndex];
       if ( dl < obj.numMeshes )
       {
-         if ( mMeshes[obj.startMeshIndex + dl] )
-            destructInPlace( mMeshes[obj.startMeshIndex + dl] );
+         if ( meshes[obj.startMeshIndex + dl] )
+            destructInPlace( meshes[obj.startMeshIndex + dl] );
          removeMeshFromObject(objIndex, dl);
 
          // Remove the object if there are no meshes left
@@ -1324,16 +1324,16 @@ bool TSShape::removeDetail( S32 size )
    }
 
    // Destroy billboard detail level
-   if ( dl < mBillboardDetails.size() )
+   if ( dl < billboardDetails.size() )
    {
-      if ( mBillboardDetails[dl] )
+      if ( billboardDetails[dl] )
       {
          // Delete old textures
-         mBillboardDetails[dl]->deleteImposterCacheTextures();
-         delete mBillboardDetails[dl];
+         billboardDetails[dl]->deleteImposterCacheTextures();
+         delete billboardDetails[dl];
      }
      
-      mBillboardDetails.erase( dl );
+      billboardDetails.erase( dl );
    }
 
    // Update smallest visible detail
@@ -1354,7 +1354,7 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
 
    if (path.getExtension().equal("dsq", String::NoCase))
    {
-      S32 oldSeqCount = mSequences.size();
+      S32 oldSeqCount = sequences.size();
 
       // DSQ source file
       char filenameBuf[1024];
@@ -1377,37 +1377,37 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
       // Rename the new sequence if required (avoid rename if name is not
       // unique (this will be fixed up later, and we don't need 2 errors about it!)
       if (oldName.isEmpty())
-         oldName = getName(mSequences.last().nameIndex);
+         oldName = getName(sequences.last().nameIndex);
       if (!oldName.equal(name))
       {
          if (findSequence(name) == -1)
          {
             // Use a dummy intermediate name since we might be renaming from an
             // existing name (and we want to rename the right sequence!)
-            mSequences.last().nameIndex = addName("__dummy__");
+            sequences.last().nameIndex = addName("__dummy__");
             renameSequence("__dummy__", name);
          }
       }
 
       // Check that sequences have unique names
       bool lastSequenceRejected = false;
-      for (S32 i = mSequences.size()-1; i >= oldSeqCount; i--)
+      for (S32 i = sequences.size()-1; i >= oldSeqCount; i--)
       {
-         S32 nameIndex = (i == mSequences.size()-1) ? findName(name) : mSequences[i].nameIndex;
+         S32 nameIndex = (i == sequences.size()-1) ? findName(name) : sequences[i].nameIndex;
          S32 seqIndex = findSequence(nameIndex);
          if ((seqIndex != -1) && (seqIndex != i))
          {
             Con::errorf("TSShape::addSequence: Failed to add sequence '%s' "
                "(name already exists)", getName(nameIndex).c_str());
-            mSequences[i].nameIndex = addName("__dummy__");
+            sequences[i].nameIndex = addName("__dummy__");
             removeSequence("__dummy__");
-            if (i == mSequences.size())
+            if (i == sequences.size())
                lastSequenceRejected = true;
          }
       }
 
       // @todo:Need to remove keyframes if start!=0 and end!=-1
-      TSShape::Sequence& seq = mSequences.last();
+      TSShape::Sequence& seq = sequences.last();
 
       // Store information about how this sequence was created
       seq.sourceData.from = String::ToString("%s\t%s", filenameBuf, name.c_str());
@@ -1415,7 +1415,7 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
       seq.sourceData.start = ((startFrame < 0) || (startFrame >= seq.numKeyframes)) ? 0 : startFrame;
       seq.sourceData.end = ((endFrame < 0) || (endFrame >= seq.numKeyframes)) ? seq.numKeyframes-1 : endFrame;
 
-      return (mSequences.size() != oldSeqCount);
+      return (sequences.size() != oldSeqCount);
    }
 
    /* Check that sequence to be added does not already exist */
@@ -1442,7 +1442,7 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
          return false;
       }
       srcShape = const_cast<TSShape*>((const TSShape*)hSrcShape);
-      if (!srcShape->mSequences.size())
+      if (!srcShape->sequences.size())
       {
          Con::errorf("TSShape::addSequence: Source shape '%s' does not contain any sequences", path.getFullPath().c_str());
          return false;
@@ -1450,7 +1450,7 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
 
       // If no sequence name is specified, just use the first one
       if (oldName.isEmpty())
-         oldName = srcShape->getName(srcShape->mSequences[0].nameIndex);
+         oldName = srcShape->getName(srcShape->sequences[0].nameIndex);
    }
    else
    {
@@ -1467,7 +1467,7 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
    }
 
    // Check keyframe range
-   const TSShape::Sequence* srcSeq = &srcShape->mSequences[seqIndex];
+   const TSShape::Sequence* srcSeq = &srcShape->sequences[seqIndex];
    if ((startFrame < 0) || (startFrame >= srcSeq->numKeyframes))
    {
       Con::warnf("TSShape::addSequence: Start keyframe (%d) out of range (0-%d) for sequence '%s'",
@@ -1484,21 +1484,21 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
    }
 
    // Create array to map source nodes to our nodes
-   Vector<S32> nodeMap(srcShape->mNodes.size());
-   for (S32 i = 0; i < srcShape->mNodes.size(); i++)
-      nodeMap.push_back(findNode(srcShape->getName(srcShape->mNodes[i].nameIndex)));
+   Vector<S32> nodeMap(srcShape->nodes.size());
+   for (S32 i = 0; i < srcShape->nodes.size(); i++)
+      nodeMap.push_back(findNode(srcShape->getName(srcShape->nodes[i].nameIndex)));
 
    // Create array to map source objects to our objects
-   Vector<S32> objectMap(srcShape->mObjects.size());
-   for (S32 i = 0; i < srcShape->mObjects.size(); i++)
-      objectMap.push_back(findObject(srcShape->getName(srcShape->mObjects[i].nameIndex)));
+   Vector<S32> objectMap(srcShape->objects.size());
+   for (S32 i = 0; i < srcShape->objects.size(); i++)
+      objectMap.push_back(findObject(srcShape->getName(srcShape->objects[i].nameIndex)));
 
    // Copy the source sequence (need to do it this ugly way instead of just
    // using push_back since srcSeq pointer may change if copying a sequence
    // from inside the shape itself
-   mSequences.increment();
-   TSShape::Sequence& seq = mSequences.last();
-   srcSeq = &srcShape->mSequences[seqIndex]; // update pointer as it may have changed!
+   sequences.increment();
+   TSShape::Sequence& seq = sequences.last();
+   srcSeq = &srcShape->sequences[seqIndex]; // update pointer as it may have changed!
    seq = *srcSeq;
 
    seq.nameIndex = addName(name);
@@ -1519,7 +1519,7 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
       if (srcSeq->visMatters.test(i))
       {
          // Check if visibility is animated within the frames to be copied
-         const F32 defaultVis = srcShape->mObjectStates[i].vis;
+         const F32 defaultVis = srcShape->objectStates[i].vis;
          S32 objNum = srcSeq->visMatters.count(i);
          for (S32 iFrame = startFrame; iFrame <= endFrame; iFrame++)
          {
@@ -1540,8 +1540,8 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
    objectStateSet.overlap(seq.matFrameMatters);
    objectStateSet.overlap(seq.visMatters);
 
-   seq.baseObjectState = mObjectStates.size();
-   mObjectStates.increment(objectStateSet.count()*seq.numKeyframes);
+   seq.baseObjectState = objectStates.size();
+   objectStates.increment(objectStateSet.count()*seq.numKeyframes);
    for (S32 i = 0; i < objectMap.size(); i++)
    {
       if (objectMap[i] < 0)
@@ -1552,7 +1552,7 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
       {
          S32 src = srcSeq->baseObjectState + srcSeq->numKeyframes * srcObjectStateSet.count(i) + startFrame;
          S32 dest = seq.baseObjectState + seq.numKeyframes * objectStateSet.count(objectMap[i]);
-         dCopyArray(&mObjectStates[dest], &srcShape->mObjectStates[src], seq.numKeyframes);
+         dCopyArray(&objectStates[dest], &srcShape->objectStates[src], seq.numKeyframes);
       }
    }
 
@@ -1561,27 +1561,27 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
    S32 groundBase = srcSeq->firstGroundFrame + startFrame*ratio;
 
    seq.numGroundFrames *= ratio;
-   seq.firstGroundFrame = mGroundTranslations.size();
-   mGroundTranslations.reserve(mGroundTranslations.size() + seq.numGroundFrames);
-   mGroundRotations.reserve(mGroundRotations.size() + seq.numGroundFrames);
+   seq.firstGroundFrame = groundTranslations.size();
+   groundTranslations.reserve(groundTranslations.size() + seq.numGroundFrames);
+   groundRotations.reserve(groundRotations.size() + seq.numGroundFrames);
    for (S32 i = 0; i < seq.numGroundFrames; i++)
    {
-      mGroundTranslations.push_back(srcShape->mGroundTranslations[groundBase + i]);
-      mGroundRotations.push_back(srcShape->mGroundRotations[groundBase + i]);
+      groundTranslations.push_back(srcShape->groundTranslations[groundBase + i]);
+      groundRotations.push_back(srcShape->groundRotations[groundBase + i]);
    }
 
    // Add triggers
    seq.numTriggers = 0;
-   seq.firstTrigger = mTriggers.size();
+   seq.firstTrigger = triggers.size();
    F32 seqStartPos = (F32)startFrame / seq.numKeyframes;
    F32 seqEndPos = (F32)endFrame / seq.numKeyframes;
    for (S32 i = 0; i < srcSeq->numTriggers; i++)
    {
-      const TSShape::Trigger& srcTrig = srcShape->mTriggers[srcSeq->firstTrigger + i];
+      const TSShape::Trigger& srcTrig = srcShape->triggers[srcSeq->firstTrigger + i];
       if ((srcTrig.pos >= seqStartPos) && (srcTrig.pos <= seqEndPos))
       {
-         mTriggers.push_back(srcTrig);
-         mTriggers.last().pos -= seqStartPos;
+         triggers.push_back(srcTrig);
+         triggers.last().pos -= seqStartPos;
          seq.numTriggers++;
       }
    }
@@ -1598,7 +1598,7 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
       if (srcSeq->translationMatters.test(i))
       {
          // Check if node position is animated within the frames to be copied
-         const Point3F& defaultTrans = srcShape->mDefaultTranslations[i];
+         const Point3F& defaultTrans = srcShape->defaultTranslations[i];
          S32 tranNum = srcSeq->translationMatters.count(i);
          for (S32 iFrame = startFrame; iFrame <= endFrame; iFrame++)
          {
@@ -1613,7 +1613,7 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
       if (srcSeq->rotationMatters.test(i))
       {
          // Check if node rotation is animated within the frames to be copied
-         const QuatF defaultRot = srcShape->mDefaultRotations[i].getQuatF();
+         const QuatF defaultRot = srcShape->defaultRotations[i].getQuatF();
          S32 rotNum = srcSeq->rotationMatters.count(i);
          for (S32 iFrame = startFrame; iFrame <= endFrame; iFrame++)
          {
@@ -1672,26 +1672,26 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
    }
 
    // Resize the node transform arrays
-   seq.baseTranslation = mNodeTranslations.size();
-   mNodeTranslations.increment(seq.translationMatters.count()*seq.numKeyframes);
-   seq.baseRotation = mNodeRotations.size();
-   mNodeRotations.increment(seq.rotationMatters.count()*seq.numKeyframes);
+   seq.baseTranslation = nodeTranslations.size();
+   nodeTranslations.increment(seq.translationMatters.count()*seq.numKeyframes);
+   seq.baseRotation = nodeRotations.size();
+   nodeRotations.increment(seq.rotationMatters.count()*seq.numKeyframes);
    if (seq.flags & TSShape::ArbitraryScale)
    {
       S32 scaleCount = seq.scaleMatters.count();
-      seq.baseScale = mNodeArbitraryScaleRots.size();
-      mNodeArbitraryScaleRots.increment(scaleCount*seq.numKeyframes);
-      mNodeArbitraryScaleFactors.increment(scaleCount*seq.numKeyframes);
+      seq.baseScale = nodeArbitraryScaleRots.size();
+      nodeArbitraryScaleRots.increment(scaleCount*seq.numKeyframes);
+      nodeArbitraryScaleFactors.increment(scaleCount*seq.numKeyframes);
    }
    else if (seq.flags & TSShape::AlignedScale)
    {
-      seq.baseScale = mNodeAlignedScales.size();
-      mNodeAlignedScales.increment(seq.scaleMatters.count()*seq.numKeyframes);
+      seq.baseScale = nodeAlignedScales.size();
+      nodeAlignedScales.increment(seq.scaleMatters.count()*seq.numKeyframes);
    }
    else
    {
-      seq.baseScale = mNodeUniformScales.size();
-      mNodeUniformScales.increment(seq.scaleMatters.count()*seq.numKeyframes);
+      seq.baseScale = nodeUniformScales.size();
+      nodeUniformScales.increment(seq.scaleMatters.count()*seq.numKeyframes);
    }
 
    // Add node transforms (remap from source node indices to our node indices). As
@@ -1707,28 +1707,28 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
       {
          S32 src = srcSeq->baseTranslation + srcSeq->numKeyframes * srcSeq->translationMatters.count(i) + startFrame;
          S32 dest = seq.baseTranslation + seq.numKeyframes * seq.translationMatters.count(nodeMap[i]);
-         dCopyArray(&mNodeTranslations[dest], &srcShape->mNodeTranslations[src], seq.numKeyframes);
+         dCopyArray(&nodeTranslations[dest], &srcShape->nodeTranslations[src], seq.numKeyframes);
       }
-      else if (padTransKeys && (mDefaultTranslations[nodeMap[i]] != srcShape->mDefaultTranslations[i]))
+      else if (padTransKeys && (defaultTranslations[nodeMap[i]] != srcShape->defaultTranslations[i]))
       {
          seq.translationMatters.set(nodeMap[i]);
          S32 dest = seq.baseTranslation + seq.numKeyframes * seq.translationMatters.count(nodeMap[i]);
          for (S32 j = 0; j < seq.numKeyframes; j++)
-            mNodeTranslations.insert(dest, srcShape->mDefaultTranslations[i]);
+            nodeTranslations.insert(dest, srcShape->defaultTranslations[i]);
       }
 
       if (seq.rotationMatters.test(nodeMap[i]))
       {
          S32 src = srcSeq->baseRotation + srcSeq->numKeyframes * srcSeq->rotationMatters.count(i) + startFrame;
          S32 dest = seq.baseRotation + seq.numKeyframes * seq.rotationMatters.count(nodeMap[i]);
-         dCopyArray(&mNodeRotations[dest], &srcShape->mNodeRotations[src], seq.numKeyframes);
+         dCopyArray(&nodeRotations[dest], &srcShape->nodeRotations[src], seq.numKeyframes);
       }
-      else if (padRotKeys && (mDefaultRotations[nodeMap[i]] != srcShape->mDefaultRotations[i]))
+      else if (padRotKeys && (defaultRotations[nodeMap[i]] != srcShape->defaultRotations[i]))
       {
          seq.rotationMatters.set(nodeMap[i]);
          S32 dest = seq.baseRotation + seq.numKeyframes * seq.rotationMatters.count(nodeMap[i]);
          for (S32 j = 0; j < seq.numKeyframes; j++)
-            mNodeRotations.insert(dest, srcShape->mDefaultRotations[i]);
+            nodeRotations.insert(dest, srcShape->defaultRotations[i]);
       }
 
       if (seq.scaleMatters.test(nodeMap[i]))
@@ -1737,13 +1737,13 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
          S32 dest = seq.baseScale + seq.numKeyframes * seq.scaleMatters.count(nodeMap[i]);
          if (seq.flags & TSShape::ArbitraryScale)
          {
-            dCopyArray(&mNodeArbitraryScaleRots[dest], &srcShape->mNodeArbitraryScaleRots[src], seq.numKeyframes);
-            dCopyArray(&mNodeArbitraryScaleFactors[dest], &srcShape->mNodeArbitraryScaleFactors[src], seq.numKeyframes);
+            dCopyArray(&nodeArbitraryScaleRots[dest], &srcShape->nodeArbitraryScaleRots[src], seq.numKeyframes);
+            dCopyArray(&nodeArbitraryScaleFactors[dest], &srcShape->nodeArbitraryScaleFactors[src], seq.numKeyframes);
          }
          else if (seq.flags & TSShape::AlignedScale)
-            dCopyArray(&mNodeAlignedScales[dest], &srcShape->mNodeAlignedScales[src], seq.numKeyframes);
+            dCopyArray(&nodeAlignedScales[dest], &srcShape->nodeAlignedScales[src], seq.numKeyframes);
          else
-            dCopyArray(&mNodeUniformScales[dest], &srcShape->mNodeUniformScales[src], seq.numKeyframes);
+            dCopyArray(&nodeUniformScales[dest], &srcShape->nodeUniformScales[src], seq.numKeyframes);
       }
    }
 
@@ -1782,47 +1782,47 @@ bool TSShape::removeSequence(const String& name)
       return false;
    }
 
-   TSShape::Sequence& seq = mSequences[seqIndex];
+   TSShape::Sequence& seq = sequences[seqIndex];
 
    // Remove the node transforms for this sequence
-   S32 transCount = eraseStates(mNodeTranslations, seq.translationMatters, seq.baseTranslation, seq.numKeyframes);
-   S32 rotCount = eraseStates(mNodeRotations, seq.rotationMatters, seq.baseRotation, seq.numKeyframes);
+   S32 transCount = eraseStates(nodeTranslations, seq.translationMatters, seq.baseTranslation, seq.numKeyframes);
+   S32 rotCount = eraseStates(nodeRotations, seq.rotationMatters, seq.baseRotation, seq.numKeyframes);
    S32 scaleCount = 0;
    if (seq.flags & TSShape::ArbitraryScale)
    {
-      scaleCount = eraseStates(mNodeArbitraryScaleRots, seq.scaleMatters, seq.baseScale, seq.numKeyframes);
-      eraseStates(mNodeArbitraryScaleFactors, seq.scaleMatters, seq.baseScale, seq.numKeyframes);
+      scaleCount = eraseStates(nodeArbitraryScaleRots, seq.scaleMatters, seq.baseScale, seq.numKeyframes);
+      eraseStates(nodeArbitraryScaleFactors, seq.scaleMatters, seq.baseScale, seq.numKeyframes);
    }
    else if (seq.flags & TSShape::AlignedScale)
-      scaleCount = eraseStates(mNodeAlignedScales, seq.scaleMatters, seq.baseScale, seq.numKeyframes);
+      scaleCount = eraseStates(nodeAlignedScales, seq.scaleMatters, seq.baseScale, seq.numKeyframes);
    else
-      scaleCount = eraseStates(mNodeUniformScales, seq.scaleMatters, seq.baseScale, seq.numKeyframes);
+      scaleCount = eraseStates(nodeUniformScales, seq.scaleMatters, seq.baseScale, seq.numKeyframes);
 
    // Remove the object states for this sequence
    TSIntegerSet objMatters(seq.frameMatters);
    objMatters.overlap(seq.matFrameMatters);
    objMatters.overlap(seq.visMatters);
-   S32 objCount = eraseStates(mObjectStates, objMatters, seq.baseObjectState, seq.numKeyframes);
+   S32 objCount = eraseStates(objectStates, objMatters, seq.baseObjectState, seq.numKeyframes);
 
    // Remove groundframes and triggers
    TSIntegerSet dummy;
-   eraseStates(mGroundTranslations, dummy, seq.firstGroundFrame, seq.numGroundFrames, 0);
-   eraseStates(mGroundRotations, dummy, seq.firstGroundFrame, seq.numGroundFrames, 0);
-   eraseStates(mTriggers, dummy, seq.firstTrigger, seq.numTriggers, 0);
+   eraseStates(groundTranslations, dummy, seq.firstGroundFrame, seq.numGroundFrames, 0);
+   eraseStates(groundRotations, dummy, seq.firstGroundFrame, seq.numGroundFrames, 0);
+   eraseStates(triggers, dummy, seq.firstTrigger, seq.numTriggers, 0);
 
    // Fixup the base indices of the other sequences
-   for (S32 i = seqIndex + 1; i < mSequences.size(); i++)
+   for (S32 i = seqIndex + 1; i < sequences.size(); i++)
    {
-      mSequences[i].baseTranslation -= transCount;
-      mSequences[i].baseRotation -= rotCount;
-      mSequences[i].baseScale -= scaleCount;
-      mSequences[i].baseObjectState -= objCount;
-      mSequences[i].firstGroundFrame -= seq.numGroundFrames;
-      mSequences[i].firstTrigger -= seq.numTriggers;
+      sequences[i].baseTranslation -= transCount;
+      sequences[i].baseRotation -= rotCount;
+      sequences[i].baseScale -= scaleCount;
+      sequences[i].baseObjectState -= objCount;
+      sequences[i].firstGroundFrame -= seq.numGroundFrames;
+      sequences[i].firstTrigger -= seq.numTriggers;
    }
 
    // Remove the sequence itself
-   mSequences.erase(seqIndex);
+   sequences.erase(seqIndex);
 
    // Remove the sequence name if it is no longer in use
    removeName(name);
@@ -1842,7 +1842,7 @@ bool TSShape::addTrigger(const String& seqName, S32 keyframe, S32 state)
       return false;
    }
 
-   TSShape::Sequence& seq = mSequences[seqIndex];
+   TSShape::Sequence& seq = sequences[seqIndex];
    if (keyframe >= seq.numKeyframes)
    {
       Con::errorf("TSShape::addTrigger: Keyframe out of range (0-%d for sequence '%s')",
@@ -1861,14 +1861,14 @@ bool TSShape::addTrigger(const String& seqName, S32 keyframe, S32 state)
    {
       seq.firstTrigger = 0;
       for (S32 i = 0; i < seqIndex; i++)
-         seq.firstTrigger += mSequences[i].numTriggers;
+         seq.firstTrigger += sequences[i].numTriggers;
    }
 
    // Find where to insert the trigger (sorted by keyframe)
    S32 trigIndex;
    for (trigIndex = seq.firstTrigger; trigIndex < (seq.firstTrigger + seq.numTriggers); trigIndex++)
    {
-      const TSShape::Trigger& trig = mTriggers[trigIndex];
+      const TSShape::Trigger& trig = triggers[trigIndex];
       if ((S32)(trig.pos * seq.numKeyframes) > keyframe)
          break;
    }
@@ -1877,7 +1877,7 @@ bool TSShape::addTrigger(const String& seqName, S32 keyframe, S32 state)
    TSShape::Trigger trig;
    trig.pos = (F32)keyframe / getMax(1, seq.numKeyframes-1);
    trig.state = state;
-   mTriggers.insert(trigIndex, trig);
+   triggers.insert(trigIndex, trig);
    seq.numTriggers++;
 
    // set invert for other triggers if needed
@@ -1886,16 +1886,16 @@ bool TSShape::addTrigger(const String& seqName, S32 keyframe, S32 state)
       U32 offTrigger = (trig.state & TSShape::Trigger::StateMask);
       for (S32 i = 0; i < seq.numTriggers; i++)
       {
-         if (mTriggers[seq.firstTrigger + i].state & offTrigger)
-            mTriggers[seq.firstTrigger + i].state |= TSShape::Trigger::InvertOnReverse;
+         if (triggers[seq.firstTrigger + i].state & offTrigger)
+            triggers[seq.firstTrigger + i].state |= TSShape::Trigger::InvertOnReverse;
       }
    }
 
    // fixup firstTrigger index for other sequences
-   for (S32 i = seqIndex + 1; i < mSequences.size(); i++)
+   for (S32 i = seqIndex + 1; i < sequences.size(); i++)
    {
-      if (mSequences[i].numTriggers > 0)
-         mSequences[i].firstTrigger++;
+      if (sequences[i].numTriggers > 0)
+         sequences[i].firstTrigger++;
    }
 
    // set MakePath flag so triggers will be animated
@@ -1914,7 +1914,7 @@ bool TSShape::removeTrigger(const String& seqName, S32 keyframe, S32 state)
       return false;
    }
 
-   TSShape::Sequence& seq = mSequences[seqIndex];
+   TSShape::Sequence& seq = sequences[seqIndex];
    if (keyframe >= seq.numKeyframes)
    {
       Con::errorf("TSShape::removeTrigger: Keyframe out of range (0-%d for sequence '%s')",
@@ -1931,20 +1931,20 @@ bool TSShape::removeTrigger(const String& seqName, S32 keyframe, S32 state)
    // Find and remove the trigger
    for (S32 trigIndex = seq.firstTrigger; trigIndex < (seq.firstTrigger + seq.numTriggers); trigIndex++)
    {
-      TSShape::Trigger& trig = mTriggers[trigIndex];
+      TSShape::Trigger& trig = triggers[trigIndex];
       S32 cmpFrame = (S32)(trig.pos * (seq.numKeyframes-1) + 0.5f); 
       S32 cmpState = trig.state & (~TSShape::Trigger::InvertOnReverse);
 
       if ((cmpFrame == keyframe) && (cmpState == state))
       {
-         mTriggers.erase(trigIndex);
+         triggers.erase(trigIndex);
          seq.numTriggers--;
 
          // Fix up firstTrigger for other sequences
-         for (S32 i = seqIndex + 1; i < mSequences.size(); i++)
+         for (S32 i = seqIndex + 1; i < sequences.size(); i++)
          {
-            if (mSequences[i].numTriggers > 0)
-               mSequences[i].firstTrigger--;
+            if (sequences[i].numTriggers > 0)
+               sequences[i].firstTrigger--;
          }
 
          // Clear MakePath flag if no more triggers
@@ -1968,19 +1968,19 @@ void TSShape::getNodeKeyframe(S32 nodeIndex, const TSShape::Sequence& seq, S32 k
    if (seq.rotationMatters.test(nodeIndex))
    {
       S32 index = seq.rotationMatters.count(nodeIndex) * seq.numKeyframes + keyframe;
-      mNodeRotations[seq.baseRotation + index].getQuatF(&rot);
+      nodeRotations[seq.baseRotation + index].getQuatF(&rot);
    }   
    else
-      mDefaultRotations[nodeIndex].getQuatF(&rot);
+      defaultRotations[nodeIndex].getQuatF(&rot);
 
    Point3F trans;
    if (seq.translationMatters.test(nodeIndex))
    {
       S32 index = seq.translationMatters.count(nodeIndex) * seq.numKeyframes + keyframe;
-      trans = mNodeTranslations[seq.baseTranslation + index];
+      trans = nodeTranslations[seq.baseTranslation + index];
    }
    else
-      trans = mDefaultTranslations[nodeIndex];
+      trans = defaultTranslations[nodeIndex];
 
    // Set the keyframe matrix
    rot.setMatrix(mat);
@@ -1996,7 +1996,7 @@ bool TSShape::setSequenceBlend(const String& seqName, bool blend, const String& 
       Con::errorf("TSShape::setSequenceBlend: Could not find sequence named '%s'", seqName.c_str());
       return false;
    }
-   TSShape::Sequence& seq = mSequences[seqIndex];
+   TSShape::Sequence& seq = sequences[seqIndex];
 
    // Ignore if blend flag is already correct
    if (seq.isBlend() == blend)
@@ -2009,7 +2009,7 @@ bool TSShape::setSequenceBlend(const String& seqName, bool blend, const String& 
       Con::errorf("TSShape::setSequenceBlend: Could not find reference sequence named '%s'", blendRefSeqName.c_str());
       return false;
    }
-   TSShape::Sequence& blendRefSeq = mSequences[blendRefSeqIndex];
+   TSShape::Sequence& blendRefSeq = sequences[blendRefSeqIndex];
 
    if ((blendRefFrame < 0) || (blendRefFrame >= blendRefSeq.numKeyframes))
    {
@@ -2060,9 +2060,9 @@ bool TSShape::setSequenceBlend(const String& seqName, bool blend, const String& 
          newMat.mul(refMat, oldMat);
 
          if (updateRot)
-            mNodeRotations[rotOffset + frame].set(QuatF(newMat));
+            nodeRotations[rotOffset + frame].set(QuatF(newMat));
          if (updateTrans)
-            mNodeTranslations[transOffset + frame] = newMat.getPosition();
+            nodeTranslations[transOffset + frame] = newMat.getPosition();
       }
    }
 
@@ -2082,7 +2082,7 @@ bool TSShape::setSequenceGroundSpeed(const String& seqName, const Point3F& trans
       Con::errorf("setSequenceGroundSpeed: Could not find sequence named '%s'", seqName.c_str());
       return false;
    }
-   TSShape::Sequence& seq = mSequences[seqIndex];
+   TSShape::Sequence& seq = sequences[seqIndex];
 
    // Determine how many ground-frames to generate (FPS=10, at least 1 frame)
    const F32 groundFrameRate = 10.0f;
@@ -2094,20 +2094,20 @@ bool TSShape::setSequenceGroundSpeed(const String& seqName, const Point3F& trans
    {
       if (frameAdjust > 0)
       {
-         mGroundTranslations.insert(seq.firstGroundFrame);
-         mGroundRotations.insert(seq.firstGroundFrame);
+         groundTranslations.insert(seq.firstGroundFrame);
+         groundRotations.insert(seq.firstGroundFrame);
       }
       else
       {
-         mGroundTranslations.erase(seq.firstGroundFrame);
-         mGroundRotations.erase(seq.firstGroundFrame);
+         groundTranslations.erase(seq.firstGroundFrame);
+         groundRotations.erase(seq.firstGroundFrame);
       }
    }
 
    // Fixup ground frame indices
    seq.numGroundFrames += frameAdjust;
-   for (S32 i = seqIndex+1; i < mSequences.size(); i++)
-      mSequences[i].firstGroundFrame += frameAdjust;
+   for (S32 i = seqIndex+1; i < sequences.size(); i++)
+      sequences[i].firstGroundFrame += frameAdjust;
 
    // Generate the ground-frames
    Point3F adjTrans = trans;
@@ -2121,8 +2121,8 @@ bool TSShape::setSequenceGroundSpeed(const String& seqName, const Point3F& trans
    QuatF groundRot(rotSpeed);
    for (S32 i = 0; i < seq.numGroundFrames; i++)
    {
-      mGroundTranslations[seq.firstGroundFrame + i] = adjTrans * (i + 1);
-      mGroundRotations[seq.firstGroundFrame + i].set(groundRot);
+      groundTranslations[seq.firstGroundFrame + i] = adjTrans * (i + 1);
+      groundRotations[seq.firstGroundFrame + i].set(groundRot);
       groundRot *= rotSpeed;
    }
 

--- a/Engine/source/ts/tsShapeInstance.h
+++ b/Engine/source/ts/tsShapeInstance.h
@@ -531,7 +531,7 @@ protected:
    void deltaGround1(TSThread *, F32 start, F32 end, MatrixF& mat);
    /// @}
 
-   U32 getNumDetails() const { return mShape ? mShape->mDetails.size() : 0; }
+   U32 getNumDetails() const { return mShape ? mShape->details.size() : 0; }
 
    S32 getCurrentDetail() const { return mCurrentDetailLevel; }
 
@@ -702,20 +702,20 @@ class TSThread
 {
    friend class TSShapeInstance;
 
-   S32 mPriority;
+   S32 priority;
 
    TSShapeInstance * mShapeInstance;  ///< Instance of the shape that this thread animates
 
-   S32 mSequence;                      ///< Sequence this thread will perform
-   F32 mPos;
+   S32 sequence;                      ///< Sequence this thread will perform
+   F32 pos;
 
-   F32 mTimeScale;                     ///< How fast to play through the sequence
+   F32 timeScale;                     ///< How fast to play through the sequence
 
-   S32 mKeyNum1;                       ///< Keyframe at or before current position
-   S32 mKeyNum2;                       ///< Keyframe at or after current position
-   F32 mKeyPos;
+   S32 keyNum1;                       ///< Keyframe at or before current position
+   S32 keyNum2;                       ///< Keyframe at or after current position
+   F32 keyPos;
 
-   bool mBlendDisabled;                ///< Blend with other sequences?
+   bool blendDisabled;                ///< Blend with other sequences?
 
    /// if in transition...
    struct TransitionData
@@ -732,15 +732,15 @@ class TSThread
       TSIntegerSet oldScaleNodes;       ///< nodes controlled by this thread pre-transition
       U32 oldSequence; ///< sequence that was set before transition began
       F32 oldPos;      ///< position of sequence before transition began
-   } mTransitionData;
+   } transitionData;
 
    struct
    {
       F32 start;
       F32 end;
       S32 loop;
-   } mPath;
-   bool mMakePath;
+   } path;
+   bool makePath;
 
    /// given a position on the thread, choose correct keyframes
    /// slight difference between one-shot and cyclic sequences -- see comments below for details
@@ -789,10 +789,10 @@ class TSThread
 public:
 
    TSShapeInstance * getShapeInstance() { return mShapeInstance; }
-   bool hasSequence() const { return mSequence >= 0; }
-   U32 getSeqIndex() const { return mSequence; }
-   const TSSequence* getSequence() const { return &(mShapeInstance->mShape->mSequences[mSequence]); }
-   const String& getSequenceName() const { return mShapeInstance->mShape->getSequenceName(mSequence); }
+   bool hasSequence() const { return sequence >= 0; }
+   U32 getSeqIndex() const { return sequence; }
+   const TSSequence* getSequence() const { return &(mShapeInstance->mShape->sequences[sequence]); }
+   const String& getSequenceName() const { return mShapeInstance->mShape->getSequenceName(sequence); }
    S32 operator<(const TSThread &) const;
 };
 

--- a/Engine/source/ts/tsShapeOldRead.cpp
+++ b/Engine/source/ts/tsShapeOldRead.cpp
@@ -33,12 +33,12 @@ void TSShape::fixupOldSkins(S32 numMeshes, S32 numSkins, S32 numDetails, S32 * d
 {
 #if !defined(TORQUE_MAX_LIB)
    // this method not necessary in exporter, and a couple lines won't compile for exporter
-   if (!mObjects.address() || !mMeshes.address() || !numSkins)
+   if (!objects.address() || !meshes.address() || !numSkins)
       // not ready for this yet, will catch it on the next pass
       return;
-   S32 numObjects = mObjects.size();
-   TSObject * newObjects = mObjects.address() + mObjects.size();
-   TSSkinMesh ** skins = (TSSkinMesh**)&mMeshes[numMeshes];
+   S32 numObjects = objects.size();
+   TSObject * newObjects = objects.address() + objects.size();
+   TSSkinMesh ** skins = (TSSkinMesh**)&meshes[numMeshes];
    Vector<TSSkinMesh*> skinsCopy;
    // Note: newObjects has as much free space as we need, so we just need to keep track of the
    //       number of objects we use and then update objects.size
@@ -52,7 +52,7 @@ void TSShape::fixupOldSkins(S32 numMeshes, S32 numSkins, S32 numDetails, S32 * d
    while (skinsUsed<numSkins-emptySkins)
    {
       TSObject & object = newObjects[numSkinObjects++];
-      mObjects.increment();
+      objects.increment();
       object.nameIndex = 0; // no name
       object.numMeshes = 0;
       object.startMeshIndex = numMeshes + skinsCopy.size();
@@ -92,29 +92,29 @@ void TSShape::fixupOldSkins(S32 numMeshes, S32 numSkins, S32 numDetails, S32 * d
       // if no meshes, don't need object
       if (!object.numMeshes)
       {
-         mObjects.decrement();
+         objects.decrement();
          numSkinObjects--;
       }
    }
    dMemcpy(skins,skinsCopy.address(),skinsCopy.size()*sizeof(TSSkinMesh*));
 
-   if (mSubShapeFirstObject.size()==1)
+   if (subShapeFirstObject.size()==1)
       // as long as only one subshape, we'll now be rendered
-      mSubShapeNumObjects[0] += numSkinObjects;
+      subShapeNumObjects[0] += numSkinObjects;
 
    // now for something ugly -- we've added somoe objects to hold the skins...
    // now we have to add default states for those objects
    // we also have to increment base states on all the sequences that are loaded
-   dMemmove(mObjectStates.address()+numObjects+numSkinObjects,mObjectStates.address()+numObjects,(mObjectStates.size()-numObjects)*sizeof(ObjectState));
+   dMemmove(objectStates.address()+numObjects+numSkinObjects,objectStates.address()+numObjects,(objectStates.size()-numObjects)*sizeof(ObjectState));
    for (i=numObjects; i<numObjects+numSkinObjects; i++)
    {
-      mObjectStates[i].vis=1.0f;
-      mObjectStates[i].frameIndex=0;
-      mObjectStates[i].matFrameIndex=0;
+      objectStates[i].vis=1.0f;
+      objectStates[i].frameIndex=0;
+      objectStates[i].matFrameIndex=0;
    }
-   for (i=0;i<mSequences.size();i++)
+   for (i=0;i<sequences.size();i++)
    {
-      mSequences[i].baseObjectState += numSkinObjects;
+      sequences[i].baseObjectState += numSkinObjects;
    }
 #endif
 }
@@ -197,10 +197,10 @@ void TSShape::exportSequences(Stream * s)
 
    // write node names
    // -- this is how we will map imported sequence nodes to shape nodes
-   sz = mNodes.size();
+   sz = nodes.size();
    s->write(sz);
-   for (i=0;i<mNodes.size();i++)
-      writeName(s,mNodes[i].nameIndex);
+   for (i=0;i<nodes.size();i++)
+      writeName(s,nodes[i].nameIndex);
 
    // legacy write -- write zero objects, don't pretend to support object export anymore
    s->write(0);
@@ -208,71 +208,71 @@ void TSShape::exportSequences(Stream * s)
    // on import, we will need to adjust keyframe data based on number of
    // nodes/objects in this shape...number of nodes can be inferred from
    // above, but number of objects cannot be.  Write that quantity here:
-   s->write(mObjects.size());
+   s->write(objects.size());
 
    // write node states -- skip default node states
-   s->write(mNodeRotations.size());
-   for (i=0;i<mNodeRotations.size();i++)
+   s->write(nodeRotations.size());
+   for (i=0;i<nodeRotations.size();i++)
    {
-      s->write(mNodeRotations[i].x);
-      s->write(mNodeRotations[i].y);
-      s->write(mNodeRotations[i].z);
-      s->write(mNodeRotations[i].w);
+      s->write(nodeRotations[i].x);
+      s->write(nodeRotations[i].y);
+      s->write(nodeRotations[i].z);
+      s->write(nodeRotations[i].w);
    }
-   s->write(mNodeTranslations.size());
-   for (i=0;i<mNodeTranslations.size(); i++)
+   s->write(nodeTranslations.size());
+   for (i=0;i<nodeTranslations.size(); i++)
    {
-      s->write(mNodeTranslations[i].x);
-      s->write(mNodeTranslations[i].y);
-      s->write(mNodeTranslations[i].z);
+      s->write(nodeTranslations[i].x);
+      s->write(nodeTranslations[i].y);
+      s->write(nodeTranslations[i].z);
    }
-   s->write(mNodeUniformScales.size());
-   for (i=0;i<mNodeUniformScales.size();i++)
-      s->write(mNodeUniformScales[i]);
-   s->write(mNodeAlignedScales.size());
-   for (i=0;i<mNodeAlignedScales.size();i++)
+   s->write(nodeUniformScales.size());
+   for (i=0;i<nodeUniformScales.size();i++)
+      s->write(nodeUniformScales[i]);
+   s->write(nodeAlignedScales.size());
+   for (i=0;i<nodeAlignedScales.size();i++)
    {
-      s->write(mNodeAlignedScales[i].x);
-      s->write(mNodeAlignedScales[i].y);
-      s->write(mNodeAlignedScales[i].z);
+      s->write(nodeAlignedScales[i].x);
+      s->write(nodeAlignedScales[i].y);
+      s->write(nodeAlignedScales[i].z);
    }
-   s->write(mNodeArbitraryScaleRots.size());
-   for (i=0;i<mNodeArbitraryScaleRots.size();i++)
+   s->write(nodeArbitraryScaleRots.size());
+   for (i=0;i<nodeArbitraryScaleRots.size();i++)
    {
-      s->write(mNodeArbitraryScaleRots[i].x);
-      s->write(mNodeArbitraryScaleRots[i].y);
-      s->write(mNodeArbitraryScaleRots[i].z);
-      s->write(mNodeArbitraryScaleRots[i].w);
+      s->write(nodeArbitraryScaleRots[i].x);
+      s->write(nodeArbitraryScaleRots[i].y);
+      s->write(nodeArbitraryScaleRots[i].z);
+      s->write(nodeArbitraryScaleRots[i].w);
    }
-   for (i=0;i<mNodeArbitraryScaleFactors.size();i++)
+   for (i=0;i<nodeArbitraryScaleFactors.size();i++)
    {
-      s->write(mNodeArbitraryScaleFactors[i].x);
-      s->write(mNodeArbitraryScaleFactors[i].y);
-      s->write(mNodeArbitraryScaleFactors[i].z);
+      s->write(nodeArbitraryScaleFactors[i].x);
+      s->write(nodeArbitraryScaleFactors[i].y);
+      s->write(nodeArbitraryScaleFactors[i].z);
    }
-   s->write(mGroundTranslations.size());
-   for (i=0;i<mGroundTranslations.size();i++)
+   s->write(groundTranslations.size());
+   for (i=0;i<groundTranslations.size();i++)
    {
-      s->write(mGroundTranslations[i].x);
-      s->write(mGroundTranslations[i].y);
-      s->write(mGroundTranslations[i].z);
+      s->write(groundTranslations[i].x);
+      s->write(groundTranslations[i].y);
+      s->write(groundTranslations[i].z);
    }
-   for (i=0;i<mGroundRotations.size();i++)
+   for (i=0;i<groundRotations.size();i++)
    {
-      s->write(mGroundRotations[i].x);
-      s->write(mGroundRotations[i].y);
-      s->write(mGroundRotations[i].z);
-      s->write(mGroundRotations[i].w);
+      s->write(groundRotations[i].x);
+      s->write(groundRotations[i].y);
+      s->write(groundRotations[i].z);
+      s->write(groundRotations[i].w);
    }
 
    // write object states -- legacy..no object states
    s->write((S32)0);
 
    // write sequences
-   s->write(mSequences.size());
-   for (i=0;i<mSequences.size();i++)
+   s->write(sequences.size());
+   for (i=0;i<sequences.size();i++)
    {
-      Sequence & seq = mSequences[i];
+      Sequence & seq = sequences[i];
 
       // first write sequence name
       writeName(s,seq.nameIndex);
@@ -282,11 +282,11 @@ void TSShape::exportSequences(Stream * s)
    }
 
    // write out all the triggers...
-   s->write(mTriggers.size());
-   for (i=0; i<mTriggers.size(); i++)
+   s->write(triggers.size());
+   for (i=0; i<triggers.size(); i++)
    {
-      s->write(mTriggers[i].state);
-      s->write(mTriggers[i].pos);
+      s->write(triggers[i].state);
+      s->write(triggers[i].pos);
    }
 }
 
@@ -303,9 +303,9 @@ void TSShape::exportSequence(Stream * s, const TSShape::Sequence& seq, bool save
    s->write(smVersion);
 
    // write node names
-   s->write( mNodes.size() );
-   for ( S32 i = 0; i < mNodes.size(); i++ )
-      writeName( s, mNodes[i].nameIndex );
+   s->write( nodes.size() );
+   for ( S32 i = 0; i < nodes.size(); i++ )
+      writeName( s, nodes[i].nameIndex );
 
    // legacy write -- write zero objects, don't pretend to support object export anymore
    s->write( (S32)0 );
@@ -313,26 +313,26 @@ void TSShape::exportSequence(Stream * s, const TSShape::Sequence& seq, bool save
    // on import, we will need to adjust keyframe data based on number of
    // nodes/objects in this shape...number of nodes can be inferred from
    // above, but number of objects cannot be.  Write that quantity here:
-   s->write( mObjects.size() );
+   s->write( objects.size() );
 
    // write node states -- skip default node states
    S32 count = seq.rotationMatters.count() * seq.numKeyframes;
    s->write( count );
    for ( S32 i = seq.baseRotation; i < seq.baseRotation + count; i++ )
    {
-      s->write( mNodeRotations[i].x );
-      s->write( mNodeRotations[i].y );
-      s->write( mNodeRotations[i].z );
-      s->write( mNodeRotations[i].w );
+      s->write( nodeRotations[i].x );
+      s->write( nodeRotations[i].y );
+      s->write( nodeRotations[i].z );
+      s->write( nodeRotations[i].w );
    }
 
    count = seq.translationMatters.count() * seq.numKeyframes;
    s->write( count );
    for ( S32 i = seq.baseTranslation; i < seq.baseTranslation + count; i++ )
    {
-      s->write( mNodeTranslations[i].x );
-      s->write( mNodeTranslations[i].y );
-      s->write( mNodeTranslations[i].z );
+      s->write( nodeTranslations[i].x );
+      s->write( nodeTranslations[i].y );
+      s->write( nodeTranslations[i].z );
    }
 
    count = seq.scaleMatters.count() * seq.numKeyframes;
@@ -340,7 +340,7 @@ void TSShape::exportSequence(Stream * s, const TSShape::Sequence& seq, bool save
    {
       s->write( count );
       for ( S32 i = seq.baseScale; i < seq.baseScale + count; i++ )
-         s->write( mNodeUniformScales[i] );
+         s->write( nodeUniformScales[i] );
    }
    else
       s->write( (S32)0 );
@@ -350,9 +350,9 @@ void TSShape::exportSequence(Stream * s, const TSShape::Sequence& seq, bool save
       s->write( count );
       for ( S32 i = seq.baseScale; i < seq.baseScale + count; i++ )
       {
-         s->write( mNodeAlignedScales[i].x );
-         s->write( mNodeAlignedScales[i].y );
-         s->write( mNodeAlignedScales[i].z );
+         s->write( nodeAlignedScales[i].x );
+         s->write( nodeAlignedScales[i].y );
+         s->write( nodeAlignedScales[i].z );
       }
    }
    else
@@ -363,16 +363,16 @@ void TSShape::exportSequence(Stream * s, const TSShape::Sequence& seq, bool save
       s->write( count );
       for ( S32 i = seq.baseScale; i < seq.baseScale + count; i++ )
       {
-         s->write( mNodeArbitraryScaleRots[i].x );
-         s->write( mNodeArbitraryScaleRots[i].y );
-         s->write( mNodeArbitraryScaleRots[i].z );
-         s->write( mNodeArbitraryScaleRots[i].w );
+         s->write( nodeArbitraryScaleRots[i].x );
+         s->write( nodeArbitraryScaleRots[i].y );
+         s->write( nodeArbitraryScaleRots[i].z );
+         s->write( nodeArbitraryScaleRots[i].w );
       }
       for ( S32 i = seq.baseScale; i < seq.baseScale + count; i++ )
       {
-         s->write( mNodeArbitraryScaleFactors[i].x );
-         s->write( mNodeArbitraryScaleFactors[i].y );
-         s->write( mNodeArbitraryScaleFactors[i].z );
+         s->write( nodeArbitraryScaleFactors[i].x );
+         s->write( nodeArbitraryScaleFactors[i].y );
+         s->write( nodeArbitraryScaleFactors[i].z );
       }
    }
    else
@@ -381,16 +381,16 @@ void TSShape::exportSequence(Stream * s, const TSShape::Sequence& seq, bool save
    s->write( seq.numGroundFrames );
    for ( S32 i = seq.firstGroundFrame; i < seq.firstGroundFrame + seq.numGroundFrames; i++ )
    {
-      s->write( mGroundTranslations[i].x );
-      s->write( mGroundTranslations[i].y );
-      s->write( mGroundTranslations[i].z );
+      s->write( groundTranslations[i].x );
+      s->write( groundTranslations[i].y );
+      s->write( groundTranslations[i].z );
    }
    for ( S32 i = seq.firstGroundFrame; i < seq.firstGroundFrame + seq.numGroundFrames; i++ )
    {
-      s->write( mGroundRotations[i].x );
-      s->write( mGroundRotations[i].y );
-      s->write( mGroundRotations[i].z );
-      s->write( mGroundRotations[i].w );
+      s->write( groundRotations[i].x );
+      s->write( groundRotations[i].y );
+      s->write( groundRotations[i].z );
+      s->write( groundRotations[i].w );
    }
 
    // write object states -- legacy..no object states
@@ -417,8 +417,8 @@ void TSShape::exportSequence(Stream * s, const TSShape::Sequence& seq, bool save
    s->write( seq.numTriggers );
    for ( S32 i = seq.firstTrigger; i < seq.firstTrigger + seq.numTriggers; i++ )
    {
-      s->write( mTriggers[i].state );
-      s->write( mTriggers[i].pos );
+      s->write( triggers[i].state );
+      s->write( triggers[i].pos );
    }
 
    smVersion = currentVersion;
@@ -460,7 +460,7 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
 
    for (i=0;i<sz;i++)
    {
-      U32 startSize = mNames.size();
+      U32 startSize = names.size();
       S32 nameIndex = readName(s,true);
       
       nodeMap[i] = findNode(nameIndex);
@@ -468,12 +468,12 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
       if (nodeMap[i] < 0)
       {
          // node found in sequence but not shape => remove the added node name
-         if (mNames.size() != startSize)
+         if (names.size() != startSize)
          {
-            mNames.decrement();
+            names.decrement();
 
-            if (mNames.size() != startSize)
-               Con::errorf(ConsoleLogEntry::General, "TSShape::importSequence: failed to remove unused node correctly for dsq %s.", mNames[nameIndex].c_str(), sequencePath.c_str());
+            if (names.size() != startSize)
+               Con::errorf(ConsoleLogEntry::General, "TSShape::importSequence: failed to remove unused node correctly for dsq %s.", names[nameIndex].c_str(), sequencePath.c_str());
          }
       }
    }
@@ -487,9 +487,9 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
    s->read(&oldShapeNumObjects);
 
    // adjust all the new keyframes
-   S32 adjNodeRots = smReadVersion<22 ? mNodeRotations.size() - nodeMap.size() : mNodeRotations.size();
-   S32 adjNodeTrans = smReadVersion<22 ? mNodeTranslations.size() - nodeMap.size() : mNodeTranslations.size();
-   S32 adjGroundStates = smReadVersion<22 ? 0 : mGroundTranslations.size(); // groundTrans==groundRot
+   S32 adjNodeRots = smReadVersion<22 ? nodeRotations.size() - nodeMap.size() : nodeRotations.size();
+   S32 adjNodeTrans = smReadVersion<22 ? nodeTranslations.size() - nodeMap.size() : nodeTranslations.size();
+   S32 adjGroundStates = smReadVersion<22 ? 0 : groundTranslations.size(); // groundTrans==groundRot
 
    // Read the node states into temporary vectors, then use the
    // nodeMap to discard unused transforms and map others to our nodes
@@ -551,21 +551,21 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
       // ground transforms can be read directly into the shape (none will be
       // discarded)
       s->read(&sz);
-      S32 oldSz = mGroundTranslations.size();
-      mGroundTranslations.setSize(sz+oldSz);
+      S32 oldSz = groundTranslations.size();
+      groundTranslations.setSize(sz+oldSz);
       for (i=oldSz;i<sz+oldSz;i++)
       {
-         s->read(&mGroundTranslations[i].x);
-         s->read(&mGroundTranslations[i].y);
-         s->read(&mGroundTranslations[i].z);
+         s->read(&groundTranslations[i].x);
+         s->read(&groundTranslations[i].y);
+         s->read(&groundTranslations[i].z);
       }
-      mGroundRotations.setSize(sz+oldSz);
+      groundRotations.setSize(sz+oldSz);
       for (i=oldSz;i<sz+oldSz;i++)
       {
-         s->read(&mGroundRotations[i].x);
-         s->read(&mGroundRotations[i].y);
-         s->read(&mGroundRotations[i].z);
-         s->read(&mGroundRotations[i].w);
+         s->read(&groundRotations[i].x);
+         s->read(&groundRotations[i].y);
+         s->read(&groundRotations[i].z);
+         s->read(&groundRotations[i].w);
       }
    }
    else
@@ -590,28 +590,28 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
 
    // read sequences
    s->read(&sz);
-   S32 startSeqNum = mSequences.size();
+   S32 startSeqNum = sequences.size();
    for (i=0;i<sz;i++)
    {
-      mSequences.increment();
-      Sequence & seq = mSequences.last();
+      sequences.increment();
+      Sequence & seq = sequences.last();
 
       // read name
       seq.nameIndex = readName(s,true);
 
       // read the rest of the sequence
       seq.read(s,false);
-      seq.baseRotation = mNodeRotations.size();
-      seq.baseTranslation = mNodeTranslations.size();
+      seq.baseRotation = nodeRotations.size();
+      seq.baseTranslation = nodeTranslations.size();
 
       if (smReadVersion > 21)
       {
          if (seq.animatesUniformScale())
-            seq.baseScale = mNodeUniformScales.size();
+            seq.baseScale = nodeUniformScales.size();
          else if (seq.animatesAlignedScale())
-            seq.baseScale = mNodeAlignedScales.size();
+            seq.baseScale = nodeAlignedScales.size();
          else if (seq.animatesArbitraryScale())
-            seq.baseScale = mNodeArbitraryScaleFactors.size();
+            seq.baseScale = nodeArbitraryScaleFactors.size();
       }
 
       // remap the node matters arrays
@@ -633,18 +633,18 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
       }
 
       // resize node transform arrays
-      mNodeTranslations.increment(newTransMembership.count() * seq.numKeyframes);
-      mNodeRotations.increment(newRotMembership.count() * seq.numKeyframes);
+      nodeTranslations.increment(newTransMembership.count() * seq.numKeyframes);
+      nodeRotations.increment(newRotMembership.count() * seq.numKeyframes);
       if (seq.flags & TSShape::ArbitraryScale)
       {
          S32 scaleCount = newScaleMembership.count() * seq.numKeyframes;
-         mNodeArbitraryScaleRots.increment(scaleCount);
-         mNodeArbitraryScaleFactors.increment(scaleCount);
+         nodeArbitraryScaleRots.increment(scaleCount);
+         nodeArbitraryScaleFactors.increment(scaleCount);
       }
       else if (seq.flags & TSShape::AlignedScale)
-         mNodeAlignedScales.increment(newScaleMembership.count() * seq.numKeyframes);
+         nodeAlignedScales.increment(newScaleMembership.count() * seq.numKeyframes);
       else
-         mNodeUniformScales.increment(newScaleMembership.count() * seq.numKeyframes);
+         nodeUniformScales.increment(newScaleMembership.count() * seq.numKeyframes);
 
       // remap node transforms from temporary arrays
       for (S32 j = 0; j < nodeMap.size(); j++)
@@ -656,13 +656,13 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
          {
             S32 src = seq.numKeyframes * seq.translationMatters.count(j);
             S32 dest = seq.baseTranslation + seq.numKeyframes * newTransMembership.count(nodeMap[j]);
-            dCopyArray(&mNodeTranslations[dest], &seqTranslations[src], seq.numKeyframes);
+            dCopyArray(&nodeTranslations[dest], &seqTranslations[src], seq.numKeyframes);
          }
          if (newRotMembership.test(nodeMap[j]))
          {
             S32 src = seq.numKeyframes * seq.rotationMatters.count(j);
             S32 dest = seq.baseRotation + seq.numKeyframes * newRotMembership.count(nodeMap[j]);
-            dCopyArray(&mNodeRotations[dest], &seqRotations[src], seq.numKeyframes);
+            dCopyArray(&nodeRotations[dest], &seqRotations[src], seq.numKeyframes);
          }
          if (newScaleMembership.test(nodeMap[j]))
          {
@@ -670,13 +670,13 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
             S32 dest = seq.baseScale + seq.numKeyframes * newScaleMembership.count(nodeMap[j]);
             if (seq.flags & TSShape::ArbitraryScale)
             {
-               dCopyArray(&mNodeArbitraryScaleRots[dest], &seqArbitraryScaleRots[src], seq.numKeyframes);
-               dCopyArray(&mNodeArbitraryScaleFactors[dest], &seqArbitraryScaleFactors[src], seq.numKeyframes);
+               dCopyArray(&nodeArbitraryScaleRots[dest], &seqArbitraryScaleRots[src], seq.numKeyframes);
+               dCopyArray(&nodeArbitraryScaleFactors[dest], &seqArbitraryScaleFactors[src], seq.numKeyframes);
             }
             else if (seq.flags & TSShape::AlignedScale)
-               dCopyArray(&mNodeAlignedScales[dest], &seqAlignedScales[src], seq.numKeyframes);
+               dCopyArray(&nodeAlignedScales[dest], &seqAlignedScales[src], seq.numKeyframes);
             else
-               dCopyArray(&mNodeUniformScales[dest], &seqUniformScales[src], seq.numKeyframes);
+               dCopyArray(&nodeUniformScales[dest], &seqUniformScales[src], seq.numKeyframes);
          }
       }
 
@@ -685,7 +685,7 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
       seq.scaleMatters = newScaleMembership;
 
       // adjust trigger numbers...we'll read triggers after sequences...
-      seq.firstTrigger += mTriggers.size();
+      seq.firstTrigger += triggers.size();
 
       // finally, adjust ground transform's nodes states
       seq.firstGroundFrame += adjGroundStates;
@@ -693,30 +693,30 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
 
    if (smReadVersion<22)
    {
-      for (i=startSeqNum; i<mSequences.size(); i++)
+      for (i=startSeqNum; i<sequences.size(); i++)
       {
          // move ground transform data to ground vectors
-         Sequence & seq = mSequences[i];
-         S32 oldSz = mGroundTranslations.size();
-         mGroundTranslations.setSize(oldSz+seq.numGroundFrames);
-         mGroundRotations.setSize(oldSz+seq.numGroundFrames);
+         Sequence & seq = sequences[i];
+         S32 oldSz = groundTranslations.size();
+         groundTranslations.setSize(oldSz+seq.numGroundFrames);
+         groundRotations.setSize(oldSz+seq.numGroundFrames);
          for (S32 j=0;j<seq.numGroundFrames;j++)
          {
-            mGroundTranslations[j+oldSz] = mNodeTranslations[seq.firstGroundFrame+adjNodeTrans+j];
-            mGroundRotations[j+oldSz] = mNodeRotations[seq.firstGroundFrame+adjNodeRots+j];
+            groundTranslations[j+oldSz] = nodeTranslations[seq.firstGroundFrame+adjNodeTrans+j];
+            groundRotations[j+oldSz] = nodeRotations[seq.firstGroundFrame+adjNodeRots+j];
          }
          seq.firstGroundFrame = oldSz;
       }
    }
 
    // add the new triggers
-   S32 oldSz = mTriggers.size();
+   S32 oldSz = triggers.size();
    s->read(&sz);
-   mTriggers.setSize(oldSz+sz);
+   triggers.setSize(oldSz+sz);
    for (S32 i=0; i<sz;i++)
    {
-      s->read(&mTriggers[i+oldSz].state);
-      s->read(&mTriggers[i+oldSz].pos);
+      s->read(&triggers[i+oldSz].state);
+      s->read(&triggers[i+oldSz].pos);
    }
 
    if (smInitOnRead)
@@ -846,7 +846,7 @@ void TSShape::writeName(Stream * s, S32 nameIndex)
 {
    const char * name = "";
    if (nameIndex>=0)
-      name = mNames[nameIndex];
+      name = names[nameIndex];
    S32 sz = (S32)dStrlen(name);
    s->write(sz);
    if (sz)
@@ -876,9 +876,9 @@ S32 TSShape::readName(Stream * s, bool addName)
 
       if (nameIndex<0 && addName)
       {
-         nameIndex = mNames.size();
-         mNames.increment();
-         mNames.last() = buffer;
+         nameIndex = names.size();
+         names.increment();
+         names.last() = buffer;
       }
    }
 

--- a/Engine/source/ts/tsSortedMesh.cpp
+++ b/Engine/source/ts/tsSortedMesh.cpp
@@ -80,16 +80,16 @@ bool TSSortedMesh::buildConvexHull()
 S32 TSSortedMesh::getNumPolys()
 {
    S32 count = 0;
-   S32 cIdx = !mClusters.size() ? -1 : 0;
+   S32 cIdx = !clusters.size() ? -1 : 0;
    while (cIdx>=0)
    {
-      Cluster & cluster = mClusters[cIdx];
+      Cluster & cluster = clusters[cIdx];
       for (S32 i=cluster.startPrimitive; i<cluster.endPrimitive; i++)
       {
-         if (mPrimitives[i].matIndex & TSDrawPrimitive::Triangles)
-            count += mPrimitives[i].numElements / 3;
+         if (primitives[i].matIndex & TSDrawPrimitive::Triangles)
+            count += primitives[i].numElements / 3;
          else
-            count += mPrimitives[i].numElements - 2;
+            count += primitives[i].numElements - 2;
       }
       cIdx = cluster.frontCluster; // always use frontCluster...we assume about the same no matter what
    }
@@ -117,25 +117,25 @@ void TSSortedMesh::assemble(bool skip)
 
    S32 numClusters = tsalloc.get32();
    S32 * ptr32 = tsalloc.copyToShape32(numClusters*8);
-   mClusters.set(ptr32,numClusters);
+   clusters.set(ptr32,numClusters);
 
    S32 sz = tsalloc.get32();
    ptr32 = tsalloc.copyToShape32(sz);
-   mStartCluster.set(ptr32,sz);
+   startCluster.set(ptr32,sz);
 
    sz = tsalloc.get32();
    ptr32 = tsalloc.copyToShape32(sz);
-   mFirstVerts.set(ptr32,sz);
+   firstVerts.set(ptr32,sz);
 
    sz = tsalloc.get32();
    ptr32 = tsalloc.copyToShape32(sz);
-   mNumVerts.set(ptr32,sz);
+   numVerts.set(ptr32,sz);
 
    sz = tsalloc.get32();
    ptr32 = tsalloc.copyToShape32(sz);
-   mFirstTVerts.set(ptr32,sz);
+   firstTVerts.set(ptr32,sz);
 
-   mAlwaysWriteDepth = tsalloc.get32()!=0;
+   alwaysWriteDepth = tsalloc.get32()!=0;
 
    tsalloc.checkGuard();
 }
@@ -144,22 +144,22 @@ void TSSortedMesh::disassemble()
 {
    TSMesh::disassemble();
 
-   tsalloc.set32(mClusters.size());
-   tsalloc.copyToBuffer32((S32*)mClusters.address(),mClusters.size()*8);
+   tsalloc.set32(clusters.size());
+   tsalloc.copyToBuffer32((S32*)clusters.address(),clusters.size()*8);
 
-   tsalloc.set32(mStartCluster.size());
-   tsalloc.copyToBuffer32((S32*)mStartCluster.address(),mStartCluster.size());
+   tsalloc.set32(startCluster.size());
+   tsalloc.copyToBuffer32((S32*)startCluster.address(),startCluster.size());
 
-   tsalloc.set32(mFirstVerts.size());
-   tsalloc.copyToBuffer32((S32*)mFirstVerts.address(),mFirstVerts.size());
+   tsalloc.set32(firstVerts.size());
+   tsalloc.copyToBuffer32((S32*)firstVerts.address(),firstVerts.size());
 
-   tsalloc.set32(mNumVerts.size());
-   tsalloc.copyToBuffer32((S32*)mNumVerts.address(),mNumVerts.size());
+   tsalloc.set32(numVerts.size());
+   tsalloc.copyToBuffer32((S32*)numVerts.address(),numVerts.size());
 
-   tsalloc.set32(mFirstTVerts.size());
-   tsalloc.copyToBuffer32((S32*)mFirstTVerts.address(),mFirstTVerts.size());
+   tsalloc.set32(firstTVerts.size());
+   tsalloc.copyToBuffer32((S32*)firstTVerts.address(),firstTVerts.size());
 
-   tsalloc.set32(mAlwaysWriteDepth ? 1 : 0);
+   tsalloc.set32(alwaysWriteDepth ? 1 : 0);
 
    tsalloc.setGuard();
 }

--- a/Engine/source/ts/tsSortedMesh.h
+++ b/Engine/source/ts/tsSortedMesh.h
@@ -48,14 +48,14 @@ public:
                         ///< if frontCluster==backCluster, no plane to test against...
    };
 
-   Vector<Cluster> mClusters; ///< All of the clusters of primitives to be drawn
-   Vector<S32> mStartCluster; ///< indexed by frame number
-   Vector<S32> mFirstVerts;   ///< indexed by frame number
-   Vector<S32> mNumVerts;     ///< indexed by frame number
-   Vector<S32> mFirstTVerts;  ///< indexed by frame number or matFrame number, depending on which one animates (never both)
+   Vector<Cluster> clusters; ///< All of the clusters of primitives to be drawn
+   Vector<S32> startCluster; ///< indexed by frame number
+   Vector<S32> firstVerts;   ///< indexed by frame number
+   Vector<S32> numVerts;     ///< indexed by frame number
+   Vector<S32> firstTVerts;  ///< indexed by frame number or matFrame number, depending on which one animates (never both)
 
    /// sometimes, we want to write the depth value to the frame buffer even when object is translucent
-   bool mAlwaysWriteDepth;
+   bool alwaysWriteDepth;
 
    // render methods..
    void render(S32 frame, S32 matFrame, TSMaterialList *);
@@ -71,7 +71,7 @@ public:
    void disassemble();
 
    TSSortedMesh() {
-      mMeshType = SortedMeshType;
+      meshType = SortedMeshType;
    }
 };
 


### PR DESCRIPTION
It seems to be fairly unanimous that the style cleanup PR was a bad idea, especially so late in 3.7, so we'll revert it and re-add it for 3.8, subject to a little more discussion. In the meantime, get thee gone!

Note that this means the 3,000 line changeset will appear three times in the history - original merge, reversion, and reinstatement (if we decide we want it in the end). Sorry, but that's just how the cookie crumbles. Rebasing history in a public repo is a can of worms I'm not gonna open right now.