### PR TITLE
Fix bug on DefineConsoleMethod GuiCanvas::setVideoMode.

### DIFF
--- a/Engine/source/gui/core/guiCanvas.cpp
+++ b/Engine/source/gui/core/guiCanvas.cpp
@@ -2723,7 +2723,7 @@ DefineConsoleMethod( GuiCanvas, setVideoMode, void,
    // aren't specified, just leave them at whatever they were set to.
    if (bitDepth > 0)
    {
-      vm.bitDepth = refreshRate;
+      vm.bitDepth = bitDepth;
    }
 
    if (refreshRate > 0)


### PR DESCRIPTION
Fixes  fullscreen alt+tab erorrs #1250 

```
 if (bitDepth > 0)
{
   vm.bitDepth = refreshRate; // <- O_o
}
```