### PR TITLE
tsForestItemData: default to no bounds instead of crazy bounds

### DIFF
--- a/Engine/source/forest/ts/tsForestItemData.h
+++ b/Engine/source/forest/ts/tsForestItemData.h
@@ -88,7 +88,7 @@ public:
    const Vector<S32>& getLOSDetails() const { return mLOSDetails; }
 
    // ForestItemData
-   const Box3F& getObjBox() const { return mShape ? mShape->bounds : Box3F::Invalid; }
+   const Box3F& getObjBox() const { return mShape ? mShape->bounds : Box3F::Zero; }
    bool render( TSRenderState *rdata, const ForestItem& item ) const;
    ForestCellBatch* allocateBatch() const;
    bool canBillboard( const SceneRenderState *state, const ForestItem &item, F32 distToCamera ) const;


### PR DESCRIPTION
See #1287.

> As for the source of the crash, the problem originates in [tsForestItemData.h](https://github.com/GarageGames/Torque3D/blob/b30b5d907623a89ddb812992de1b0c588f0f41cf/Engine/source/forest/ts/tsForestItemData.h#L91). When the shape file is not found, every item gets given an invalid object box. Then, when the forest cell goes to [update its bounds](https://github.com/GarageGames/Torque3D/blob/b30b5d907623a89ddb812992de1b0c588f0f41cf/Engine/source/forest/forestCell.cpp#L180), it tries to update with all these invalid boxes.
>
> If you're missing a shape file, you really don't want a crash, you want a console error, which you do currently get.