### PR TITLE
Patch to fix no-sound in Linux

### DIFF
--- a/Engine/source/platform/platformIntrinsics.gcc.h
+++ b/Engine/source/platform/platformIntrinsics.gcc.h
@@ -42,7 +42,8 @@ inline void dFetchAndAdd( volatile U32& ref, U32 val )
    #if defined(TORQUE_OS_PS3)
       cellAtomicAdd32( (std::uint32_t *)&ref, val );
    #elif !defined(TORQUE_OS_MAC)
-      __sync_fetch_and_add( ( volatile long* ) &ref, val );
+      //__sync_fetch_and_add( ( volatile long* ) &ref, val );
+      __sync_fetch_and_add(&ref, val );
    #else
       OSAtomicAdd32( val, (int32_t* ) &ref);
    #endif
@@ -53,7 +54,8 @@ inline void dFetchAndAdd( volatile S32& ref, S32 val )
    #if defined(TORQUE_OS_PS3)
       cellAtomicAdd32( (std::uint32_t *)&ref, val );
    #elif !defined(TORQUE_OS_MAC)
-      __sync_fetch_and_add( ( volatile long* ) &ref, val );
+      //__sync_fetch_and_add( ( volatile long* ) &ref, val );
+      __sync_fetch_and_add( &ref, val );
    #else
       OSAtomicAdd32( val, (int32_t* ) &ref);
    #endif

--- a/Engine/source/platform/threads/threadPool.cpp
+++ b/Engine/source/platform/threads/threadPool.cpp
@@ -418,8 +418,12 @@ void ThreadPool::queueWorkItem( WorkItem* item )
       // thread's run function.  This may lead us to release
       // the semaphore more often than necessary, but it avoids
       // a race condition.
-
-      if( !dCompareAndSwap( mNumThreadsReady, mNumThreads, mNumThreads ) )
+      
+      //Isn't there still a race condition? Why not rely entirely on the semaphore?
+      //Also, mNumThreadsReady counts threads which are busy when, in actuality, what we
+      //want is to wake a thread if any are sleeping. This conditional only wakes a thread
+      //if all are sleeping. 
+      //if( !dCompareAndSwap( mNumThreadsReady, mNumThreads, mNumThreads ) )
          mSemaphore.release();
    }
 }

--- a/Engine/source/platform/threads/threadPool.cpp
+++ b/Engine/source/platform/threads/threadPool.cpp
@@ -419,10 +419,9 @@ void ThreadPool::queueWorkItem( WorkItem* item )
       // the semaphore more often than necessary, but it avoids
       // a race condition.
       
-      //Isn't there still a race condition? Why not rely entirely on the semaphore?
-      //Also, mNumThreadsReady counts threads which are busy when, in actuality, what we
-      //want is to wake a thread if any are sleeping. This conditional only wakes a thread
-      //if all are sleeping. 
+      //Wasn't there still a race condition? Why not rely entirely on the semaphore?
+      //For example, mNumThreadsReady initializes equalto mNumThreads, which could cause
+      //initial work items to hang.
       //if( !dCompareAndSwap( mNumThreadsReady, mNumThreads, mNumThreads ) )
          mSemaphore.release();
    }


### PR DESCRIPTION
The default multi-threaded build under Linux had no sound, and this patch fixes that. There was a problem with the way that worker threads are awakened, and the background loading of sounds was not happening.

Addresses [Issue #1265](https://github.com/GarageGames/Torque3D/issues/1265)