### PR TITLE
Replace uses of dStrCmp  with new String::compare

### DIFF
--- a/Engine/source/T3D/aiClient.cpp
+++ b/Engine/source/T3D/aiClient.cpp
@@ -403,7 +403,7 @@ void AIClient::onAdd( const char *nameSpace ) {
 
    // This doesn't work...
    //
-   if( dStrcmp( nameSpace, mNameSpace->mName ) ) {
+   if( String::compare( nameSpace, mNameSpace->mName ) ) {
       Con::linkNamespaces( mNameSpace->mName, nameSpace );
       mNameSpace = Con::lookupNamespace( nameSpace );
    }
@@ -547,7 +547,7 @@ DefineConsoleFunction( aiAddPlayer, S32, (const char * name, const char * ns), (
    aiPlayer->onConnect_callback( name );
 
    // Now execute the onAdd command and feed it the namespace
-   if(dStrcmp( ns,"" ) != 0 )
+   if(String::compare( ns,"" ) != 0 )
       aiPlayer->onAdd( ns );
    else
       aiPlayer->onAdd( "AIClient" );

--- a/Engine/source/T3D/aiPlayer.cpp
+++ b/Engine/source/T3D/aiPlayer.cpp
@@ -1028,11 +1028,11 @@ DefineEngineMethod(AIPlayer, getNavMesh, S32, (),,
 DefineEngineMethod(AIPlayer, setNavSize, void, (const char *size),,
    "@brief Set the size of NavMesh this character uses. One of \"Small\", \"Regular\" or \"Large\".")
 {
-   if(!dStrcmp(size, "Small"))
+   if(!String::compare(size, "Small"))
       object->setNavSize(AIPlayer::Small);
-   else if(!dStrcmp(size, "Regular"))
+   else if(!String::compare(size, "Regular"))
       object->setNavSize(AIPlayer::Regular);
-   else if(!dStrcmp(size, "Large"))
+   else if(!String::compare(size, "Large"))
       object->setNavSize(AIPlayer::Large);
    else
       Con::errorf("AIPlayer::setNavSize: no such size '%s'.", size);

--- a/Engine/source/T3D/fx/fxShapeReplicator.cpp
+++ b/Engine/source/T3D/fx/fxShapeReplicator.cpp
@@ -209,7 +209,7 @@ void fxShapeReplicator::CreateShapes(void)
    if (mFieldData.mHideReplications) return;
 
    // Cannot continue without shapes!
-   if (dStrcmp(mFieldData.mShapeFile, "") == 0) return;
+   if (String::compare(mFieldData.mShapeFile, "") == 0) return;
 
    // Check that we can position somewhere!
    if (!(	mFieldData.mAllowOnTerrain ||

--- a/Engine/source/T3D/gameBase/gameConnection.cpp
+++ b/Engine/source/T3D/gameBase/gameConnection.cpp
@@ -419,7 +419,7 @@ bool GameConnection::readConnectRequest(BitStream *stream, const char **errorStr
    U32 currentProtocol, minProtocol;
    char gameString[256];
    stream->readString(gameString);
-   if(dStrcmp(gameString, GameString))
+   if(String::compare(gameString, GameString))
    {
       *errorString = "CHR_GAME";
       return false;
@@ -446,7 +446,7 @@ bool GameConnection::readConnectRequest(BitStream *stream, const char **errorStr
    const char *serverPassword = Con::getVariable("pref::Server::Password");
    if(serverPassword[0])
    {
-      if(dStrcmp(joinPassword, serverPassword))
+      if(String::compare(joinPassword, serverPassword))
       {
          *errorString = "CHR_PASSWORD";
          return false;

--- a/Engine/source/T3D/gameBase/gameConnectionEvents.cpp
+++ b/Engine/source/T3D/gameBase/gameConnectionEvents.cpp
@@ -175,7 +175,7 @@ void SimDataBlockEvent::unpack(NetConnection *cptr, BitStream *bstream)
          // An object with the given ID already exists.  Make sure it has the right class.
          
          AbstractClassRep* classRep = AbstractClassRep::findClassRep( cptr->getNetClassGroup(), NetClassTypeDataBlock, classId );
-         if( classRep && dStrcmp( classRep->getClassName(), ptr->getClassName() ) != 0 )
+         if( classRep && String::compare( classRep->getClassName(), ptr->getClassName() ) != 0 )
          {
             Con::warnf( "A '%s' datablock with id: %d already existed. "
                         "Clobbering it with new '%s' datablock from server.",

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -2353,7 +2353,7 @@ void Player::getDamageLocation(const Point3F& in_rPos, const char *&out_rpVert, 
    else
       out_rpVert = "head";
 
-   if(dStrcmp(out_rpVert, "head") != 0)
+   if(String::compare(out_rpVert, "head") != 0)
    {
       if (newPoint.y >= 0.0f)
       {

--- a/Engine/source/app/mainLoop.cpp
+++ b/Engine/source/app/mainLoop.cpp
@@ -438,7 +438,7 @@ bool StandardMainLoop::handleCommandLine( S32 argc, const char **argv )
    if (argc > 1)
    {
       // If so, check if the first parameter is a file to open.
-      if ( (dStrcmp(argv[1], "") != 0 ) && (str.open(argv[1], Torque::FS::File::Read)) )
+      if ( (String::compare(argv[1], "") != 0 ) && (str.open(argv[1], Torque::FS::File::Read)) )
       {
          // If it opens, we assume it is the script to run.
          useDefaultScript = false;

--- a/Engine/source/app/net/serverQuery.cpp
+++ b/Engine/source/app/net/serverQuery.cpp
@@ -490,13 +490,13 @@ void queryMasterServer(U8 flags, const char* gameType, const char* missionType,
       sActiveFilter.type = ServerFilter::Normal;
 
       // Update the active filter:
-      if ( !sActiveFilter.gameType || dStrcmp( sActiveFilter.gameType, gameType ) != 0 )
+      if ( !sActiveFilter.gameType || String::compare( sActiveFilter.gameType, gameType ) != 0 )
       {
          sActiveFilter.gameType = (char*) dRealloc( sActiveFilter.gameType, dStrlen( gameType ) + 1 );
          dStrcpy( sActiveFilter.gameType, gameType );
       }
 
-      if ( !sActiveFilter.missionType || dStrcmp( sActiveFilter.missionType, missionType ) != 0 )
+      if ( !sActiveFilter.missionType || String::compare( sActiveFilter.missionType, missionType ) != 0 )
       {
          sActiveFilter.missionType = (char*) dRealloc( sActiveFilter.missionType, dStrlen( missionType ) + 1 );
          dStrcpy( sActiveFilter.missionType, missionType );
@@ -1728,7 +1728,7 @@ static void handleGamePingResponse( const NetAddress* address, BitStream* stream
    // Verify the version:
    char buf[256];
    stream->readString( buf );
-   if ( dStrcmp( buf, versionString ) != 0 )
+   if ( String::compare( buf, versionString ) != 0 )
    {
       // Version is different, so remove it from consideration:
       Con::printf( "Server %s is a different version.", addrString );
@@ -1943,7 +1943,7 @@ static void handleGameInfoResponse( const NetAddress* address, BitStream* stream
 
    // Get the mission type:
    stream->readString( stringBuf );
-   if ( !si->missionType || dStrcmp( si->missionType, stringBuf ) != 0 )
+   if ( !si->missionType || String::compare( si->missionType, stringBuf ) != 0 )
    {
       si->missionType = (char*) dRealloc( (void*) si->missionType, dStrlen( stringBuf ) + 1 );
       dStrcpy( si->missionType, stringBuf );
@@ -1964,7 +1964,7 @@ static void handleGameInfoResponse( const NetAddress* address, BitStream* stream
    char* temp = dStrstr( static_cast<char*>( stringBuf ), const_cast<char*>( ".mis" ) );
    if ( temp )
       *temp = '\0';
-   if ( !si->missionName || dStrcmp( si->missionName, stringBuf ) != 0 )
+   if ( !si->missionName || String::compare( si->missionName, stringBuf ) != 0 )
    {
       si->missionName = (char*) dRealloc( (void*) si->missionName, dStrlen( stringBuf ) + 1 );
       dStrcpy( si->missionName, stringBuf );
@@ -2039,7 +2039,7 @@ static void handleGameInfoResponse( const NetAddress* address, BitStream* stream
 
    // Get the server info:
    stream->readString( stringBuf );
-   if ( !si->statusString || ( isUpdate && dStrcmp( si->statusString, stringBuf ) != 0 ) )
+   if ( !si->statusString || ( isUpdate && String::compare( si->statusString, stringBuf ) != 0 ) )
    {
       si->infoString = (char*) dRealloc( (void*) si->infoString, dStrlen( stringBuf ) + 1 );
       dStrcpy( si->infoString, stringBuf );
@@ -2047,7 +2047,7 @@ static void handleGameInfoResponse( const NetAddress* address, BitStream* stream
 
    // Get the content string:
    readLongCString( stream, stringBuf );
-   if ( !si->statusString || ( isUpdate && dStrcmp( si->statusString, stringBuf ) != 0 ) )
+   if ( !si->statusString || ( isUpdate && String::compare( si->statusString, stringBuf ) != 0 ) )
    {
       si->statusString = (char*) dRealloc( (void*) si->statusString, dStrlen( stringBuf ) + 1 );
       dStrcpy( si->statusString, stringBuf );

--- a/Engine/source/cinterface/cinterface.cpp
+++ b/Engine/source/cinterface/cinterface.cpp
@@ -462,18 +462,18 @@ extern "C" {
 DefineConsoleFunction( testJavaScriptBridge, const char *, (const char* arg1, const char* arg2, const char* arg3), , "testBridge(arg1, arg2, arg3)")
 {
 	S32 failed = 0;
-		if (dStrcmp(arg1,"one"))
+		if (String::compare(arg1,"one"))
 			failed = 2;
-		if (dStrcmp(arg2,"two"))
+		if (String::compare(arg2,"two"))
 			failed = 2;
-		if (dStrcmp(arg3,"three"))
+		if (String::compare(arg3,"three"))
 			failed = 2;
 	
 
 	//attempt to call from TorqueScript -> JavaScript
 	const char* jret = Con::evaluate("JS::bridgeCallback(\"one\",\"two\",\"three\");");
 
-	if (dStrcmp(jret,"42"))
+	if (String::compare(jret,"42"))
 		failed = 3;
 
 	static const U32 bufSize = 256;

--- a/Engine/source/console/compiler.cpp
+++ b/Engine/source/console/compiler.cpp
@@ -142,7 +142,7 @@ U32 CompilerStringTable::add(const char *str, bool caseSens, bool tag)
 
       if(caseSens)
       {
-         if(!dStrcmp((*walk)->string, str))
+         if(!String::compare((*walk)->string, str))
             return (*walk)->start;
       }
       else

--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -436,7 +436,7 @@ U32 tabComplete(char* inputBuffer, U32 cursorPos, U32 maxResultLength, bool forw
    }
 
    // See if this is the same partial text as last checked.
-   if (dStrcmp(tabBuffer, inputBuffer)) 
+   if (String::compare(tabBuffer, inputBuffer)) 
    {
       // If not...
       // Save it for checking next time.

--- a/Engine/source/console/consoleDoc.cpp
+++ b/Engine/source/console/consoleDoc.cpp
@@ -135,7 +135,7 @@ void printClassHeader(const char* usage, const char * className, const char * su
          }
 
          // Print all fields that aren't associated with the 'field' keyword.
-         if( dStrcmp( keyword, "field" ) )
+         if( String::compare( keyword, "field" ) )
             Con::printf( "%s", lineStr );    // print lineStr as an unformatted string (otherwise '%' characters in the string could cause problems)
 
 

--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -135,7 +135,7 @@ DefineConsoleFunction( strcmp, S32, ( const char* str1, const char* str2 ),,
    "@see strnatcmp\n"
    "@ingroup Strings" )
 {
-   return dStrcmp( str1, str2 );
+   return String::compare( str1, str2 );
 }
 
 //-----------------------------------------------------------------------------
@@ -741,7 +741,7 @@ DefineConsoleFunction( endsWith, bool, ( const char* str, const char* suffix, bo
       return false;
       
    if( caseSensitive )
-      return ( dStrcmp( &str[ srcLen - targetLen ], suffix ) == 0 );
+      return ( String::compare( &str[ srcLen - targetLen ], suffix ) == 0 );
 
    // both src and target are non empty, create temp buffers for lowercase operation
    char* srcBuf = new char[ srcLen + 1 ];
@@ -759,7 +759,7 @@ DefineConsoleFunction( endsWith, bool, ( const char* str, const char* suffix, bo
    str += srcLen - targetLen;
 
    // do the comparison
-   bool endsWith = dStrcmp( str, suffix ) == 0;
+   bool endsWith = String::compare( str, suffix ) == 0;
 
    // delete temp buffers
    delete [] srcBuf;
@@ -2385,7 +2385,7 @@ DefineConsoleFunction( isDefined, bool, ( const char* varName, const char* varVa
    else
    {
       // Is it an object?
-      if (dStrcmp(varName, "0") && dStrcmp(varName, "") && (Sim::findObject(varName) != NULL))
+      if (String::compare(varName, "0") && String::compare(varName, "") && (Sim::findObject(varName) != NULL))
          return true;
       else if (!dStrIsEmpty(varValue))
       {

--- a/Engine/source/console/consoleInternal.cpp
+++ b/Engine/source/console/consoleInternal.cpp
@@ -1584,11 +1584,11 @@ namespace {
       if( dStrncmp( nativeType, "const ", 6 ) == 0 )
          nativeType += 6;
 
-      if( dStrcmp( nativeType, "char*" ) == 0 || dStrcmp( nativeType, "char *" ) == 0 )
+      if( String::compare( nativeType, "char*" ) == 0 || String::compare( nativeType, "char *" ) == 0 )
          return "string";
-      else if( dStrcmp( nativeType, "S32" ) == 0 || dStrcmp( nativeType, "U32" ) == 0 )
+      else if( String::compare( nativeType, "S32" ) == 0 || String::compare( nativeType, "U32" ) == 0 )
          return "int";
-      else if( dStrcmp( nativeType, "F32" ) == 0 )
+      else if( String::compare( nativeType, "F32" ) == 0 )
          return "float";
          
       const U32 length = dStrlen( nativeType );

--- a/Engine/source/console/consoleObject.cpp
+++ b/Engine/source/console/consoleObject.cpp
@@ -117,7 +117,7 @@ void AbstractClassRep::registerClassRep(AbstractClassRep* in_pRep)
 #ifdef TORQUE_DEBUG  // assert if this class is already registered.
    for(AbstractClassRep *walk = classLinkList; walk; walk = walk->nextClass)
    {
-      AssertFatal(dStrcmp(in_pRep->mClassName, walk->mClassName),
+      AssertFatal(String::compare(in_pRep->mClassName, walk->mClassName),
          "Duplicate class name registered in AbstractClassRep::registerClassRep()");
    }
 #endif

--- a/Engine/source/console/dynamicTypes.cpp
+++ b/Engine/source/console/dynamicTypes.cpp
@@ -93,7 +93,7 @@ ConsoleBaseType* ConsoleBaseType::getTypeByName(const char *typeName)
    ConsoleBaseType* walk = getListHead();
    while( walk != NULL )
    {
-      if( dStrcmp( walk->getTypeName(), typeName ) == 0 )
+      if( String::compare( walk->getTypeName(), typeName ) == 0 )
          return walk;
 
       walk = walk->getListNext();
@@ -109,7 +109,7 @@ ConsoleBaseType * ConsoleBaseType::getTypeByClassName(const char *typeName)
    ConsoleBaseType *walk = getListHead();
    while( walk != NULL )
    {
-      if( dStrcmp( walk->getTypeClassName(), typeName ) == 0 )
+      if( String::compare( walk->getTypeClassName(), typeName ) == 0 )
          return walk;
 
       walk = walk->getListNext();

--- a/Engine/source/console/fieldBrushObject.cpp
+++ b/Engine/source/console/fieldBrushObject.cpp
@@ -391,7 +391,7 @@ DefineConsoleMethod(FieldBrushObject, copyFields, void, (const char* simObjName,
 void FieldBrushObject::copyFields( SimObject* pSimObject, const char* fieldList )
 {
     // FieldBrushObject class?   
-    if ( dStrcmp(pSimObject->getClassName(), getClassName()) == 0 )
+    if ( String::compare(pSimObject->getClassName(), getClassName()) == 0 )
     {
         // Yes, so warn.
         Con::warnf("FieldBrushObject::copyFields() - Cannot copy FieldBrushObject objects!");
@@ -522,7 +522,7 @@ DefineConsoleMethod(FieldBrushObject, pasteFields, void, (const char* simObjName
 void FieldBrushObject::pasteFields( SimObject* pSimObject )
 {
     // FieldBrushObject class?   
-    if ( dStrcmp(pSimObject->getClassName(), getClassName()) == 0 )
+    if ( String::compare(pSimObject->getClassName(), getClassName()) == 0 )
     {
         // Yes, so warn.
         Con::warnf("FieldBrushObject::pasteFields() - Cannot paste FieldBrushObject objects!");
@@ -573,7 +573,7 @@ void FieldBrushObject::pasteFields( SimObject* pSimObject )
                         staticField.type != AbstractClassRep::DeprecatedFieldType )
                 {
                     // Target field?
-                    if ( dStrcmp(staticField.pFieldname, pInternalField) == 0 )
+                    if ( String::compare(staticField.pFieldname, pInternalField) == 0 )
                     {
                         // Yes, so set data.
                         pSimObject->setDataField( staticField.pFieldname, NULL, fieldEntry->value );

--- a/Engine/source/console/fileSystemFunctions.cpp
+++ b/Engine/source/console/fileSystemFunctions.cpp
@@ -463,7 +463,7 @@ DefineEngineFunction(getDirectoryList, String, ( const char* path, S32 depth ), 
 {
    // Grab the full path.
    char fullpath[1024];
-   Platform::makeFullPathName(dStrcmp(path, "/") == 0 ? "" : path, fullpath, sizeof(fullpath));
+   Platform::makeFullPathName(String::compare(path, "/") == 0 ? "" : path, fullpath, sizeof(fullpath));
 
    //dSprintf(fullpath, 511, "%s/%s", Platform::getWorkingDirectory(), path);
 

--- a/Engine/source/console/persistenceManager.cpp
+++ b/Engine/source/console/persistenceManager.cpp
@@ -890,10 +890,10 @@ PersistenceManager::ParsedObject* PersistenceManager::findParsedObject(SimObject
          {
             const ParsedProperty &prop = testObj->properties[j];
 
-            if (	dStrcmp( prop.name, "internalName" ) == 0 && 
-               dStrcmp( prop.value, object->getInternalName() ) == 0 )
+            if (	String::compare( prop.name, "internalName" ) == 0 && 
+               String::compare( prop.value, object->getInternalName() ) == 0 )
                return testObj;
-            else if ( dStrcmp(prop.name, "internalName") == 0)
+            else if ( String::compare(prop.name, "internalName") == 0)
                break;
          }
       }
@@ -1544,7 +1544,7 @@ void PersistenceManager::updateObject(SimObject* object, ParsedObject* parentObj
          if( object->getCopySource() )
          {
             const char* copySourceFieldValue = object->getCopySource()->getDataField( entry->slotName, NULL );
-            if( dStrcmp( copySourceFieldValue, entry->value ) == 0 )
+            if( String::compare( copySourceFieldValue, entry->value ) == 0 )
             {
                removeField( prop );
                continue;
@@ -1576,7 +1576,7 @@ void PersistenceManager::updateObject(SimObject* object, ParsedObject* parentObj
          if( object->getCopySource() )
          {
             const char* copySourceFieldValue = object->getCopySource()->getDataField( entry->slotName, NULL );
-            if( dStrcmp( copySourceFieldValue, entry->value ) == 0 )
+            if( String::compare( copySourceFieldValue, entry->value ) == 0 )
                continue;
          }
 
@@ -2201,7 +2201,7 @@ DefineConsoleMethod( PersistenceManager, setDirty, void,  ( const char * objName
               "Mark an existing SimObject as dirty (will be written out when saveDirty() is called).")
 {
    SimObject *dirtyObject = NULL;
-   if (dStrcmp(objName,"") != 0)
+   if (String::compare(objName,"") != 0)
    {
       if (!Sim::findObject(objName, dirtyObject))
       {
@@ -2219,7 +2219,7 @@ DefineConsoleMethod( PersistenceManager, setDirty, void,  ( const char * objName
 
    if (dirtyObject)
    {
-      if (dStrcmp( fileName,"")!=0)
+      if (String::compare( fileName,"")!=0)
          object->setDirty(dirtyObject, fileName);
       else
          object->setDirty(dirtyObject);
@@ -2230,7 +2230,7 @@ DefineConsoleMethod( PersistenceManager, removeDirty, void, ( const char * objNa
               "Remove a SimObject from the dirty list.")
 {
    SimObject *dirtyObject = NULL;
-	if (dStrcmp(  objName,"")!=0)
+	if (String::compare(  objName,"")!=0)
    {
       if (!Sim::findObject(objName, dirtyObject))
       {
@@ -2364,7 +2364,7 @@ DefineConsoleMethod( PersistenceManager, removeObjectFromFile, void, (const char
 
    if (dirtyObject)
    {
-      if (dStrcmp( filename,"")!=0)
+      if (String::compare( filename,"")!=0)
          object->removeObjectFromFile(dirtyObject, filename);
       else
          object->removeObjectFromFile(dirtyObject);
@@ -2375,7 +2375,7 @@ DefineConsoleMethod( PersistenceManager, removeField, void, (const char * objNam
               "Remove a specific field from an object declaration.")
 {
    SimObject *dirtyObject = NULL;
-   if (dStrcmp(objName,"")!=0)
+   if (String::compare(objName,"")!=0)
    {
       if (!Sim::findObject(objName, dirtyObject))
       {
@@ -2386,7 +2386,7 @@ DefineConsoleMethod( PersistenceManager, removeField, void, (const char * objNam
 
    if (dirtyObject)
    {
-      if (dStrcmp(fieldName,"") != 0)
+      if (String::compare(fieldName,"") != 0)
          object->addRemoveField(dirtyObject, fieldName);
    }
 }

--- a/Engine/source/console/sim.cpp
+++ b/Engine/source/console/sim.cpp
@@ -97,7 +97,7 @@ DefineConsoleFunction( nameToID, S32, (const char * objectName), ,"nameToID(obje
 
 DefineConsoleFunction( isObject, bool, (const char * objectName), ,"isObject(object)")
 {
-   if (!dStrcmp(objectName, "0") || !dStrcmp(objectName, ""))
+   if (!String::compare(objectName, "0") || !String::compare(objectName, ""))
       return false;
    else
       return (Sim::findObject(objectName) != NULL);

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -391,7 +391,7 @@ bool SimObject::save(const char *pcFileName, bool bOnlySelected, const char *pre
    while(!f.isEOF())
    {
       buffer = (const char *) f.readLine();
-      if(!dStrcmp(buffer, beginMessage))
+      if(!String::compare(buffer, beginMessage))
          break;
       stream->write(dStrlen(buffer), buffer);
       stream->write(2, "\r\n");
@@ -406,7 +406,7 @@ bool SimObject::save(const char *pcFileName, bool bOnlySelected, const char *pre
    while(!f.isEOF())
    {
       buffer = (const char *) f.readLine();
-      if(!dStrcmp(buffer, endMessage))
+      if(!String::compare(buffer, endMessage))
          break;
    }
    while(!f.isEOF())

--- a/Engine/source/core/fileObject.cpp
+++ b/Engine/source/core/fileObject.cpp
@@ -493,7 +493,7 @@ DefineConsoleMethod( FileObject, writeObject, void,  (const char * simName, cons
       Con::printf("FileObject::writeObject - Invalid Object!");
       return;
    }
-	if (!dStrcmp(objName,""))
+	if (!String::compare(objName,""))
        objName = NULL;
 
    object->writeObject( obj, (const U8*)objName );

--- a/Engine/source/core/stringTable.cpp
+++ b/Engine/source/core/stringTable.cpp
@@ -134,7 +134,7 @@ StringTableEntry _StringTable::insert(const char* _val, const bool caseSens)
    U32 key = hashString(val);
    walk = &buckets[key % numBuckets];
    while((temp = *walk) != NULL)   {
-      if(caseSens && !dStrcmp(temp->val, val))
+      if(caseSens && !String::compare(temp->val, val))
          return temp->val;
       else if(!caseSens && !dStricmp(temp->val, val))
          return temp->val;
@@ -174,7 +174,7 @@ StringTableEntry _StringTable::lookup(const char* val, const bool  caseSens)
    U32 key = hashString(val);
    walk = &buckets[key % numBuckets];
    while((temp = *walk) != NULL)   {
-      if(caseSens && !dStrcmp(temp->val, val))
+      if(caseSens && !String::compare(temp->val, val))
             return temp->val;
       else if(!caseSens && !dStricmp(temp->val, val))
          return temp->val;

--- a/Engine/source/core/stringTable.h
+++ b/Engine/source/core/stringTable.h
@@ -59,7 +59,7 @@
 /// pointer mapped to it. As a pointer is an integer value (usually an unsigned int),
 /// so we can do several neat things:
 ///      - StringTableEntrys can be compared directly for equality, instead of using
-///        the time-consuming dStrcmp() or dStricmp() function.
+///        the time-consuming String::compare() or dStricmp() function.
 ///      - For things like object names, we can avoid storing multiple copies of the
 ///        string containing the name. The StringTable ensures that we only ever store
 ///        one copy.

--- a/Engine/source/core/strings/stringFunctions.cpp
+++ b/Engine/source/core/strings/stringFunctions.cpp
@@ -328,7 +328,7 @@ char* dStrcpyl(char *dst, dsize_t dstSize, ...)
 }
 
 
-S32 dStrcmp( const UTF16 *str1, const UTF16 *str2)
+S32 dStrcmp(const UTF16 *str1, const UTF16 *str2)
 {
 #if defined(TORQUE_OS_WIN) || defined(TORQUE_OS_XBOX) || defined(TORQUE_OS_XENON)
    return wcscmp( reinterpret_cast<const wchar_t *>( str1 ), reinterpret_cast<const wchar_t *>( str2 ) );
@@ -484,7 +484,7 @@ bool dStrEqual(const char* str1, const char* str2)
    if (!str1 || !str2)
       return false;
    else
-      return (dStrcmp(str1, str2) == 0);
+      return (String::compare(str1, str2) == 0);
 }
 
 /// Check if one string starts with another

--- a/Engine/source/core/util/str.cpp
+++ b/Engine/source/core/util/str.cpp
@@ -439,7 +439,7 @@ namespace KeyCmp
    template<>
    inline bool equals<>( String::StringData* const& d1, String::StringData* const& d2 )
    {
-      return ( dStrcmp( d1->utf8(), d2->utf8() ) == 0 );
+      return ( String::compare( d1->utf8(), d2->utf8() ) == 0 );
    }
 }
 
@@ -1027,6 +1027,28 @@ S32 String::compare(const String &str, SizeType len, U32 mode) const
       return 0;
 
    return compare( str.c_str(), len, mode );
+}
+
+S32 String::compare(const char *str1, const char *str2)
+{
+   return strcmp(str1, str2);
+}
+
+S32 String::compare(const UTF16 *str1, const UTF16 *str2)
+{
+#if defined(TORQUE_OS_WIN) || defined(TORQUE_OS_XBOX) || defined(TORQUE_OS_XENON)
+   return wcscmp(reinterpret_cast<const wchar_t *>(str1), reinterpret_cast<const wchar_t *>(str2));
+#else
+   S32 ret;
+   const UTF16 *a, *b;
+   a = str1;
+   b = str2;
+
+   while (((ret = *a - *b) == 0) && *a && *b)
+      a++, b++;
+
+   return ret;
+#endif
 }
 
 bool String::equal(const String &str, U32 mode) const

--- a/Engine/source/core/util/str.h
+++ b/Engine/source/core/util/str.h
@@ -102,6 +102,8 @@ public:
    */
    S32 compare(const StringChar *str, SizeType len = 0, U32 mode = Case|Left) const;
    S32 compare(const String &str, SizeType len = 0, U32 mode = Case|Left) const; ///< @see compare(const StringChar *, SizeType, U32) const
+   static S32 compare(const char *str1, const char *str2);
+   static S32 compare(const UTF16 *str1, const UTF16 *str2);
 
    /**
       Compare two strings for equality.

--- a/Engine/source/core/util/tDictionary.h
+++ b/Engine/source/core/util/tDictionary.h
@@ -142,7 +142,7 @@ namespace KeyCmp
    template<>
    inline bool equals<>( const char * const &keya, const char * const &keyb )
    {
-      return ( dStrcmp( keya, keyb ) == 0 );
+      return ( String::compare( keya, keyb ) == 0 );
    }
 };
 

--- a/Engine/source/core/util/test/strTest.cpp
+++ b/Engine/source/core/util/test/strTest.cpp
@@ -103,8 +103,8 @@ TEST_FIX(Str, Test1)
       EXPECT_TRUE( !data.mData || dMemcmp( str.utf16(), data.mUTF16, str.length() * sizeof( UTF16 ) ) == 0 );
       EXPECT_TRUE( !data.mData || dMemcmp( str16.utf8(), data.mData, str.length() ) == 0 );
 
-      EXPECT_TRUE( !data.mData || dStrcmp( str.utf8(), data.mData ) == 0 );
-      EXPECT_TRUE( !data.mData || dStrcmp( str.utf16(), data.mUTF16 ) == 0 );
+      EXPECT_TRUE( !data.mData || String::compare( str.utf8(), data.mData ) == 0 );
+      EXPECT_TRUE( !data.mData || String::compare( str.utf16(), data.mUTF16 ) == 0 );
    }
 }
 

--- a/Engine/source/environment/editors/guiRiverEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRiverEditorCtrl.cpp
@@ -1454,7 +1454,7 @@ DefineConsoleMethod( GuiRiverEditorCtrl, setNodeNormal, void, (Point3F normal), 
 
 DefineConsoleMethod( GuiRiverEditorCtrl, setSelectedRiver, void, (const char * objName), (""), "" )
 {
-   if (dStrcmp( objName,"" )==0)
+   if (String::compare( objName,"" )==0)
       object->setSelectedRiver(NULL);
    else
    {

--- a/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
@@ -1077,7 +1077,7 @@ DefineConsoleMethod( GuiRoadEditorCtrl, setNodePosition, void, ( Point3F pos ), 
 
 DefineConsoleMethod( GuiRoadEditorCtrl, setSelectedRoad, void, ( const char * pathRoad ), (""), "" )
 {
-   if (dStrcmp( pathRoad,"")==0 )
+   if (String::compare( pathRoad,"")==0 )
       object->setSelectedRoad(NULL);
    else
    {

--- a/Engine/source/gui/controls/guiFileTreeCtrl.cpp
+++ b/Engine/source/gui/controls/guiFileTreeCtrl.cpp
@@ -315,7 +315,7 @@ void GuiFileTreeCtrl::recurseInsert( Item* parent, StringTableEntry path )
    {
       bool allowed = (_isDirInMainDotCsPath(value) || matchesFilters(value));
       Item *exists = parent->findChildByValue( szValue );
-      if( allowed && !exists && dStrcmp( curPos, "" ) != 0 )
+      if( allowed && !exists && String::compare( curPos, "" ) != 0 )
       {
          // Since we're adding a child this parent can't be a virtual parent, so clear that flag
          parent->setVirtualParent( false );
@@ -357,7 +357,7 @@ void GuiFileTreeCtrl::recurseInsert( Item* parent, StringTableEntry path )
    }
    if( delim )
    {
-      if( ( dStrcmp( delim, "" ) == 0 ) && item )
+      if( ( String::compare( delim, "" ) == 0 ) && item )
       {
          item->setExpanded( false );
          if( parent && _hasChildren( item->getValue() ) )

--- a/Engine/source/gui/controls/guiGameListOptionsCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListOptionsCtrl.cpp
@@ -408,7 +408,7 @@ bool GuiGameListOptionsCtrl::selectOption(S32 rowIndex, const char * theOption)
 
    for (Vector<StringTableEntry>::iterator anOption = row->mOptions.begin(); anOption < row->mOptions.end(); ++anOption)
    {
-      if (dStrcmp(*anOption, theOption) == 0)
+      if (String::compare(*anOption, theOption) == 0)
       {
          S32 newIndex = anOption - row->mOptions.begin();
          row->mSelectedOption = newIndex;

--- a/Engine/source/gui/controls/guiListBoxCtrl.cpp
+++ b/Engine/source/gui/controls/guiListBoxCtrl.cpp
@@ -513,7 +513,7 @@ S32 GuiListBoxCtrl::findItemText( StringTableEntry text, bool caseSensitive )
    for( S32 i = 0; i < mItems.size(); i++ )
    {
       // Case Sensitive Compare?
-      if( caseSensitive && ( dStrcmp( mItems[i]->itemText, text ) == 0 ) )
+      if( caseSensitive && ( String::compare( mItems[i]->itemText, text ) == 0 ) )
          return i;
       else if (!caseSensitive && ( dStricmp( mItems[i]->itemText, text ) == 0 ))
          return i;
@@ -1594,7 +1594,7 @@ void GuiListBoxCtrl::addFilteredItem( String item )
 	for ( S32 i = 0; i < mSelectedItems.size(); i++ ) 
 	{
 		String itemText = mSelectedItems[i]->itemText;
-		if ( dStrcmp( itemText.c_str(), item.c_str() ) == 0 ) 
+		if ( String::compare( itemText.c_str(), item.c_str() ) == 0 ) 
 		{
 			mSelectedItems.erase_fast( i );
 			break;
@@ -1604,7 +1604,7 @@ void GuiListBoxCtrl::addFilteredItem( String item )
 	for ( S32 i = 0; i < mItems.size(); i++ ) 
 	{
 		String itemText = mItems[i]->itemText;
-		if( dStrcmp( itemText.c_str(), item.c_str() ) == 0 )
+		if( String::compare( itemText.c_str(), item.c_str() ) == 0 )
 		{	
 			mItems[i]->isSelected = false;		
 			mFilteredItems.push_front( mItems[i] );
@@ -1637,7 +1637,7 @@ void GuiListBoxCtrl::removeFilteredItem( String item )
 	for ( S32 i = 0; i < mFilteredItems.size(); i++ ) 
 	{
 		String itemText = mFilteredItems[i]->itemText;
-		if( dStrcmp( itemText.c_str(), item.c_str() ) == 0 )
+		if( String::compare( itemText.c_str(), item.c_str() ) == 0 )
 		{			
 			mItems.push_front( mFilteredItems[i] );
 			mFilteredItems.erase( &mFilteredItems[i] );

--- a/Engine/source/gui/controls/guiPopUpCtrl.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrl.cpp
@@ -624,7 +624,7 @@ void GuiPopUpMenuCtrl::addEntry( const char *buf, S32 id, U32 scheme )
 	// Ensure that there are no other entries with exactly the same name
 	for ( U32 i = 0; i < mEntries.size(); i++ )
    {
-      if ( dStrcmp( mEntries[i].buf, buf ) == 0 )
+      if ( String::compare( mEntries[i].buf, buf ) == 0 )
          return;
    }
 
@@ -740,7 +740,7 @@ S32 GuiPopUpMenuCtrl::findText( const char* text )
 {
    for ( U32 i = 0; i < mEntries.size(); i++ )
    {
-      if ( dStrcmp( text, mEntries[i].buf ) == 0 )
+      if ( String::compare( text, mEntries[i].buf ) == 0 )
          return( mEntries[i].id );        
    }
    return( -1 );

--- a/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
@@ -827,7 +827,7 @@ void GuiPopUpMenuCtrlEx::addEntry(const char *buf, S32 id, U32 scheme)
 	// Ensure that there are no other entries with exactly the same name
 	for ( U32 i = 0; i < mEntries.size(); i++ )
    {
-      if ( dStrcmp( mEntries[i].buf, buf ) == 0 )
+      if ( String::compare( mEntries[i].buf, buf ) == 0 )
          return;
    }
 
@@ -925,7 +925,7 @@ S32 GuiPopUpMenuCtrlEx::findText( const char* text )
 {
    for ( U32 i = 0; i < mEntries.size(); i++ )
    {
-      if ( dStrcmp( text, mEntries[i].buf ) == 0 )
+      if ( String::compare( text, mEntries[i].buf ) == 0 )
          return( mEntries[i].id );        
    }
    return( -1 );

--- a/Engine/source/gui/controls/guiTextEditCtrl.cpp
+++ b/Engine/source/gui/controls/guiTextEditCtrl.cpp
@@ -229,7 +229,7 @@ void GuiTextEditCtrl::updateHistory( StringBuffer *inTxt, bool moveIndex )
       return;
 
    // see if it's already in
-   if(mHistoryLast == -1 || dStrcmp(txt, mHistoryBuf[mHistoryLast]))
+   if(mHistoryLast == -1 || String::compare(txt, mHistoryBuf[mHistoryLast]))
    {
       if(mHistoryLast == mHistorySize-1) // we're at the history limit... shuffle the pointers around:
       {

--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -4628,7 +4628,7 @@ S32 GuiTreeViewCtrl::findItemByName(const char *name)
          continue;
 	   if( mItems[i]->mState.test( Item::InspectorData ) )
 		   continue;
-      if (mItems[i] && dStrcmp(mItems[i]->getText(),name) == 0) 
+      if (mItems[i] && String::compare(mItems[i]->getText(),name) == 0) 
          return mItems[i]->mId;
    }
 
@@ -4643,7 +4643,7 @@ S32 GuiTreeViewCtrl::findItemByValue(const char *name)
    {
 	   if( mItems[i]->mState.test( Item::InspectorData ) )
 		   continue;
-	   if (mItems[i] && dStrcmp(mItems[i]->getValue(),name) == 0) 
+	   if (mItems[i] && String::compare(mItems[i]->getValue(),name) == 0) 
 		   return mItems[i]->mId;
    }
 
@@ -5203,7 +5203,7 @@ DefineEngineMethod( GuiTreeViewCtrl, getTextToRoot, const char*, (S32 itemId, co
    "@param delimiter (Optional) delimiter to use between each branch concatenation."
    "@return text from the current node to the root.")
 {
-	if (!dStrcmp(delimiter, "" ))
+	if (!String::compare(delimiter, "" ))
    {
       Con::warnf("GuiTreeViewCtrl::getTextToRoot - Invalid number of arguments!");
       return ("");

--- a/Engine/source/gui/core/guiControl.cpp
+++ b/Engine/source/gui/core/guiControl.cpp
@@ -676,7 +676,7 @@ bool GuiControl::onAdd()
    const char *cName = getClassName();
 
    // if we're a pure GuiControl, then we're a container by default.
-   if ( dStrcmp( "GuiControl", cName ) == 0 )
+   if ( String::compare( "GuiControl", cName ) == 0 )
       mIsContainer = true;
 
    // Add to root group.

--- a/Engine/source/gui/editor/guiMenuBar.cpp
+++ b/Engine/source/gui/editor/guiMenuBar.cpp
@@ -1443,7 +1443,7 @@ GuiMenuTextListCtrl::GuiMenuTextListCtrl(GuiMenuBar *ctrl)
 
 void GuiMenuTextListCtrl::onRenderCell(Point2I offset, Point2I cell, bool selected, bool mouseOver)
 {
-   if(dStrcmp(mList[cell.y].text + 3, "-\t")) //  Was: dStrcmp(mList[cell.y].text + 2, "-\t")) but has been changed to take into account the submenu flag
+   if(String::compare(mList[cell.y].text + 3, "-\t")) //  Was: String::compare(mList[cell.y].text + 2, "-\t")) but has been changed to take into account the submenu flag
       Parent::onRenderCell(offset, cell, selected, mouseOver);
    else
    {

--- a/Engine/source/gui/editor/inspector/dynamicField.cpp
+++ b/Engine/source/gui/editor/inspector/dynamicField.cpp
@@ -70,7 +70,7 @@ void GuiInspectorDynamicField::setData( const char* data, bool callbacks )
       const char *oldData = target->getDataField( mDynField->slotName, NULL );
       if ( !oldData )
          oldData = "";
-      if ( dStrcmp( oldData, data ) != 0 )
+      if ( String::compare( oldData, data ) != 0 )
       {
          target->inspectPreApply();
          

--- a/Engine/source/gui/editor/inspector/field.cpp
+++ b/Engine/source/gui/editor/inspector/field.cpp
@@ -566,7 +566,7 @@ bool GuiInspectorField::hasSameValueInAllObjects()
       if( !value2 )
          value2 = "";
 
-      if( dStrcmp( value1, value2 ) != 0 )
+      if( String::compare( value1, value2 ) != 0 )
          return false;
    }
          

--- a/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
@@ -124,7 +124,7 @@ bool GuiConvexEditorCtrl::onWake()
    SimGroup::iterator itr = missionGroup->begin();
    for ( ; itr != missionGroup->end(); itr++ )
    {
-      if ( dStrcmp( (*itr)->getClassName(), "ConvexShape" ) == 0 )
+      if ( String::compare( (*itr)->getClassName(), "ConvexShape" ) == 0 )
       {
          mConvexSEL = static_cast<ConvexShape*>( *itr );
          mGizmo->set( mConvexSEL->getTransform(), mConvexSEL->getPosition(), mConvexSEL->getScale() );

--- a/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
@@ -883,7 +883,7 @@ DefineConsoleMethod( GuiDecalEditorCtrl, getSelectionCount, S32, (), , "" )
 
 DefineConsoleMethod( GuiDecalEditorCtrl, retargetDecalDatablock, void, ( const char * dbFrom, const char * dbTo ), , "" )
 {
-   if( dStrcmp( dbFrom, "" ) != 0 && dStrcmp( dbTo, "" ) != 0 )
+   if( String::compare( dbFrom, "" ) != 0 && String::compare( dbTo, "" ) != 0 )
 		object->retargetDecalDatablock( dbFrom, dbTo );
 }
 

--- a/Engine/source/gui/worldEditor/guiMissionAreaEditor.cpp
+++ b/Engine/source/gui/worldEditor/guiMissionAreaEditor.cpp
@@ -97,7 +97,7 @@ void GuiMissionAreaEditorCtrl::setSelectedMissionArea( MissionArea *missionArea 
 
 DefineConsoleMethod( GuiMissionAreaEditorCtrl, setSelectedMissionArea, void, (const char * missionAreaName), (""), "" )
 {
-   if ( dStrcmp( missionAreaName, "" )==0 )
+   if ( String::compare( missionAreaName, "" )==0 )
       object->setSelectedMissionArea(NULL);
    else
    {

--- a/Engine/source/gui/worldEditor/terrainEditor.cpp
+++ b/Engine/source/gui/worldEditor/terrainEditor.cpp
@@ -867,7 +867,7 @@ bool TerrainEditor::isMainTile(const GridPoint & gPoint) const
    const S32 blockSize = (S32)gPoint.terrainBlock->getBlockSize();
 
    Point2I testPos = gPoint.gridPos;
-   if (!dStrcmp(getCurrentAction(),"paintMaterial"))
+   if (!String::compare(getCurrentAction(),"paintMaterial"))
    {
       if (testPos.x == blockSize)
          testPos.x--;
@@ -1181,7 +1181,7 @@ TerrainBlock* TerrainEditor::collide(const Gui3DMouseEvent & evt, Point3F & pos)
    if (mTerrainBlocks.size() == 0)
       return NULL;
 
-   if ( mMouseDown && !dStrcmp(getCurrentAction(),"paintMaterial") )
+   if ( mMouseDown && !String::compare(getCurrentAction(),"paintMaterial") )
    {
       if ( !mActiveTerrain )
          return NULL;
@@ -1779,7 +1779,7 @@ void TerrainEditor::on3DMouseDown(const Gui3DMouseEvent & event)
    if(mTerrainBlocks.size() == 0)
       return;
 
-   if (!dStrcmp(getCurrentAction(),"paintMaterial"))
+   if (!String::compare(getCurrentAction(),"paintMaterial"))
    {
       Point3F pos;
       TerrainBlock* hitTerrain = collide(event, pos);
@@ -1804,7 +1804,7 @@ void TerrainEditor::on3DMouseDown(const Gui3DMouseEvent & event)
          return;
       }
    }
-   else if ((event.modifier & SI_ALT) && !dStrcmp(getCurrentAction(),"setHeight"))
+   else if ((event.modifier & SI_ALT) && !String::compare(getCurrentAction(),"setHeight"))
    {
       // Set value to terrain height at mouse position
       GridInfo info;
@@ -1846,7 +1846,7 @@ void TerrainEditor::on3DMouseMove(const Gui3DMouseEvent & event)
       // We do not change the active terrain as the mouse moves when
       // in painting mode.  This is because it causes the material 
       // window to change as you cursor over to it.
-      if ( dStrcmp(getCurrentAction(),"paintMaterial") != 0 )
+      if ( String::compare(getCurrentAction(),"paintMaterial") != 0 )
       {
          // Set the active terrain
          bool changed = mActiveTerrain != hitTerrain;
@@ -2027,7 +2027,7 @@ void TerrainEditor::getTerrainBlocksMaterialList(Vector<StringTableEntry>& list)
 
 void TerrainEditor::setBrushType( const char *type )
 {
-   if ( mMouseBrush && dStrcmp( mMouseBrush->getType(), type ) == 0 )
+   if ( mMouseBrush && String::compare( mMouseBrush->getType(), type ) == 0 )
       return;
 
    if(!dStricmp(type, "box"))
@@ -2198,7 +2198,7 @@ void TerrainEditor::processAction(const char* sAction)
       return;
 
    TerrainAction * action = mCurrentAction;
-   if (dStrcmp(sAction, "") != 0)
+   if (String::compare(sAction, "") != 0)
    {
       action = lookupAction(sAction);
 

--- a/Engine/source/materials/materialDefinition.cpp
+++ b/Engine/source/materials/materialDefinition.cpp
@@ -645,33 +645,33 @@ DefineConsoleMethod( Material, getAnimFlags, const char*, (U32 id), , "" )
 
    if(object->mAnimFlags[ id ] & Material::Scroll)
    {
-	   if(dStrcmp( animFlags, "" ) == 0)
+	   if(String::compare( animFlags, "" ) == 0)
 	      dStrcpy( animFlags, "$Scroll" );
    }
    if(object->mAnimFlags[ id ] & Material::Rotate)
    {
-	   if(dStrcmp( animFlags, "" ) == 0)
+	   if(String::compare( animFlags, "" ) == 0)
 	      dStrcpy( animFlags, "$Rotate" );
 	   else
 			dStrcat( animFlags, " | $Rotate");
    }
    if(object->mAnimFlags[ id ] & Material::Wave)
    {
-	   if(dStrcmp( animFlags, "" ) == 0)
+	   if(String::compare( animFlags, "" ) == 0)
 	      dStrcpy( animFlags, "$Wave" );
 	   else
 			dStrcat( animFlags, " | $Wave");
    }
    if(object->mAnimFlags[ id ] & Material::Scale)
    {
-	   if(dStrcmp( animFlags, "" ) == 0)
+	   if(String::compare( animFlags, "" ) == 0)
 	      dStrcpy( animFlags, "$Scale" );
 	   else
 			dStrcat( animFlags, " | $Scale");
    }
    if(object->mAnimFlags[ id ] & Material::Sequence)
    {
-	   if(dStrcmp( animFlags, "" ) == 0)
+	   if(String::compare( animFlags, "" ) == 0)
 	      dStrcpy( animFlags, "$Sequence" );
 	   else
 			dStrcat( animFlags, " | $Sequence");

--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -315,7 +315,7 @@ void ProcessedShaderMaterial::_determineFeatures(  U32 stageNum,
 
    // TODO: This sort of sucks... BL should somehow force this
    // feature on from the outside and not this way.
-   if ( dStrcmp( LIGHTMGR->getId(), "BLM" ) == 0 )
+   if ( String::compare( LIGHTMGR->getId(), "BLM" ) == 0 )
       fd.features.addFeature( MFT_ForwardShading );
 
    // Disabling the InterlacedPrePass feature for now. It is not ready for prime-time

--- a/Engine/source/navigation/navPath.cpp
+++ b/Engine/source/navigation/navPath.cpp
@@ -135,7 +135,7 @@ bool NavPath::setProtectedFrom(void *obj, const char *index, const char *data)
 {
    NavPath *object = static_cast<NavPath*>(obj);
 
-   if(dStrcmp(data, ""))
+   if(String::compare(data, ""))
    {
       object->mFromSet = true;
       return true;
@@ -151,7 +151,7 @@ bool NavPath::setProtectedTo(void *obj, const char *index, const char *data)
 {
    NavPath *object = static_cast<NavPath*>(obj);
 
-   if(dStrcmp(data, ""))
+   if(String::compare(data, ""))
    {
       object->mToSet = true;
       return true;
@@ -709,7 +709,7 @@ DefineEngineMethod(NavPath, plan, bool, (),,
 DefineEngineMethod(NavPath, onNavMeshUpdate, void, (const char *data),,
    "@brief Callback when this path's NavMesh is loaded or rebuilt.")
 {
-   if(object->mMesh && !dStrcmp(data, object->mMesh->getIdString()))
+   if(object->mMesh && !String::compare(data, object->mMesh->getIdString()))
       object->plan();
 }
 

--- a/Engine/source/platform/platformFileIO.cpp
+++ b/Engine/source/platform/platformFileIO.cpp
@@ -117,7 +117,7 @@ void Platform::clearExcludedDirectories()
 bool Platform::isExcludedDirectory(const char *pDir)
 {
    for(CharVector::iterator i=gPlatformDirectoryExcludeList.begin(); i!=gPlatformDirectoryExcludeList.end(); i++)
-      if(!dStrcmp(pDir, *i))
+      if(!String::compare(pDir, *i))
          return true;
 
    return false;
@@ -260,18 +260,18 @@ char * Platform::makeFullPathName(const char *path, char *buffer, U32 size, cons
 
          // Directory
 
-         if(dStrcmp(ptr, "..") == 0)
+         if(String::compare(ptr, "..") == 0)
          {
             // Parent
             endptr = dStrrchr(buffer, '/');
             if (endptr)
                *endptr-- = 0;
          }
-         else if(dStrcmp(ptr, ".") == 0)
+         else if(String::compare(ptr, ".") == 0)
          {
             // Current dir
          }
-         else if(dStrcmp(ptr, "~") == 0)
+         else if(String::compare(ptr, "~") == 0)
          {
             catPath(endptr, defaultDir, size - (endptr - buffer));
             endptr += dStrlen(endptr) - 1;

--- a/Engine/source/platform/platformRedBook.cpp
+++ b/Engine/source/platform/platformRedBook.cpp
@@ -215,7 +215,7 @@ DefineConsoleFunction( redbookOpen, bool, (const char * device), (""), "(string 
 				"@brief Deprecated\n\n"
 				"@internal")
 {
-   if(dStrcmp(device,"")==0)
+   if(String::compare(device,"")==0)
       return(RedBook::open(RedBook::getDeviceName(0)));
    else
       return(RedBook::open(device));

--- a/Engine/source/platform/profiler.cpp
+++ b/Engine/source/platform/profiler.cpp
@@ -241,7 +241,7 @@ static Profiler aProfiler; // allocate the global profiler
 ProfilerRootData::ProfilerRootData(const char *name)
 {
    for(ProfilerRootData *walk = sRootList; walk; walk = walk->mNextRoot)
-      if(!dStrcmp(walk->mName, name))
+      if(!String::compare(walk->mName, name))
          AssertFatal( false, avar( "Duplicate profile name: %s", name ) );
 
    mName = name;
@@ -683,7 +683,7 @@ void Profiler::enableMarker(const char *marker, bool enable)
       }
       else
       {
-         if(!dStrcmp(marker, data->mName))
+         if(!String::compare(marker, data->mName))
             data->mEnabled = enable;
       }
    }

--- a/Engine/source/platformWin32/winFileio.cpp
+++ b/Engine/source/platformWin32/winFileio.cpp
@@ -614,7 +614,7 @@ static bool recurseDumpPath(const char *path, const char *pattern, Vector<Platfo
             continue;
 
          // skip . and .. directories
-         if (dStrcmp( findData.cFileName, TEXT( "." ) ) == 0 || dStrcmp( findData.cFileName, TEXT( ".." ) ) == 0)
+         if (String::compare( findData.cFileName, TEXT( "." ) ) == 0 || String::compare( findData.cFileName, TEXT( ".." ) ) == 0)
             continue;
 
          // Skip excluded directores
@@ -1085,7 +1085,7 @@ bool Platform::isSubDirectory(const char *pParent, const char *pDir)
          //FIXME: this has to be dStrcasecmp but there's no implementation for Unicode
 
          // and the names match
-         if (dStrcmp(dir, findData.cFileName ) == 0)
+         if (String::compare(dir, findData.cFileName ) == 0)
          {
             // then we have a real sub directory
             FindClose(handle);
@@ -1271,7 +1271,7 @@ bool Platform::hasSubDirectory(const char *pPath)
       if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
       {
          // skip . and .. directories
-         if (dStrcmp(findData.cFileName, TEXT( "." ) ) == 0 || dStrcmp(findData.cFileName, TEXT( ".." ) ) == 0)
+         if (String::compare(findData.cFileName, TEXT( "." ) ) == 0 || String::compare(findData.cFileName, TEXT( ".." ) ) == 0)
             continue;
 
 #ifdef UNICODE
@@ -1395,7 +1395,7 @@ static bool recurseDumpDirectories(const char *basePath, const char *subPath, Ve
       if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
       {
          // skip . and .. directories
-         if (dStrcmp(findData.cFileName, TEXT( "." )) == 0 || dStrcmp(findData.cFileName, TEXT( ".." )) == 0)
+         if (String::compare(findData.cFileName, TEXT( "." )) == 0 || String::compare(findData.cFileName, TEXT( ".." )) == 0)
             continue;
 
 #ifdef UNICODE

--- a/Engine/source/sfx/openal/aldlist.cpp
+++ b/Engine/source/sfx/openal/aldlist.cpp
@@ -61,7 +61,7 @@ ALDeviceList::ALDeviceList( const OPENALFNTABLE &oalft )
       index = 0;
       // go through device list (each device terminated with a single NULL, list terminated with double NULL)
       while (*devices != 0) {
-         if (dStrcmp(defaultDeviceName, devices) == 0) {
+         if (String::compare(defaultDeviceName, devices) == 0) {
             defaultDeviceIndex = index;
          }
          ALCdevice *device = ALFunction.alcOpenDevice(devices);
@@ -73,7 +73,7 @@ ALDeviceList::ALDeviceList( const OPENALFNTABLE &oalft )
                actualDeviceName = ALFunction.alcGetString(device, ALC_DEVICE_SPECIFIER);
                bool bNewName = true;
                for (int i = 0; i < GetNumDevices(); i++) {
-                  if (dStrcmp(GetDeviceName(i), actualDeviceName) == 0) {
+                  if (String::compare(GetDeviceName(i), actualDeviceName) == 0) {
                      bNewName = false;
                   }
                }

--- a/Engine/source/sfx/sfxSource.cpp
+++ b/Engine/source/sfx/sfxSource.cpp
@@ -1576,14 +1576,14 @@ DefineConsoleMethod( SFXSource, setTransform, void, ( const char * position, con
 {
    MatrixF mat = object->getTransform();
 
-   if(dStrcmp( position , "")!=0 )
+   if(String::compare( position , "")!=0 )
    {
       Point3F pos;
       dSscanf( position, "%g %g %g", &pos.x, &pos.y, &pos.z );
       mat.setPosition( pos );
    }
    
-   if(dStrcmp( direction ,"")!=0 )
+   if(String::compare( direction ,"")!=0 )
    {
       Point3F dir;
       dSscanf( direction, "%g %g %g", &dir.x, &dir.y, &dir.z );

--- a/Engine/source/shaderGen/HLSL/shaderCompHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderCompHLSL.cpp
@@ -252,11 +252,11 @@ void ParamsDefHLSL::assignConstantNumbers()
             {
                var->constNum = mCurrConst;
                // Increment our constant number based on the variable type
-               if (dStrcmp((const char*)var->type, "float4x4") == 0)
+               if (String::compare((const char*)var->type, "float4x4") == 0)
                {
                   mCurrConst += (4 * var->arraySize);
                } else {
-                  if (dStrcmp((const char*)var->type, "float3x3") == 0)
+                  if (String::compare((const char*)var->type, "float3x3") == 0)
                   {
                      mCurrConst += (3 * var->arraySize);
                   } else {

--- a/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
@@ -181,14 +181,14 @@ Var * ShaderFeatureHLSL::getVertTexCoord( const String &name )
 
    for( U32 i=0; i<LangElement::elementList.size(); i++ )
    {
-      if( !dStrcmp( (char*)LangElement::elementList[i]->name, name.c_str() ) )
+      if( !String::compare( (char*)LangElement::elementList[i]->name, name.c_str() ) )
       {
          inTex = dynamic_cast<Var*>( LangElement::elementList[i] );
          if ( inTex )
          {
             // NOTE: This used to do this check...
             //
-            // dStrcmp( (char*)inTex->structName, "IN" )
+            // String::compare( (char*)inTex->structName, "IN" )
             //
             // ... to ensure that the var was from the input
             // vertex structure, but this kept some features
@@ -377,7 +377,7 @@ Var* ShaderFeatureHLSL::getOutTexCoord(   const char *name,
       }
    }
 
-   AssertFatal( dStrcmp( type, (const char*)texCoord->type ) == 0, 
+   AssertFatal( String::compare( type, (const char*)texCoord->type ) == 0, 
       "ShaderFeatureHLSL::getOutTexCoord - Type mismatch!" );
 
    return texCoord;
@@ -399,7 +399,7 @@ Var* ShaderFeatureHLSL::getInTexCoord( const char *name,
       texCoord->mapsToSampler = mapsToSampler;
    }
 
-   AssertFatal( dStrcmp( type, (const char*)texCoord->type ) == 0, 
+   AssertFatal( String::compare( type, (const char*)texCoord->type ) == 0, 
       "ShaderFeatureHLSL::getInTexCoord - Type mismatch!" );
 
    return texCoord;
@@ -419,7 +419,7 @@ Var* ShaderFeatureHLSL::getInColor( const char *name,
       inColor->setType( type );
    }
 
-   AssertFatal( dStrcmp( type, (const char*)inColor->type ) == 0, 
+   AssertFatal( String::compare( type, (const char*)inColor->type ) == 0, 
       "ShaderFeatureHLSL::getInColor - Type mismatch!" );
 
    return inColor;

--- a/Engine/source/shaderGen/langElement.cpp
+++ b/Engine/source/shaderGen/langElement.cpp
@@ -48,7 +48,7 @@ LangElement * LangElement::find( const char *name )
 {
    for( U32 i=0; i<elementList.size(); i++ )
    {
-      if( !dStrcmp( (char*)elementList[i]->name, name ) )
+      if( !String::compare( (char*)elementList[i]->name, name ) )
       {
          return elementList[i];
       }

--- a/Engine/source/sim/netConnection.cpp
+++ b/Engine/source/sim/netConnection.cpp
@@ -1136,7 +1136,7 @@ void NetConnection::packString(BitStream *stream, const char *str)
       char buf[16];
       S32 num = dAtoi(str);
       dSprintf(buf, sizeof(buf), "%d", num);
-      if(!dStrcmp(buf, str))
+      if(!String::compare(buf, str))
       {
          stream->writeInt(Integer, 2);
          if(stream->writeFlag(num < 0))

--- a/Engine/source/sim/netStringTable.cpp
+++ b/Engine/source/sim/netStringTable.cpp
@@ -72,7 +72,7 @@ U32 NetStringTable::addString(const char *string)
    U32 bucket = hash % HashTableSize;
    for(U32 walk = hashTable[bucket];walk; walk = table[walk].next)
    {
-      if(!dStrcmp(table[walk].string, string))
+      if(!String::compare(table[walk].string, string))
       {
          table[walk].refCount++;
          return walk;

--- a/Engine/source/terrain/terrCell.cpp
+++ b/Engine/source/terrain/terrCell.cpp
@@ -1061,7 +1061,7 @@ void TerrCell::preloadMaterials()
       material->getReflectMat();
 
       if (  GFX->getPixelShaderVersion() > 2.0f && 
-            dStrcmp( LIGHTMGR->getId(), "BLM" ) != 0)
+            String::compare( LIGHTMGR->getId(), "BLM" ) != 0)
          material->getPrePassMat();
    }
 

--- a/Engine/source/terrain/terrCellMaterial.cpp
+++ b/Engine/source/terrain/terrCellMaterial.cpp
@@ -325,7 +325,7 @@ bool TerrainCellMaterial::_createPass( Vector<MaterialInfo*> *materials,
    // TODO: This seems ugly... we should trigger
    // features like this differently in the future.
    //
-   bool useBLM = dStrcmp( LIGHTMGR->getId(), "BLM" ) == 0;
+   bool useBLM = String::compare( LIGHTMGR->getId(), "BLM" ) == 0;
 
    // Do we need to disable normal mapping?
    const bool disableNormalMaps = MATMGR->getExclusionFeatures().hasFeature( MFT_NormalMap ) || useBLM;

--- a/Engine/source/ts/collada/colladaExtensions.h
+++ b/Engine/source/ts/collada/colladaExtensions.h
@@ -90,7 +90,7 @@ protected:
          // search the technique contents for the desired parameter
          for (S32 iParam = 0; iParam < pTechnique->getContents().getCount(); iParam++) {
             const domAny* param = daeSafeCast<domAny>(pTechnique->getContents()[iParam]);
-            if (param && !dStrcmp(param->getElementName(), name))
+            if (param && !String::compare(param->getElementName(), name))
                return param;
          }
       }

--- a/Engine/source/ts/collada/colladaUtils.cpp
+++ b/Engine/source/ts/collada/colladaUtils.cpp
@@ -266,7 +266,7 @@ void AnimData::parseTargetString(const char* target, S32 fullCount, const char* 
    else if (const char* p = dStrrchr(target, '.')) {
       // Check for named elements
       for (S32 iElem = 0; elements[iElem][0] != 0; iElem++) {
-         if (!dStrcmp(p, elements[iElem])) {
+         if (!String::compare(p, elements[iElem])) {
             targetValueOffset = iElem;
             targetValueCount = 1;
             break;

--- a/Engine/source/ts/tsShapeConstruct.cpp
+++ b/Engine/source/ts/tsShapeConstruct.cpp
@@ -641,7 +641,7 @@ DefineTSShapeConstructorMethod( writeChangeSet, void, (),,
    while ( !f.isEOF() )
    {
       const char* buffer = (const char *) f.readLine();
-      if ( !dStrcmp( buffer, beginMessage ))
+      if ( !String::compare( buffer, beginMessage ))
          break;
       stream->writeText( buffer );
       stream->writeText( "\r\n" );
@@ -662,7 +662,7 @@ DefineTSShapeConstructorMethod( writeChangeSet, void, (),,
    while ( !f.isEOF() )
    {
       const char* buffer = (const char *) f.readLine();
-      if ( !dStrcmp( buffer, endMessage ))
+      if ( !String::compare( buffer, endMessage ))
          break;
    }
 

--- a/Engine/source/ts/tsShapeEdit.cpp
+++ b/Engine/source/ts/tsShapeEdit.cpp
@@ -425,7 +425,7 @@ bool TSShape::addNode(const String& name, const String& parentName, const Point3
 
    // Find the parent node (OK for name to be empty => node is at root level)
    S32 parentIndex = -1;
-   if (dStrcmp(parentName, ""))
+   if (String::compare(parentName, ""))
    {
       parentIndex = findNode(parentName);
       if (parentIndex < 0)

--- a/Engine/source/ts/tsShapeInstance.cpp
+++ b/Engine/source/ts/tsShapeInstance.cpp
@@ -490,7 +490,7 @@ void TSShapeInstance::setMeshForceHidden( const char *meshName, bool hidden )
       S32 nameIndex = iter->object->nameIndex;
       const char *name = mShape->names[ nameIndex ];
 
-      if ( dStrcmp( meshName, name ) == 0 )
+      if ( String::compare( meshName, name ) == 0 )
       {
          iter->forceHidden = hidden;
          return;

--- a/Engine/source/util/messaging/eventManager.cpp
+++ b/Engine/source/util/messaging/eventManager.cpp
@@ -507,7 +507,7 @@ DefineConsoleMethod( EventManager, dumpSubscribers, void, ( const char * listene
               "Print all subscribers to an event to the console.\n"
               "@param event The event whose subscribers are to be printed. If this parameter isn't specified, all events will be dumped." )
 {
-   if (dStrcmp(listenerName, "") != 0)
+   if (String::compare(listenerName, "") != 0)
       object->dumpSubscribers( listenerName );
    else
       object->dumpSubscribers();

--- a/Engine/source/util/settings.cpp
+++ b/Engine/source/util/settings.cpp
@@ -92,9 +92,9 @@ const UTF8 *Settings::value(const UTF8 *settingName, const UTF8 *defaultValue)
    const UTF8 *storedDefaultValue = getDataField(defaultNameEntry, NULL);
    setModStaticFields(true);
 
-   if(dStrcmp(value, "") != 0)
+   if(String::compare(value, "") != 0)
       return value;
-   else if(dStrcmp(storedDefaultValue, "") != 0)
+   else if(String::compare(storedDefaultValue, "") != 0)
       return storedDefaultValue;
    else
 	  return defaultValue;
@@ -124,9 +124,9 @@ void Settings::remove(const UTF8 *settingName, bool includeDefaults)
         SimFieldDictionary::Entry* fieldEntry = *itr;
 
         // is this a field of our current group
-        if ( (dStrcmp(nameEntry, "") == 0) || 
-					dStrcmp( nameEntry, fieldEntry->slotName ) == 0 ||
-					(includeDefaults && dStrcmp( nameEntryDefault, fieldEntry->slotName ) == 0) )
+        if ( (String::compare(nameEntry, "") == 0) || 
+					String::compare( nameEntry, fieldEntry->slotName ) == 0 ||
+					(includeDefaults && String::compare( nameEntryDefault, fieldEntry->slotName ) == 0) )
         {
             // Yes, so remove it.
             pFieldDictionary->setFieldValue( fieldEntry->slotName, "" );
@@ -293,7 +293,7 @@ void Settings::readLayer(SimXMLDocument *document, String groupStack)
 	  const UTF8 *name = document->attribute("name");
 	  const UTF8 *value = document->getText();
 	  
-	  if(dStrcmp(type, "Group") == 0)
+	  if(String::compare(type, "Group") == 0)
 	  {
 		 String newStack = groupStack;
 
@@ -302,7 +302,7 @@ void Settings::readLayer(SimXMLDocument *document, String groupStack)
 
 		 newStack += name;
          readLayer(document, newStack);
-	  } else if(dStrcmp(type, "Setting") == 0)
+	  } else if(String::compare(type, "Setting") == 0)
 	  {
 		 String nameString = groupStack;
          
@@ -664,9 +664,9 @@ DefineConsoleMethod(Settings, value, const char*, (const char * settingName, con
 {
    StringTableEntry fieldName = StringTable->insert( settingName );
    
-   if (dStrcmp(defaultValue, "") != 0)
+   if (String::compare(defaultValue, "") != 0)
       return object->value( fieldName, defaultValue );
-   else if (dStrcmp(settingName, "") != 0)
+   else if (String::compare(settingName, "") != 0)
       return object->value( fieldName );
 
    return "";

--- a/Engine/source/windowManager/win32/winDispatch.cpp
+++ b/Engine/source/windowManager/win32/winDispatch.cpp
@@ -391,7 +391,7 @@ static bool _dispatch(HWND hWnd,UINT message,WPARAM wParam,WPARAM lParam)
 
 			// FIXME [tom, 5/1/2007] Hard coding this is lame since there's a const in win32Window.cpp
 			// CodeReview - this fails if there is a second jug app in the arena.
-			if (hwnd == NULL || dStrcmp(classBuf, L"TorqueJuggernaughtWindow") != 0)
+			if (hwnd == NULL || String::compare(classBuf, L"TorqueJuggernaughtWindow") != 0)
 			{
 				// We are being made inactive and the window being made active isn't
 				// a jugg window. Thus, we need to deactivate input.


### PR DESCRIPTION
Moves from using dStrCmp to the new String::compare static functions keeps things cleaner, consistent, and works with intellisense.

This is the part of the move to replace usage of the old dStr___ functions for the more standard String namespace approach.

