### PR TITLE
terrain texturecache prior functionality preservation

### DIFF
--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -288,7 +288,11 @@ bool TerrainBlock::_setBaseTexFormat(void *obj, const char *index, const char *d
          terrain->mBaseTexFormat = (BaseTexFormat)eTable[i].mInt;
          terrain->_updateMaterials();
          terrain->_updateLayerTexture();
-         terrain->_updateBaseTexture(true);
+         // If the cached base texture is older that the terrain file or
+         // it doesn't exist then generate and cache it.
+         String baseCachePath = terrain->_getBaseTexCacheFileName();
+         if (Platform::compareModifiedTimes(baseCachePath, terrain->mTerrFileName) < 0)
+            terrain->_updateBaseTexture(true);
          break;
       }
    }


### PR DESCRIPTION
re-enables prior functionality allowing folks to post-editor modify terrain cached textures.
pic related: http://i.imgur.com/G0NIzJk.jpg