### PR TITLE
Fix GLSL include when file is empty.

### DIFF
--- a/Engine/source/gfx/gl/gfxGLShader.cpp
+++ b/Engine/source/gfx/gl/gfxGLShader.cpp
@@ -929,7 +929,7 @@ char* GFXGLShader::_handleIncludes( const Torque::Path& path, FileStream *s )
          dFree(includedText);
          manip.insert(q-buffer, sItx);
          char* manipBuf = dStrdup(manip.c_str());
-         p = manipBuf + (p - buffer);
+         p = manipBuf + (q - buffer);
          dFree(buffer);
          buffer = manipBuf;
       }


### PR DESCRIPTION
For reproduce use Opengl with BasicLighting and open Outpost level.
In BL ```autogenConditioners.h``` file are empty, and every GLSL trying to include cause this error.
```
Program shaders/common/postFx/gl/postFxV.glsl: 
GFXGLShader::initShader - Error compiling shader!
Program shaders/common/postFx/hdr/gl/brightPassFilterP.glsl: 0(412) : error C7529: OpenGL does not allow #include directives
``` 