### PR TITLE
crash out on net stream leaks.

### DIFF
--- a/Engine/source/core/stream/bitStream.cpp
+++ b/Engine/source/core/stream/bitStream.cpp
@@ -336,7 +336,7 @@ S32 BitStream::readInt(S32 bitCount)
 
 void BitStream::writeInt(S32 val, S32 bitCount)
 {
-   AssertWarn((bitCount == 32) || ((val >> bitCount) == 0), "BitStream::writeInt: value out of range");
+   AssertFatal((bitCount == 32) || ((val >> bitCount) == 0), avar("BitStream::writeInt: value out of range: %i/%i (%i bits)", val, 1 << bitCount, bitCount));
 
    val = convertHostToLEndian(val);
    writeBits(bitCount, &val);


### PR DESCRIPTION
causes a fatal assertion when bitstream is passed an int value it cannot transmit given the provided bit length, and reports what the value and count were, respectively.

example of the revised output:

..\..\..\Engine\source\core\stream\bitStream.cpp(339,0): {Fatal} - BitStream::writeInt: value out of range: 40/32 (5 bits)
'Spire_DEBUG.exe' (Win32): Unloaded 'C:\Windows\SysWOW64\D3DCompiler_43.dll'
Error, a DecalManager (547a930) isn't properly out of the bins!
Error, a PhysicalZone (b70f240) isn't properly out of the bins!
Error, a EnvVolume (b712780) isn't properly out of the bins!
Error, a TSStatic (b7203c8) isn't properly out of the bins!