### PR TITLE
Replace uses of dStrIsEmpty with new String::isEmpty

### DIFF
--- a/Engine/source/T3D/lightBase.cpp
+++ b/Engine/source/T3D/lightBase.cpp
@@ -431,7 +431,7 @@ DefineConsoleMethod( LightBase, playAnimation, void, (const char * anim), (""), 
    "existing one is played."
    "@hide")
 {
-	if ( dStrIsEmpty(anim) )
+	if ( String::isEmpty(anim) )
     {
         object->playAnimation();
         return;

--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -2269,7 +2269,7 @@ DefineConsoleFunction( isDefined, bool, ( const char* varName, const char* varVa
    "@endtsexample\n\n"
 	"@ingroup Scripting")
 {
-   if(dStrIsEmpty(varName))
+   if(String::isEmpty(varName))
    {
       Con::errorf("isDefined() - did you forget to put quotes around the variable name?");
       return false;
@@ -2345,7 +2345,7 @@ DefineConsoleFunction( isDefined, bool, ( const char* varName, const char* varVa
             {
                if (dStrlen(value) > 0)
                   return true;
-               else if (!dStrIsEmpty(varValue))
+               else if (!String::isEmpty(varValue))
                { 
                   obj->setDataField(valName, 0, varValue); 
                }
@@ -2362,7 +2362,7 @@ DefineConsoleFunction( isDefined, bool, ( const char* varName, const char* varVa
 
          if (ent)
             return true;
-         else if (!dStrIsEmpty(varValue))
+         else if (!String::isEmpty(varValue))
          {
             gEvalState.getCurrentFrame().setVariable(name, varValue);
          }
@@ -2377,7 +2377,7 @@ DefineConsoleFunction( isDefined, bool, ( const char* varName, const char* varVa
 
       if (ent)
          return true;
-      else if (!dStrIsEmpty(varValue))
+      else if (!String::isEmpty(varValue))
       {
          gEvalState.globalVars.setVariable(name, varValue);
       }
@@ -2387,7 +2387,7 @@ DefineConsoleFunction( isDefined, bool, ( const char* varName, const char* varVa
       // Is it an object?
       if (dStrcmp(varName, "0") && dStrcmp(varName, "") && (Sim::findObject(varName) != NULL))
          return true;
-      else if (!dStrIsEmpty(varValue))
+      else if (!String::isEmpty(varValue))
       {
          Con::errorf("%s() - can't assign a value to a variable of the form \"%s\"", __FUNCTION__, varValue);
       }

--- a/Engine/source/console/fieldBrushObject.cpp
+++ b/Engine/source/console/fieldBrushObject.cpp
@@ -216,7 +216,7 @@ DefineConsoleMethod(FieldBrushObject, queryFields, const char*, (const char* sim
     const AbstractClassRep::FieldList& staticFields = pSimObject->getFieldList();
 
     // Did we specify a groups list?
-    if ( dStrIsEmpty(groupList) )
+    if ( String::isEmpty(groupList) )
     {
         // No, so return all fields...
 

--- a/Engine/source/environment/editors/guiMeshRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiMeshRoadEditorCtrl.cpp
@@ -1248,7 +1248,7 @@ DefineConsoleMethod( GuiMeshRoadEditorCtrl, setNodeNormal, void, (Point3F normal
 
 DefineConsoleMethod( GuiMeshRoadEditorCtrl, setSelectedRoad, void, (const char * objName), (""), "" )
 {
-   if ( dStrIsEmpty(objName) )
+   if ( String::isEmpty(objName) )
       object->setSelectedRoad(NULL);
    else
    {

--- a/Engine/source/gui/core/guiControl.cpp
+++ b/Engine/source/gui/core/guiControl.cpp
@@ -2820,9 +2820,9 @@ DefineConsoleMethod( GuiControl, setExtent, void, ( const char* extOrX, const ch
    "@hide" )
 {
    Point2I extent;
-   if(!dStrIsEmpty(extOrX) && dStrIsEmpty(y))
+   if(!String::isEmpty(extOrX) && String::isEmpty(y))
       dSscanf(extOrX, "%d %d", &extent.x, &extent.y);
-   else if(!dStrIsEmpty(extOrX) && !dStrIsEmpty(y))
+   else if(!String::isEmpty(extOrX) && !String::isEmpty(y))
    {
       extent.x = dAtoi(extOrX);
       extent.y = dAtoi(y);

--- a/Engine/source/gui/worldEditor/terrainEditor.cpp
+++ b/Engine/source/gui/worldEditor/terrainEditor.cpp
@@ -2762,9 +2762,9 @@ DefineConsoleMethod(TerrainEditor, getTerrainUnderWorldPoint, S32, (const char *
    if(tEditor == NULL)
       return 0;
    Point3F pos;
-   if(!dStrIsEmpty(ptOrX) && dStrIsEmpty(Y) && dStrIsEmpty(Z))
+   if(!String::isEmpty(ptOrX) && String::isEmpty(Y) && String::isEmpty(Z))
       dSscanf(ptOrX, "%f %f %f", &pos.x, &pos.y, &pos.z);
-   else if(!dStrIsEmpty(ptOrX) && !dStrIsEmpty(Y) && !dStrIsEmpty(Z))
+   else if(!String::isEmpty(ptOrX) && !String::isEmpty(Y) && !String::isEmpty(Z))
    {
       pos.x = dAtof(ptOrX);
       pos.y = dAtof(Y);

--- a/Engine/source/sfx/sfxSystem.cpp
+++ b/Engine/source/sfx/sfxSystem.cpp
@@ -1467,7 +1467,7 @@ DefineConsoleFunction( sfxCreateSource, S32, ( const char * sfxType, const char 
    if ( track )
    {
       // In this overloaded use of the function, arg0..arg2 are x, y, and z.
-      if ( dStrIsEmpty(arg0) )
+      if ( String::isEmpty(arg0) )
       {
          source = SFX->createSource( track );
       }
@@ -1489,7 +1489,7 @@ DefineConsoleFunction( sfxCreateSource, S32, ( const char * sfxType, const char 
       }
       else
       {
-         if ( dStrIsEmpty(arg1) )
+         if ( String::isEmpty(arg1) )
          {
             source = SFX->createSource( tempProfile );
          }
@@ -1552,7 +1552,7 @@ DefineConsoleFunction( sfxPlay, S32, ( const char * trackName, const char * poin
    "Start playing the given source or create a new source for the given track and play it.\n"
    "@hide" )
 {
-   if ( dStrIsEmpty(pointOrX) )
+   if ( String::isEmpty(pointOrX) )
    {
       SFXSource* source = dynamic_cast<SFXSource*>( Sim::findObject( trackName ) );
       if ( source )
@@ -1570,11 +1570,11 @@ DefineConsoleFunction( sfxPlay, S32, ( const char * trackName, const char * poin
    }
 
    Point3F pos(0.f, 0.f, 0.f);
-   if ( !dStrIsEmpty( pointOrX ) && dStrIsEmpty( y ) && dStrIsEmpty( z )  )
+   if ( !String::isEmpty( pointOrX ) && String::isEmpty( y ) && String::isEmpty( z )  )
    {
       dSscanf( pointOrX, "%g %g %g", &pos.x, &pos.y, &pos.z );
    }
-   else if( !dStrIsEmpty( pointOrX ) && !dStrIsEmpty( y ) && !dStrIsEmpty( z ) )
+   else if( !String::isEmpty( pointOrX ) && !String::isEmpty( y ) && !String::isEmpty( z ) )
       pos.set( dAtof(pointOrX), dAtof(y), dAtof(z) );
 
    MatrixF transform;
@@ -1679,7 +1679,7 @@ DefineConsoleFunction( sfxPlayOnce, S32, ( const char * sfxType, const char * ar
    if( track )
    {
       // In this overloaded use, arg0..arg2 are x, y, z, and arg3 is the fadeInTime.
-      if (dStrIsEmpty(arg0))
+      if (String::isEmpty(arg0))
       {
          source = SFX->playOnce( track );
       }
@@ -1701,7 +1701,7 @@ DefineConsoleFunction( sfxPlayOnce, S32, ( const char * sfxType, const char * ar
       }
       else
       {
-         if (dStrIsEmpty(arg1))
+         if (String::isEmpty(arg1))
             source = SFX->playOnce( tempProfile );
          else
          {

--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -150,9 +150,9 @@ DefineConsoleFunction( getTerrainUnderWorldPoint, S32, (const char* ptOrX, const
                                                       "@hide")
 {
    Point3F pos;
-   if(!dStrIsEmpty(ptOrX) && dStrIsEmpty(y) && dStrIsEmpty(z))
+   if(!String::isEmpty(ptOrX) && String::isEmpty(y) && String::isEmpty(z))
       dSscanf(ptOrX, "%f %f %f", &pos.x, &pos.y, &pos.z);
-   else if(!dStrIsEmpty(ptOrX) && !dStrIsEmpty(y) && !dStrIsEmpty(z))
+   else if(!String::isEmpty(ptOrX) && !String::isEmpty(y) && !String::isEmpty(z))
    {
       pos.x = dAtof(ptOrX);
       pos.y = dAtof(y);
@@ -1327,9 +1327,9 @@ DefineConsoleFunction( getTerrainHeight, F32, (const char* ptOrX, const char* y)
    F32 height = 0.0f;
 
    Point2F pos;
-   if(!dStrIsEmpty(ptOrX) && dStrIsEmpty(y))
+   if(!String::isEmpty(ptOrX) && String::isEmpty(y))
       dSscanf(ptOrX, "%f %f", &pos.x, &pos.y);
-   else if(!dStrIsEmpty(ptOrX) && !dStrIsEmpty(y))
+   else if(!String::isEmpty(ptOrX) && !String::isEmpty(y))
    {
       pos.x = dAtof(ptOrX);
       pos.y = dAtof(y);
@@ -1374,9 +1374,9 @@ DefineConsoleFunction( getTerrainHeightBelowPosition, F32, (const char* ptOrX, c
 	F32 height = 0.0f;
 
    Point3F pos;
-   if(!dStrIsEmpty(ptOrX) && dStrIsEmpty(y) && dStrIsEmpty(z))
+   if(!String::isEmpty(ptOrX) && String::isEmpty(y) && String::isEmpty(z))
       dSscanf(ptOrX, "%f %f %f", &pos.x, &pos.y, &pos.z);
-   else if(!dStrIsEmpty(ptOrX) && !dStrIsEmpty(y) && !dStrIsEmpty(z))
+   else if(!String::isEmpty(ptOrX) && !String::isEmpty(y) && !String::isEmpty(z))
    {
       pos.x = dAtof(ptOrX);
       pos.y = dAtof(y);

--- a/Engine/source/ts/collada/colladaLights.cpp
+++ b/Engine/source/ts/collada/colladaLights.cpp
@@ -168,7 +168,7 @@ DefineConsoleFunction( loadColladaLights, bool, (const char * filename, const ch
    // the MissionGroup if not specified.
    SimGroup* missionGroup = dynamic_cast<SimGroup*>(Sim::findObject("MissionGroup"));
    SimGroup* group = 0;
-   if (!dStrIsEmpty(parentGroup)){
+   if (!String::isEmpty(parentGroup)){
       if (!Sim::findObject(parentGroup, group)) {
          // Create the group if it could not be found
          group = new SimGroup;
@@ -187,7 +187,7 @@ DefineConsoleFunction( loadColladaLights, bool, (const char * filename, const ch
 
    // Optional object to provide the base transform
    MatrixF offset(true);
-   if (!dStrIsEmpty(baseObject)){
+   if (!String::isEmpty(baseObject)){
       SceneObject *obj;
       if (Sim::findObject(baseObject, obj))
          offset = obj->getTransform();

--- a/Engine/source/util/settings.cpp
+++ b/Engine/source/util/settings.cpp
@@ -648,7 +648,7 @@ DefineConsoleMethod(Settings, setValue, void, (const char * settingName, const c
 {
    StringTableEntry fieldName = StringTable->insert( settingName );
    
-   if (!dStrIsEmpty(value))
+   if (!String::isEmpty(value))
       object->setValue( fieldName, value );
    else
       object->setValue( fieldName );

--- a/Engine/source/util/undo.cpp
+++ b/Engine/source/util/undo.cpp
@@ -504,7 +504,7 @@ void UndoManager::popCompound( bool discard )
 DefineConsoleMethod(UndoAction, addToManager, void, (const char * undoManager), (""), "action.addToManager([undoManager])")
 {
    UndoManager *theMan = NULL;
-   if (!dStrIsEmpty(undoManager))
+   if (!String::isEmpty(undoManager))
    {
       SimObject *obj = Sim::findObject(undoManager);
       if(obj)


### PR DESCRIPTION
Moves from using dStrIsEmpty to the new String::isEmpty static function. Keeps things cleaner, consistent, and works with intellisense.

This is the first move to replace usage of the old dStr___ functions for the more standard String namespace approach.