### PR TITLE
opengl crashfix: cannot self-multiply a uniform. use a temp-variable.

### DIFF
--- a/Templates/Full/game/shaders/common/lighting/advanced/gl/pointLightP.glsl
+++ b/Templates/Full/game/shaders/common/lighting/advanced/gl/pointLightP.glsl
@@ -187,13 +187,14 @@ void main()
 
    #endif // !NO_SHADOW
    
+   vec3 lightcol = lightColor.rgb;
    #ifdef USE_COOKIE_TEX
 
       // Lookup the cookie sample.
       vec4 cookie = texture( cookieMap, tMul( viewToLightProj, -lightVec ) );
 
       // Multiply the light with the cookie tex.
-      lightColor.rgb *= cookie.rgb;
+      lightcol *= cookie.rgb;
 
       // Use a maximum channel luminance to attenuate 
       // the lighting else we get specular in the dark
@@ -211,7 +212,7 @@ void main()
                                        normalize( -eyeRay ) ) * lightBrightness * atten * shadowed;
 
    float Sat_NL_Att = saturate( nDotL * atten * shadowed ) * lightBrightness;
-   vec3 lightColorOut = lightMapParams.rgb * lightColor.rgb;
+   vec3 lightColorOut = lightMapParams.rgb * lightcol;
    vec4 addToResult = vec4(0.0);
     
    // TODO: This needs to be removed when lightmapping is disabled

--- a/Templates/Full/game/shaders/common/lighting/advanced/gl/spotLightP.glsl
+++ b/Templates/Full/game/shaders/common/lighting/advanced/gl/spotLightP.glsl
@@ -121,13 +121,14 @@ void main()
 
    #endif // !NO_SHADOW
    
+   vec3 lightcol = lightColor.rgb;
    #ifdef USE_COOKIE_TEX
 
       // Lookup the cookie sample.
       vec4 cookie = texture( cookieMap, shadowCoord );
 
       // Multiply the light with the cookie tex.
-      lightColor.rgb *= cookie.rgb;
+      lightcol *= cookie.rgb;
 
       // Use a maximum channel luminance to attenuate 
       // the lighting else we get specular in the dark
@@ -145,7 +146,7 @@ void main()
                                        normalize( -eyeRay ) ) * lightBrightness * atten * shadowed;
 
    float Sat_NL_Att = saturate( nDotL * atten * shadowed ) * lightBrightness;
-   vec3 lightColorOut = lightMapParams.rgb * lightColor.rgb;
+   vec3 lightColorOut = lightMapParams.rgb * lightcol;
    vec4 addToResult = vec4(0.0);
 
    // TODO: This needs to be removed when lightmapping is disabled

--- a/Templates/Full/game/shaders/common/lighting/advanced/pointLightP.hlsl
+++ b/Templates/Full/game/shaders/common/lighting/advanced/pointLightP.hlsl
@@ -192,13 +192,14 @@ float4 main(   ConvexConnectP IN,
 
    #endif // !NO_SHADOW
    
+   float3 lightcol = lightColor.rgb;
    #ifdef USE_COOKIE_TEX
 
       // Lookup the cookie sample.
       float4 cookie = texCUBE( cookieMap, mul( viewToLightProj, -lightVec ) );
 
       // Multiply the light with the cookie tex.
-      lightColor.rgb *= cookie.rgb;
+      lightcol *= cookie.rgb;
 
       // Use a maximum channel luminance to attenuate 
       // the lighting else we get specular in the dark
@@ -216,7 +217,7 @@ float4 main(   ConvexConnectP IN,
                                        normalize( -eyeRay ) ) * lightBrightness * atten * shadowed;
 
    float Sat_NL_Att = saturate( nDotL * atten * shadowed ) * lightBrightness;
-   float3 lightColorOut = lightMapParams.rgb * lightColor.rgb;
+   float3 lightColorOut = lightMapParams.rgb * lightcol;
    float4 addToResult = 0.0;
     
    // TODO: This needs to be removed when lightmapping is disabled

--- a/Templates/Full/game/shaders/common/lighting/advanced/spotLightP.hlsl
+++ b/Templates/Full/game/shaders/common/lighting/advanced/spotLightP.hlsl
@@ -120,13 +120,14 @@ float4 main(   ConvexConnectP IN,
 
    #endif // !NO_SHADOW
    
+   float3 lightcol = lightColor.rgb;
    #ifdef USE_COOKIE_TEX
 
       // Lookup the cookie sample.
       float4 cookie = tex2D( cookieMap, shadowCoord );
 
       // Multiply the light with the cookie tex.
-      lightColor.rgb *= cookie.rgb;
+      lightcol *= cookie.rgb;
 
       // Use a maximum channel luminance to attenuate 
       // the lighting else we get specular in the dark
@@ -144,7 +145,7 @@ float4 main(   ConvexConnectP IN,
                                        normalize( -eyeRay ) ) * lightBrightness * atten * shadowed;
 
    float Sat_NL_Att = saturate( nDotL * atten * shadowed ) * lightBrightness;
-   float3 lightColorOut = lightMapParams.rgb * lightColor.rgb;
+   float3 lightColorOut = lightMapParams.rgb * lightcol;
    float4 addToResult = 0.0;
 
    // TODO: This needs to be removed when lightmapping is disabled


### PR DESCRIPTION
opengl crashfix: cannot self-multiply a uniform. use a temp-variable. (directx altered for parity)