### PR TITLE
Fix for issue #1257

### DIFF
--- a/Templates/Empty/game/tools/missionAreaEditor/main.cs
+++ b/Templates/Empty/game/tools/missionAreaEditor/main.cs
@@ -99,6 +99,27 @@ function MissionAreaEditorPlugin::onDeactivated( %this )
    Parent::onDeactivated(%this);
 }
 
+function MissionAreaEditorPlugin::setEditorFunction( %this )
+{
+   %missionAreaExists = isObject(getMissionAreaServerObject());
+
+   if( %missionAreaExists == false )
+      MessageBoxYesNoCancel("No Mission Area","Would you like to create a New Mission Area?", "MissionAreaEditorPlugin.createNewMissionArea();");
+
+   return %missionAreaExists;
+}
+
+function MissionAreaEditorPlugin::createNewMissionArea(%this)
+{
+   %newMissionArea = new MissionArea();
+   %newMissionArea.area = "-256 -256 512 512";
+
+   MissionGroup.add(%newMissionArea);
+
+   EditorGui.setEditor(MissionAreaEditorPlugin);
+
+   EWorldEditor.isDirty = true;
+}
 //-----------------------------------------------------------------------------
 // Settings
 //-----------------------------------------------------------------------------

--- a/Templates/Empty/game/tools/missionAreaEditor/missionAreaEditorGui.ed.cs
+++ b/Templates/Empty/game/tools/missionAreaEditor/missionAreaEditorGui.ed.cs
@@ -25,11 +25,14 @@ function MissionAreaEditorGui::onEditorActivated( %this )
    EWorldEditor.clearSelection();
    
    %ma = getMissionAreaServerObject();
-   EWorldEditor.selectObject( %ma );
-   EWorldEditor.syncGui();
-   MissionAreaEditorTerrainEditor.updateTerrain();
-   %this.setSelectedMissionArea( %ma );
-   %this.onMissionAreaSelected( %this.getSelectedMissionArea() );   
+   if( isObject( %ma ) )
+   {
+      EWorldEditor.selectObject( %ma );
+      EWorldEditor.syncGui();
+      MissionAreaEditorTerrainEditor.updateTerrain();
+      %this.setSelectedMissionArea( %ma );
+      %this.onMissionAreaSelected( %this.getSelectedMissionArea() );   
+   }
 }
 
 function MissionAreaEditorGui::onEditorDeactivated( %this )

--- a/Templates/Full/game/tools/missionAreaEditor/main.cs
+++ b/Templates/Full/game/tools/missionAreaEditor/main.cs
@@ -99,6 +99,27 @@ function MissionAreaEditorPlugin::onDeactivated( %this )
    Parent::onDeactivated(%this);
 }
 
+function MissionAreaEditorPlugin::setEditorFunction( %this )
+{
+   %missionAreaExists = isObject(getMissionAreaServerObject());
+
+   if( %missionAreaExists == false )
+      MessageBoxYesNoCancel("No Mission Area","Would you like to create a New Mission Area?", "MissionAreaEditorPlugin.createNewMissionArea();");
+
+   return %missionAreaExists;
+}
+
+function MissionAreaEditorPlugin::createNewMissionArea(%this)
+{
+   %newMissionArea = new MissionArea();
+   %newMissionArea.area = "-256 -256 512 512";
+
+   MissionGroup.add(%newMissionArea);
+
+   EditorGui.setEditor(MissionAreaEditorPlugin);
+
+   EWorldEditor.isDirty = true;
+}
 //-----------------------------------------------------------------------------
 // Settings
 //-----------------------------------------------------------------------------

--- a/Templates/Full/game/tools/missionAreaEditor/missionAreaEditorGui.ed.cs
+++ b/Templates/Full/game/tools/missionAreaEditor/missionAreaEditorGui.ed.cs
@@ -25,11 +25,14 @@ function MissionAreaEditorGui::onEditorActivated( %this )
    EWorldEditor.clearSelection();
    
    %ma = getMissionAreaServerObject();
-   EWorldEditor.selectObject( %ma );
-   EWorldEditor.syncGui();
-   MissionAreaEditorTerrainEditor.updateTerrain();
-   %this.setSelectedMissionArea( %ma );
-   %this.onMissionAreaSelected( %this.getSelectedMissionArea() );   
+   if( isObject( %ma ) )
+   {
+      EWorldEditor.selectObject( %ma );
+      EWorldEditor.syncGui();
+      MissionAreaEditorTerrainEditor.updateTerrain();
+      %this.setSelectedMissionArea( %ma );
+      %this.onMissionAreaSelected( %this.getSelectedMissionArea() );   
+   }
 }
 
 function MissionAreaEditorGui::onEditorDeactivated( %this )


### PR DESCRIPTION
Fixes #1257

The editor didn't test that a mission area actually existed, so when you switched to the editor, it would trigger the crash.

It now tests if there is a mission area when switching to the editor tool, and if there is not, prompts for the creation of a new one, similar to the auto-prompt for creating terrain blocks.