### PR TITLE
Add check for empty string before overwriting the object data file name

### DIFF
--- a/Engine/source/forest/forest.cpp
+++ b/Engine/source/forest/forest.cpp
@@ -354,7 +354,7 @@ void Forest::createNewFile()
 
 void Forest::saveDataFile( const char *path )
 {
-   if ( path )
+   if ( path && strcmp(path, "") != 0)
       mDataFileName = StringTable->insert( path );
 
    if ( mData )


### PR DESCRIPTION
The EngineAPI method passes in "" by default - which is not null, so passes the if(path) condition and overwrites the object's mDataFileName with an empty string.  This in turn asserts when it tries to save the file.

So, adding a check for an empty string seems the "cheapest" fix.