### PR TITLE
buttoninspector field

### DIFF
--- a/Engine/source/console/consoleObject.h
+++ b/Engine/source/console/consoleObject.h
@@ -460,6 +460,7 @@ public:
    enum FieldFlags
    {
       FIELD_HideInInspectors     = BIT( 0 ),    ///< Do not show the field in inspectors.
+      FIELD_ButtonInInspectors   = BIT( 1 ),    ///< Display as a button in inspectors.
    };
 
    struct Field 

--- a/Engine/source/gui/editor/guiInspectorTypes.cpp
+++ b/Engine/source/gui/editor/guiInspectorTypes.cpp
@@ -412,6 +412,32 @@ ConsoleDocClass( GuiInspectorTypeCheckBox,
 
 GuiControl* GuiInspectorTypeCheckBox::constructEditControl()
 {
+   if ( mField->flag.test(AbstractClassRep::FieldFlags::FIELD_ButtonInInspectors) )
+   {
+      // This checkbox (bool field) is meant to be treated as a button.
+      GuiControl* retCtrl = new GuiButtonCtrl();
+
+      // If we couldn't construct the control, bail!
+      if( retCtrl == NULL )
+         return retCtrl;
+
+      GuiButtonCtrl *button = dynamic_cast<GuiButtonCtrl*>(retCtrl);
+
+      // Let's make it look pretty.
+      retCtrl->setDataField( StringTable->insert("profile"), NULL, "InspectorTypeButtonProfile" );
+      retCtrl->setField( "text", "Click Here" );
+
+      retCtrl->setScriptValue( getData() );
+
+      _registerEditControl( retCtrl );
+
+      // Configure it to update our value when the popup is closed
+      char szBuffer[512];
+      dSprintf( szBuffer, 512, "%d.apply(%d.getValue());",getId(), button->getId() );
+      button->setField("Command", szBuffer );
+
+      return retCtrl;
+   } else {
    GuiControl* retCtrl = new GuiCheckBoxCtrl();
 
    // If we couldn't construct the control, bail!
@@ -436,6 +462,7 @@ GuiControl* GuiInspectorTypeCheckBox::constructEditControl()
    check->setField("Command", szBuffer );
 
    return retCtrl;
+   }
 }
 
 

--- a/Engine/source/gui/editor/guiInspectorTypes.cpp
+++ b/Engine/source/gui/editor/guiInspectorTypes.cpp
@@ -412,7 +412,7 @@ ConsoleDocClass( GuiInspectorTypeCheckBox,
 
 GuiControl* GuiInspectorTypeCheckBox::constructEditControl()
 {
-   if ( mField->flag.test(AbstractClassRep::FieldFlags::FIELD_ButtonInInspectors) )
+   if ( mField->flag.test(AbstractClassRep::FIELD_ButtonInInspectors) )
    {
       // This checkbox (bool field) is meant to be treated as a button.
       GuiControl* retCtrl = new GuiButtonCtrl();


### PR DESCRIPTION
extract from @andr3wmac:
adds the capacity to include an execution button via initpersistfields to tie that automatically into editors

primary example: http://i.imgur.com/oXr22sU.jpg