### PR TITLE
Apply vignette settings properly for #1302

### DIFF
--- a/Templates/Empty/game/core/scripts/client/postFx/default.postfxpreset.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/default.postfxpreset.cs
@@ -20,11 +20,13 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
+$PostFXManager::Settings::EnableVignette = "0";
 $PostFXManager::Settings::EnableDOF = "0";
 $PostFXManager::Settings::EnabledSSAO = "0";
 $PostFXManager::Settings::EnableHDR = "0";
 $PostFXManager::Settings::EnableLightRays = "0";
 $PostFXManager::Settings::EnablePostFX = "0";
+$PostFXManager::Settings::Vignette::VMax = "0.6";
 $PostFXManager::Settings::DOF::BlurCurveFar = "";
 $PostFXManager::Settings::DOF::BlurCurveNear = "";
 $PostFXManager::Settings::DOF::BlurMax = "";

--- a/Templates/Empty/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
@@ -298,6 +298,9 @@ function PostFXManager::settingsApplyFromPreset(%this)
    $DOFPostFx::FocusRangeMax           = $PostFXManager::Settings::DOF::FocusRangeMax;
    $DOFPostFx::BlurCurveNear           = $PostFXManager::Settings::DOF::BlurCurveNear;
    $DOFPostFx::BlurCurveFar            = $PostFXManager::Settings::DOF::BlurCurveFar;
+
+   //Vignette settings   
+   $VignettePostEffect::VMax           = $PostFXManager::Settings::Vignette::VMax;
   
    if ( $PostFXManager::forceEnableFromPresets )
    {
@@ -392,6 +395,8 @@ function PostFXManager::settingsApplyDOF(%this)
 
 function PostFXManager::settingsApplyVignette(%this)
 {
+   $PostFXManager::Settings::Vignette::VMax                 = $VignettePostEffect::VMax;
+
    postVerbose("% - PostFX Manager - Settings Saved - Vignette");   
    
 }

--- a/Templates/Full/game/core/scripts/client/postFx/default.postfxpreset.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/default.postfxpreset.cs
@@ -20,11 +20,13 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
+$PostFXManager::Settings::EnableVignette = "0";
 $PostFXManager::Settings::EnableDOF = "0";
 $PostFXManager::Settings::EnabledSSAO = "0";
 $PostFXManager::Settings::EnableHDR = "0";
 $PostFXManager::Settings::EnableLightRays = "0";
 $PostFXManager::Settings::EnablePostFX = "0";
+$PostFXManager::Settings::Vignette::VMax = "0.6";
 $PostFXManager::Settings::DOF::BlurCurveFar = "";
 $PostFXManager::Settings::DOF::BlurCurveNear = "";
 $PostFXManager::Settings::DOF::BlurMax = "";

--- a/Templates/Full/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/postFxManager.gui.settings.cs
@@ -298,6 +298,9 @@ function PostFXManager::settingsApplyFromPreset(%this)
    $DOFPostFx::FocusRangeMax           = $PostFXManager::Settings::DOF::FocusRangeMax;
    $DOFPostFx::BlurCurveNear           = $PostFXManager::Settings::DOF::BlurCurveNear;
    $DOFPostFx::BlurCurveFar            = $PostFXManager::Settings::DOF::BlurCurveFar;
+
+   //Vignette settings   
+   $VignettePostEffect::VMax           = $PostFXManager::Settings::Vignette::VMax;
   
    if ( $PostFXManager::forceEnableFromPresets )
    {
@@ -392,6 +395,8 @@ function PostFXManager::settingsApplyDOF(%this)
 
 function PostFXManager::settingsApplyVignette(%this)
 {
+   $PostFXManager::Settings::Vignette::VMax                 = $VignettePostEffect::VMax;
+
    postVerbose("% - PostFX Manager - Settings Saved - Vignette");   
    
 }

--- a/Templates/Full/game/levels/Outpost.postfxpreset.cs
+++ b/Templates/Full/game/levels/Outpost.postfxpreset.cs
@@ -7,6 +7,7 @@ $PostFXManager::Settings::DOF::EnableAutoFocus = "";
 $PostFXManager::Settings::DOF::EnableDOF = "";
 $PostFXManager::Settings::DOF::FocusRangeMax = "";
 $PostFXManager::Settings::DOF::FocusRangeMin = "";
+$PostFXManager::Settings::EnableVignette = "0";
 $PostFXManager::Settings::EnableDOF = "1";
 $PostFXManager::Settings::EnabledSSAO = "1";
 $PostFXManager::Settings::EnableHDR = "1";


### PR DESCRIPTION
@Duion see if this fixes #1302 for you. Seems to work fine for me!

Annoyingly, there's no cleanup before running a level-specific `postfxpreset.cs` file, so each of these files have to have settings for _all_ postFX in them, hence the change in the Outpost presets (to turn the vignette off). See #1304.