### PR TITLE
Fix GuiTreeViewCtrl::getParentItem incorrent use in ShapeEditor script files.

### DIFF
--- a/Templates/Empty/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
+++ b/Templates/Empty/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
@@ -1132,7 +1132,7 @@ function ShapeEdNodes::onDeleteNode( %this )
 function ShapeEdNodeTreeView::getChildIndexByName( %this, %name )
 {
    %id = %this.findItemByName( %name );
-   %parentId = %this.getParent( %id );
+   %parentId = %this.getParentItem( %id );
    %childId = %this.getChild( %parentId );
    if ( %childId <= 0 )
       return 0;   // bad!
@@ -2399,7 +2399,7 @@ function ShapeEdDetailTree::onDefineIcons(%this)
 // a mesh)
 function ShapeEdDetailTree::isDetailItem( %this, %id )
 {
-   return ( %this.getParent( %id ) == 1 );
+   return ( %this.getParentItem( %id ) == 1 );
 }
 
 // Get the detail level index from the ID of an item in the details tree view
@@ -2409,7 +2409,7 @@ function ShapeEdDetailTree::getDetailLevelFromItem( %this, %id )
       %detSize = %this.getItemValue( %id );
       
    else
-      %detSize = %this.getItemValue( %this.getParent( %id ) );
+      %detSize = %this.getItemValue( %this.getParentItem( %id ) );
    return ShapeEditor.shape.getDetailLevelIndex( %detSize );
 }
 
@@ -2443,7 +2443,7 @@ function ShapeEdDetailTree::removeMeshEntry( %this, %name, %size )
    if ( ShapeEditor.shape.getDetailLevelIndex( %size ) < 0 )
    {
       // Last mesh of a detail level has been removed => remove the detail level
-      %this.removeItem( %this.getParent( %id ) );
+      %this.removeItem( %this.getParentItem( %id ) );
       ShapeEdDetails.update_onDetailsChanged();
    }
    else

--- a/Templates/Full/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
+++ b/Templates/Full/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
@@ -1132,7 +1132,7 @@ function ShapeEdNodes::onDeleteNode( %this )
 function ShapeEdNodeTreeView::getChildIndexByName( %this, %name )
 {
    %id = %this.findItemByName( %name );
-   %parentId = %this.getParent( %id );
+   %parentId = %this.getParentItem( %id );
    %childId = %this.getChild( %parentId );
    if ( %childId <= 0 )
       return 0;   // bad!
@@ -2399,7 +2399,7 @@ function ShapeEdDetailTree::onDefineIcons(%this)
 // a mesh)
 function ShapeEdDetailTree::isDetailItem( %this, %id )
 {
-   return ( %this.getParent( %id ) == 1 );
+   return ( %this.getParentItem( %id ) == 1 );
 }
 
 // Get the detail level index from the ID of an item in the details tree view
@@ -2409,7 +2409,7 @@ function ShapeEdDetailTree::getDetailLevelFromItem( %this, %id )
       %detSize = %this.getItemValue( %id );
       
    else
-      %detSize = %this.getItemValue( %this.getParent( %id ) );
+      %detSize = %this.getItemValue( %this.getParentItem( %id ) );
    return ShapeEditor.shape.getDetailLevelIndex( %detSize );
 }
 
@@ -2443,7 +2443,7 @@ function ShapeEdDetailTree::removeMeshEntry( %this, %name, %size )
    if ( ShapeEditor.shape.getDetailLevelIndex( %size ) < 0 )
    {
       // Last mesh of a detail level has been removed => remove the detail level
-      %this.removeItem( %this.getParent( %id ) );
+      %this.removeItem( %this.getParentItem( %id ) );
       ShapeEdDetails.update_onDetailsChanged();
    }
    else


### PR DESCRIPTION
Related to  Object editor lod alteration fails #1135 

If you check script files, use ```%this.getParent( %id );``` but are a invalid method:
```
DefineEngineMethod( GuiControl, getParent, GuiControl*, (),,
   "Get the immediate parent control of the control.\n"
   "@return The immediate parent GuiControl or 0 if the control is not parented to a GuiControl.\n" )
{
   return object->getParent();
}
```

Looks like the correct method is:
```
//FIXME: [rene 11/09/09 - This clashes with GuiControl.getParent(); bad thing; should be getParentItem]
DefineEngineMethod( GuiTreeViewCtrl, getParentItem, S32, (S32 itemId), ,
   "Get the parent of a given id in the tree.\n\n"
   "@param itemId TreeItemID of item that has a parent we should get.\n"
   "@return Id of parent of given item.")
{      
   return(object->getParentItem(itemId));
}
```