### PR TITLE
standardization, and fix for editors with non-occulous builds (missing popups)

### DIFF
--- a/Templates/Full/game/tools/base/utils/swatchButtons.ed.cs
+++ b/Templates/Full/game/tools/base/utils/swatchButtons.ed.cs
@@ -37,7 +37,7 @@ function GuiSwatchButtonCtrl::onMouseDragged( %this )
    
    %xOffset = getWord( %payload.extent, 0 ) / 2;
    %yOffset = getWord( %payload.extent, 1 ) / 2;  
-   %cursorpos = Canvas.getCursorPos();
+   %cursorpos = $GameCanvas.getCursorPos();
    %xPos = getWord( %cursorpos, 0 ) - %xOffset;
    %yPos = getWord( %cursorpos, 1 ) - %yOffset;
 
@@ -63,7 +63,7 @@ function GuiSwatchButtonCtrl::onMouseDragged( %this )
    
    // Start drag.
    
-   Canvas.getContent().add( %ctrl );
+   $GameCanvas.getContent().add( %ctrl );
    %ctrl.startDragging( %xOffset, %yOffset );
 }
 

--- a/Templates/Full/game/tools/datablockEditor/DatablockEditorCreatePrompt.ed.gui
+++ b/Templates/Full/game/tools/datablockEditor/DatablockEditorCreatePrompt.ed.gui
@@ -24,7 +24,7 @@
       canMinimize = "0";
       canMaximize = "0";
       canCollapse = "0";
-      closeCommand = "canvas.popDialog(DatablockEditorCreatePrompt);";
+      closeCommand = "$GameCanvas.popDialog(DatablockEditorCreatePrompt);";
       edgeSnap = "0";
       margin = "0 0 0 0";
       padding = "0 0 0 0";
@@ -137,7 +137,7 @@
          profile = "ToolsGuiButtonProfile";
          visible = "1";
          active = "1";
-         command = "canvas.popDialog(DatablockEditorCreatePrompt);";
+         command = "$GameCanvas.popDialog(DatablockEditorCreatePrompt);";
          accelerator = "escape";
          tooltipProfile = "ToolsGuiToolTipProfile";
          hovertime = "1000";

--- a/Templates/Full/game/tools/datablockEditor/datablockEditor.cs
+++ b/Templates/Full/game/tools/datablockEditor/datablockEditor.cs
@@ -383,7 +383,7 @@ function DatablockEditorPlugin::showSaveNewFileDialog(%this)
 function DatablockEditorPlugin::saveNewFileFinish( %this, %newFileName )
 {
    // Clear the first responder to capture any inspector changes
-   %ctrl = canvas.getFirstResponder();
+   %ctrl = $GameCanvas.getFirstResponder();
    if( isObject(%ctrl) )
       %ctrl.clearFirstResponder();
 
@@ -421,7 +421,7 @@ function DatablockEditorPlugin::saveNewFileFinish( %this, %newFileName )
 function DatablockEditorPlugin::save( %this )
 {
    // Clear the first responder to capture any inspector changes
-   %ctrl = canvas.getFirstResponder();
+   %ctrl = $GameCanvas.getFirstResponder();
    if( isObject(%ctrl) )
       %ctrl.clearFirstResponder();
 
@@ -669,7 +669,7 @@ function DatablockEditorPlugin::createDatablock(%this)
       
       // Show the dialog.
       
-      canvas.pushDialog( DatablockEditorCreatePrompt, 0, true );
+      $GameCanvas.pushDialog( DatablockEditorCreatePrompt, 0, true );
    }
 }
 
@@ -688,7 +688,7 @@ function DatablockEditorPlugin::createPromptNameCheck(%this)
    
    // Remove the dialog and create the datablock.
    
-   canvas.popDialog( DatablockEditorCreatePrompt );
+   $GameCanvas.popDialog( DatablockEditorCreatePrompt );
    %this.createDatablockFinish( %name, %copySource );
 }
 

--- a/Templates/Full/game/tools/debugger/gui/breakConditionDlg.ed.gui
+++ b/Templates/Full/game/tools/debugger/gui/breakConditionDlg.ed.gui
@@ -136,7 +136,7 @@
          visible = "True";
          setFirstResponder = "False";
          modal = "True";
-         command = "Canvas.popDialog(DebuggerBreakConditionDlg);";
+         command = "$GameCanvas.popDialog(DebuggerBreakConditionDlg);";
          helpTag = "0";
          text = "Cancel";
       };

--- a/Templates/Full/game/tools/debugger/gui/connectDlg.ed.gui
+++ b/Templates/Full/game/tools/debugger/gui/connectDlg.ed.gui
@@ -139,7 +139,7 @@
          visible = "True";
          setFirstResponder = "False";
          modal = "True";
-         command = "Canvas.popDialog(DebuggerConnectDlg);";
+         command = "$GameCanvas.popDialog(DebuggerConnectDlg);";
          helpTag = "0";
          text = "Cancel";
       };

--- a/Templates/Full/game/tools/debugger/gui/debugger.ed.gui
+++ b/Templates/Full/game/tools/debugger/gui/debugger.ed.gui
@@ -21,7 +21,7 @@
       visible = "True";
       setFirstResponder = "False";
       modal = "True";
-      command = "Canvas.pushDialog(DebuggerConnectDlg, 80);";
+      command = "$GameCanvas.pushDialog(DebuggerConnectDlg, 80);";
       helpTag = "0";
       text = "Connect";
    };
@@ -35,7 +35,7 @@
       visible = "True";
       setFirstResponder = "False";
       modal = "True";
-      command = "Canvas.pushDialog(OpenFileDialog, 80);";
+      command = "$GameCanvas.pushDialog(OpenFileDialog, 80);";
       helpTag = "0";
       text = "File";
    };
@@ -109,7 +109,7 @@
       visible = "True";
       setFirstResponder = "False";
       modal = "True";
-      command = "Canvas.pushDialog(DebuggerFindDlg, 80);";
+      command = "$GameCanvas.pushDialog(DebuggerFindDlg, 80);";
       helpTag = "0";
       text = "Find";
    };
@@ -267,7 +267,7 @@
                visible = "True";
                setFirstResponder = "False";
                modal = "True";
-               command = "Canvas.pushDialog(DebuggerWatchDlg, 80);";
+               command = "$GameCanvas.pushDialog(DebuggerWatchDlg, 80);";
                helpTag = "0";
                text = "Add";
             };
@@ -281,7 +281,7 @@
                visible = "True";
                setFirstResponder = "False";
                modal = "True";
-               command = "Canvas.pushDialog(DebuggerEditWatchDlg, 80);";
+               command = "$GameCanvas.pushDialog(DebuggerEditWatchDlg, 80);";
                helpTag = "0";
                text = "Edit";
             };
@@ -436,7 +436,7 @@
                visible = "True";
                setFirstResponder = "False";
                modal = "True";
-               command = "Canvas.pushDialog(DebuggerBreakConditionDlg, 80);";
+               command = "$GameCanvas.pushDialog(DebuggerBreakConditionDlg, 80);";
                helpTag = "0";
                text = "Condition";
             };

--- a/Templates/Full/game/tools/debugger/gui/editWatchDlg.ed.gui
+++ b/Templates/Full/game/tools/debugger/gui/editWatchDlg.ed.gui
@@ -84,7 +84,7 @@
          visible = "True";
          setFirstResponder = "False";
          modal = "True";
-         command = "Canvas.popDialog(DebuggerEditWatchDlg);";
+         command = "$GameCanvas.popDialog(DebuggerEditWatchDlg);";
          helpTag = "0";
          text = "Cancel";
       };

--- a/Templates/Full/game/tools/debugger/gui/findDlg.ed.gui
+++ b/Templates/Full/game/tools/debugger/gui/findDlg.ed.gui
@@ -84,7 +84,7 @@
          visible = "True";
          setFirstResponder = "False";
          modal = "True";
-         command = "Canvas.popDialog(DebuggerFindDlg);";
+         command = "$GameCanvas.popDialog(DebuggerFindDlg);";
          helpTag = "0";
          text = "Cancel";
       };

--- a/Templates/Full/game/tools/debugger/gui/watchDlg.ed.gui
+++ b/Templates/Full/game/tools/debugger/gui/watchDlg.ed.gui
@@ -83,7 +83,7 @@
          visible = "True";
          setFirstResponder = "False";
          modal = "True";
-         command = "Canvas.popDialog(DebuggerWatchDlg);";
+         command = "$GameCanvas.popDialog(DebuggerWatchDlg);";
          helpTag = "0";
          text = "Cancel";
       };

--- a/Templates/Full/game/tools/debugger/main.cs
+++ b/Templates/Full/game/tools/debugger/main.cs
@@ -64,5 +64,5 @@ function startDebugger()
    
    // Set up the GUI.
    DebuggerConsoleView.setActive(false);
-   Canvas.pushDialog(DebuggerGui);
+   $GameCanvas.pushDialog(DebuggerGui);
 }

--- a/Templates/Full/game/tools/debugger/scripts/debugger.ed.cs
+++ b/Templates/Full/game/tools/debugger/scripts/debugger.ed.cs
@@ -301,7 +301,7 @@ function DbgWatchDialogAdd()
       TCPDebugger.send("EVAL " @ $DbgWatchSeq @ " 0 " @ %expr @ "\r\n");
       $DbgWatchSeq++;
    }
-   Canvas.popDialog(DebuggerWatchDlg);
+   $GameCanvas.popDialog(DebuggerWatchDlg);
 }
 
 // Edit a watch expression.
@@ -320,7 +320,7 @@ function DbgWatchDialogEdit()
       }
       TCPDebugger.send("EVAL " @ %id  @ " 0 " @ %assignment @ "\r\n");
    }
-   Canvas.popDialog(DebuggerEditWatchDlg);
+   $GameCanvas.popDialog(DebuggerEditWatchDlg);
 }
 
 // Set/change the singular "cursor watch" expression.
@@ -348,7 +348,7 @@ function DbgConnect()
       TCPDebugger.password = %password;
    }
 
-   Canvas.popDialog(DebuggerConnectDlg);
+   $GameCanvas.popDialog(DebuggerConnectDlg);
 }
 
 // Put a condition on a breakpoint.
@@ -375,7 +375,7 @@ function DbgBreakConditionSet()
       DbgSetBreakPoint(getField(%bkp, 1), getField(%bkp, 0), %clear, %passct, %condition);
    }
 
-   Canvas.popDialog(DebuggerBreakConditionDlg);
+   $GameCanvas.popDialog(DebuggerBreakConditionDlg);
 }
 
 // Open a file, go to the indicated line, and optionally select the line.
@@ -401,7 +401,7 @@ function DbgFileViewFind()
    %searchString = DebuggerFindStringText.getValue();
    DebuggerFileView.findString(%searchString);
 
-   Canvas.popDialog(DebuggerFindDlg);
+   $GameCanvas.popDialog(DebuggerFindDlg);
 }
 
 // Set a breakpoint, optionally with condition.

--- a/Templates/Full/game/tools/decalEditor/decalEditorGui.cs
+++ b/Templates/Full/game/tools/decalEditor/decalEditorGui.cs
@@ -129,7 +129,7 @@ function DecalDataList::onSelect( %this, %id, %text )
    // Update the materialEditorList
    $Tools::materialEditorList = %data.getId();
    
-   //Canvas.pushDialog( DecalEditDlg );
+   //$GameCanvas.pushDialog( DecalEditDlg );
    DecalInspector.inspect( %data );
    DecalEditorGui.updateDecalPreview( %data.material );
 }
@@ -172,7 +172,7 @@ function NewDecalButton::onClick( %this )
    %id = DecalDataList.findItemText( %name );
    DecalDataList.setSelected( %id, true );
       
-   Canvas.pushDialog( DecalEditDlg );
+   $GameCanvas.pushDialog( DecalEditDlg );
    DecalInspector.inspect( %name );
 }
 

--- a/Templates/Full/game/tools/editorClasses/scripts/contextPopup.ed.cs
+++ b/Templates/Full/game/tools/editorClasses/scripts/contextPopup.ed.cs
@@ -139,7 +139,7 @@ function ContextDialogContainer::Show( %this, %positionX, %positionY, %delay )
    if( %positionX !$= "" && %positionY !$= "" )
       %this.Dialog.setPositionGlobal( %positionX, %positionY );
    
-   Canvas.pushDialog( %this.base, 99 );
+   $GameCanvas.pushDialog( %this.base, 99 );
    
    // Setup Delay Schedule   
    if( isEventPending( %this.popSchedule ) )
@@ -164,7 +164,7 @@ function ContextDialogContainer::Show( %this, %positionX, %positionY, %delay )
 function ContextDialogContainer::Hide( %this )
 {
    if( %this.isPushed == true )
-      Canvas.popDialog( %this.base );
+      $GameCanvas.popDialog( %this.base );
       
    // Restore Old Parent;
    if( isObject( %this.Dialog ) && isObject( %this.oldParent ) )

--- a/Templates/Full/game/tools/forestEditor/forestEditToolbar.ed.gui
+++ b/Templates/Full/game/tools/forestEditor/forestEditToolbar.ed.gui
@@ -131,7 +131,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(ForestBrushSizeSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(ForestBrushSizeSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes size of the brush";
             hovertime = "750";
@@ -233,7 +233,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(ForestBrushPressureSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(ForestBrushPressureSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes the pressure";
             hovertime = "750";
@@ -335,7 +335,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(ForestBrushHardnessSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(ForestBrushHardnessSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes the hardness curve.";
             hovertime = "750";

--- a/Templates/Full/game/tools/gui/colladaImport.ed.gui
+++ b/Templates/Full/game/tools/gui/colladaImport.ed.gui
@@ -21,7 +21,7 @@
       canMinimize = "0";
       canMaximize = "0";
       minSize = "50 50";
-      closeCommand = "Canvas.popDialog(ColladaImportDlg);";
+      closeCommand = "$GameCanvas.popDialog(ColladaImportDlg);";
       EdgeSnap = "1";
       text = "";
       Margin = "0 0 0 0";
@@ -1299,7 +1299,7 @@ function ColladaImportDlg::showDialog(%this, %shapePath, %cmd)
       %this-->loadLights.setStateOn(0);
    }
 
-   Canvas.pushDialog(%this);
+   $GameCanvas.pushDialog(%this);
 
    ColladaImportTreeView.refresh("all");
 }
@@ -1507,13 +1507,13 @@ function ColladaImportTreeView::refreshNode(%this, %id)
 
 function ColladaImportDlg::onCancel(%this)
 {
-   Canvas.popDialog(%this);
+   $GameCanvas.popDialog(%this);
    ColladaImportTreeView.clear();
 }
 
 function ColladaImportDlg::onOK(%this)
 {
-   Canvas.popDialog(%this);
+   $GameCanvas.popDialog(%this);
    ColladaImportTreeView.clear();
 
    // Need to create a TSShapeConstructor object if any settings are not
@@ -1642,11 +1642,11 @@ function updateTSShapeLoadProgress(%progress, %msg)
       {
          ColladaImportProgress-->window.text = "Importing" SPC %msg;
          %msg = "Reading file into memory...";
-         Canvas.pushDialog(ColladaImportProgress);
+         $GameCanvas.pushDialog(ColladaImportProgress);
       }
       else if ( %progress == 1.0 )
       {
-         Canvas.popDialog(ColladaImportProgress);
+         $GameCanvas.popDialog(ColladaImportProgress);
       }
 
       %progressCtrl = ColladaImportProgress-->progressBar;
@@ -1665,7 +1665,7 @@ function updateTSShapeLoadProgress(%progress, %msg)
       %textCtrl.setText(%msg);
    }
 
-   Canvas.repaint(33);
+   $GameCanvas.repaint(33);
 }
 
 

--- a/Templates/Full/game/tools/gui/fileDialogBase.ed.cs
+++ b/Templates/Full/game/tools/gui/fileDialogBase.ed.cs
@@ -251,7 +251,7 @@ function FileDialogOkButton::onClick( %this )
    //
    %fullPath = %path @ "/" @ %fileName;
    
-   Canvas.popDialog( %this.parent );
+   $GameCanvas.popDialog( %this.parent );
 
    // Callback      
    eval( %this.parent.SuccessCallback @ "(\"" @ %fullPath @"\");" );
@@ -264,7 +264,7 @@ function FileDialogOkButton::onClick( %this )
 
 function FileDialogCancelButton::onClick( %this )
 {
-   Canvas.popDialog( %this.parent );
+   $GameCanvas.popDialog( %this.parent );
    //error("Cancel");
 }
 

--- a/Templates/Full/game/tools/gui/guiObjectInspector.ed.cs
+++ b/Templates/Full/game/tools/gui/guiObjectInspector.ed.cs
@@ -47,7 +47,7 @@ function inspectObject( %object )
    
    %guiContent.init( %object );
       
-   Canvas.getContent().add( %guiContent );
+   $GameCanvas.getContent().add( %guiContent );
 }
 
 //=============================================================================================

--- a/Templates/Full/game/tools/gui/materialSelector.ed.gui
+++ b/Templates/Full/game/tools/gui/materialSelector.ed.gui
@@ -742,7 +742,7 @@ function MaterialSelector::showDialogBase( %this, %selectCallback, %returnType, 
    MaterialSelector-->materialPreviewCountPopup.add( "100", 5 );
    MaterialSelector-->materialPreviewCountPopup.setSelected( $Pref::MaterialSelector::ThumbnailCountIndex );
    
-   Canvas.pushDialog(MaterialSelectorOverlay);
+   $GameCanvas.pushDialog(MaterialSelectorOverlay);
    MaterialSelector.setVisible(1);
    MaterialSelector.buildStaticFilters();   
    
@@ -754,7 +754,7 @@ function MaterialSelector::hideDialog( %this )
 {
    MaterialSelector.breakdown();
    MaterialSelector.setVisible(0);
-   Canvas.popDialog(MaterialSelectorOverlay);
+   $GameCanvas.popDialog(MaterialSelectorOverlay);
 }
 
 function MaterialSelector::breakdown( %this )

--- a/Templates/Full/game/tools/gui/messageBoxOKBuy.ed.gui
+++ b/Templates/Full/game/tools/gui/messageBoxOKBuy.ed.gui
@@ -78,7 +78,7 @@ function MessageBoxOKBuy(%title, %message, %OKCallback, %BuyCallback)
 {
    MBOKBuyFrame.text = %title;
    MessageBoxOKBuyDlg.profile = "ToolsGuiOverlayProfile";
-   Canvas.pushDialog(MessageBoxOKBuyDlg);
+   $GameCanvas.pushDialog(MessageBoxOKBuyDlg);
    MBSetText(MBOKBuyText, MBOKBuyFrame, %message);
    MessageBoxOKBuyDlg.OKCallback = %OKCallback;
    MessageBoxOKBuyDlg.BuyCallback = %BuyCallback;

--- a/Templates/Full/game/tools/gui/saveChangesMBDlg.ed.gui
+++ b/Templates/Full/game/tools/gui/saveChangesMBDlg.ed.gui
@@ -145,19 +145,19 @@ function mbSaveDlgSaveButton::onClick( %this )
 {
    if( MessageBoxSaveChangesDlg.SaveCallback !$= "" )
       eval( MessageBoxSaveChangesDlg.SaveCallback @ "(" @ MessageBoxSaveChangesDlg.Data @ ");" );
-   Canvas.popDialog( MessageBoxSaveChangesDlg );
+   $GameCanvas.popDialog( MessageBoxSaveChangesDlg );
 }
 
 function mbSaveDlgCancelButton::onClick( %this )
 {
-   Canvas.popDialog( MessageBoxSaveChangesDlg );
+   $GameCanvas.popDialog( MessageBoxSaveChangesDlg );
 }
 
 function mbSaveDlgDontButton::onClick( %this )
 {
    if( MessageBoxSaveChangesDlg.DontSaveCallback !$= "" )
       eval( MessageBoxSaveChangesDlg.DontSaveCallback @ "(" @ MessageBoxSaveChangesDlg.Data @ ");" );
-   Canvas.popDialog( MessageBoxSaveChangesDlg );
+   $GameCanvas.popDialog( MessageBoxSaveChangesDlg );
 }
 
 // Deprecated when platform layers are all sufficient
@@ -176,5 +176,5 @@ function checkSaveChangesOld( %data, %saveCallback, %dontSaveCallback )
    MessageBoxSaveChangesDlg.Data = %data;
    
    // Show Dialog
-   Canvas.pushDialog( MessageBoxSaveChangesDlg );
+   $GameCanvas.pushDialog( MessageBoxSaveChangesDlg );
 }

--- a/Templates/Full/game/tools/gui/simViewDlg.ed.gui
+++ b/Templates/Full/game/tools/gui/simViewDlg.ed.gui
@@ -31,7 +31,7 @@
       canMinimize = "1";
       canMaximize = "1";
       minSize = "50 50";
-      closeCommand = "Canvas.popDialog(simViewDlg);";
+      closeCommand = "$GameCanvas.popDialog(simViewDlg);";
 
       new GuiScrollCtrl() {
          canSaveDynamicFields = "0";
@@ -322,8 +322,8 @@ function InspectTreeView::onSelect(%this, %obj)
 
 function Tree(%obj)
 {
-   Canvas.popDialog("simViewDlg");
-   Canvas.pushDialog("simViewDlg", 20);
+   $GameCanvas.popDialog("simViewDlg");
+   $GameCanvas.pushDialog("simViewDlg", 20);
    InspectTreeView.open(%obj);
 }
 

--- a/Templates/Full/game/tools/gui/uvEditor.ed.gui
+++ b/Templates/Full/game/tools/gui/uvEditor.ed.gui
@@ -550,14 +550,14 @@ function UVEditor::showDialog( %this, %applyCallback, %obj, %uv)
    UVEditor-->uvHandles.useCustomColor = true;
    UVEditor-->uvHandles.handleColor = %popup.getColorById(%popup.getSelected());
    
-   Canvas.pushDialog(UVEditorOverlay);
+   $GameCanvas.pushDialog(UVEditorOverlay);
    UVEditor.setVisible(1);
 }
 
 function UVEditor::hideDialog( %this )
 {
    UVEditor.setVisible(0);
-   Canvas.popDialog(UVEditorOverlay);
+   $GameCanvas.popDialog(UVEditorOverlay);
 }
 
 function UVEditor::apply( %this )

--- a/Templates/Full/game/tools/guiEditor/gui/EditorChooseGUI.ed.gui
+++ b/Templates/Full/game/tools/guiEditor/gui/EditorChooseGUI.ed.gui
@@ -193,7 +193,7 @@
          MinExtent = "8 2";
          canSave = "1";
          Visible = "1";
-         Command = "GuiEditorNewGuiDialog.init( \"NewGui\", \"GuiControl\" );" @ "Canvas.pushdialog(GuiEditorNewGuiDialog);";
+         Command = "GuiEditorNewGuiDialog.init( \"NewGui\", \"GuiControl\" );" @ "$GameCanvas.pushdialog(GuiEditorNewGuiDialog);";
          tooltipprofile = "ToolsGuiToolTipProfile";
          hovertime = "1000";
          text = "New GUI";

--- a/Templates/Full/game/tools/guiEditor/gui/guiEditorPrefsDlg.ed.gui
+++ b/Templates/Full/game/tools/guiEditor/gui/guiEditorPrefsDlg.ed.gui
@@ -34,7 +34,7 @@
       canMinimize = "0";
       canMaximize = "0";
       minSize = "50 50";
-      closeCommand = "Canvas.popDialog(\"GuiEditorPrefsDlg\");";
+      closeCommand = "$GameCanvas.popDialog(\"GuiEditorPrefsDlg\");";
       EdgeSnap = "0";
       text = "Gui Editor Grid Preferences";
 

--- a/Templates/Full/game/tools/guiEditor/scripts/EditorChooseGUI.ed.cs
+++ b/Templates/Full/game/tools/guiEditor/scripts/EditorChooseGUI.ed.cs
@@ -54,7 +54,7 @@ function GE_OpenGUIFile()
       MessageBox( getEngineName(),
          "You have loaded a Gui file that was created before this version.  It has been loaded but you must open it manually from the content list dropdown",
          "Ok", "Information" );   
-      GuiEditContent( Canvas.getContent() );
+      GuiEditContent( $GameCanvas.getContent() );
       return 0;
    }
 

--- a/Templates/Full/game/tools/guiEditor/scripts/guiEditor.ed.cs
+++ b/Templates/Full/game/tools/guiEditor/scripts/guiEditor.ed.cs
@@ -30,7 +30,7 @@ $MLAAFxGuiEditorTemp = false;
 
 function GuiEdit( %val )
 {
-   if (Canvas.isFullscreen())
+   if ($GameCanvas.isFullscreen())
    {
       MessageBoxOK("Windowed Mode Required", "Please switch to windowed mode to access the GUI Editor.");
       return;
@@ -41,7 +41,7 @@ function GuiEdit( %val )
 
    if (!$InGuiEditor)
    {
-      GuiEditContent(Canvas.getContent());
+      GuiEditContent($GameCanvas.getContent());
       
       //Temp fix to disable MLAA when in GUI editor
       if( isObject(MLAAFx) && MLAAFx.isEnabled==true )
@@ -100,7 +100,7 @@ package GuiEditor_BlockDialogs
 
 function GuiEditor::openForEditing( %this, %content )
 {   
-   Canvas.setContent( GuiEditorGui );
+   $GameCanvas.setContent( GuiEditorGui );
    while( GuiEditorContent.getCount() )
       GuiGroup.add( GuiEditorContent.getObject( 0 ) ); // get rid of anything being edited
       
@@ -212,7 +212,7 @@ function GuiEditor::enableMenuItems(%this, %val)
 
 function GuiEditor::showPrefsDialog(%this)
 {
-   Canvas.pushDialog(GuiEditorPrefsDlg);
+   $GameCanvas.pushDialog(GuiEditorPrefsDlg);
 }
 
 //---------------------------------------------------------------------------------------------

--- a/Templates/Full/game/tools/guiEditor/scripts/guiEditorPrefsDlg.ed.cs
+++ b/Templates/Full/game/tools/guiEditor/scripts/guiEditorPrefsDlg.ed.cs
@@ -33,12 +33,12 @@ function GuiEditorPrefsDlgOkBtn::onAction(%this)
    if( GuiEditor.snap2grid )
       GuiEditor.setSnapToGrid( GuiEditor.snap2gridsize );
       
-   Canvas.popDialog( GuiEditorPrefsDlg );
+   $GameCanvas.popDialog( GuiEditorPrefsDlg );
 }
 
 function GuiEditorPrefsDlgCancelBtn::onAction(%this)
 {
-   Canvas.popDialog( GuiEditorPrefsDlg );
+   $GameCanvas.popDialog( GuiEditorPrefsDlg );
 }
 
 function GuiEditorPrefsDlgDefaultsBtn::onAction(%this)

--- a/Templates/Full/game/tools/guiEditor/scripts/guiEditorToolbox.ed.cs
+++ b/Templates/Full/game/tools/guiEditor/scripts/guiEditorToolbox.ed.cs
@@ -297,7 +297,7 @@ function GuiEditorToolbox::startGuiControlDrag( %this, %class )
    %yOffset = getWord( %payload.extent, 1 ) / 2;  
    
    // position where the drag will start, to prevent visible jumping.
-   %cursorpos = Canvas.getCursorPos();
+   %cursorpos = $GameCanvas.getCursorPos();
    %xPos = getWord( %cursorpos, 0 ) - %xOffset;
    %yPos = getWord( %cursorpos, 1 ) - %yOffset;
    
@@ -320,7 +320,7 @@ function GuiEditorToolbox::startGuiControlDrag( %this, %class )
    };
    
    %dragCtrl.add( %payload );
-   Canvas.getContent().add( %dragCtrl );
+   $GameCanvas.getContent().add( %dragCtrl );
    
    // Start drag.
 

--- a/Templates/Full/game/tools/meshRoadEditor/meshRoadEditorToolbar.gui
+++ b/Templates/Full/game/tools/meshRoadEditor/meshRoadEditorToolbar.gui
@@ -173,7 +173,7 @@
          MinExtent = "8 2";
          canSave = "1";
          Visible = "1";
-         Command = "Canvas.pushDialog(MeshRoadDefaultWidthSliderCtrlContainer);";
+         Command = "$GameCanvas.pushDialog(MeshRoadDefaultWidthSliderCtrlContainer);";
          tooltipprofile = "ToolsGuiToolTipProfile";
          ToolTip = "Changes Default Road Width";
          hovertime = "750";
@@ -251,7 +251,7 @@
          MinExtent = "8 2";
          canSave = "1";
          Visible = "1";
-         Command = "Canvas.pushDialog(MeshRoadDefaultDepthSliderCtrlContainer);";
+         Command = "$GameCanvas.pushDialog(MeshRoadDefaultDepthSliderCtrlContainer);";
          tooltipprofile = "ToolsGuiToolTipProfile";
          ToolTip = "Changes Default Road Depth";
          hovertime = "750";

--- a/Templates/Full/game/tools/navEditor/CreateNewNavMeshDlg.gui
+++ b/Templates/Full/game/tools/navEditor/CreateNewNavMeshDlg.gui
@@ -23,7 +23,7 @@
       canMinimize = "0";
       canMaximize = "0";
       canCollapse = "0";
-      closeCommand = "Canvas.popDialog(CreateNewNavMeshDlg);";
+      closeCommand = "$GameCanvas.popDialog(CreateNewNavMeshDlg);";
       edgeSnap = "1";
       margin = "0 0 0 0";
       padding = "0 0 0 0";
@@ -274,7 +274,7 @@
          profile = "GuiButtonProfile";
          visible = "1";
          active = "1";
-         command = "Canvas.popDialog(CreateNewNavMeshDlg);";
+         command = "$GameCanvas.popDialog(CreateNewNavMeshDlg);";
          tooltipProfile = "GuiToolTipProfile";
          hovertime = "1000";
          isContainer = "0";
@@ -383,7 +383,7 @@ function CreateNewNavMeshDlg::create(%this)
    MissionGroup.add(%mesh);
    NavEditorGui.selectObject(%mesh);
 
-   Canvas.popDialog(CreateNewNavMeshDlg);
+   $GameCanvas.popDialog(CreateNewNavMeshDlg);
 }
 
 function MeshMissionBounds::onClick(%this)

--- a/Templates/Full/game/tools/navEditor/NavEditorGui.gui
+++ b/Templates/Full/game/tools/navEditor/NavEditorGui.gui
@@ -76,7 +76,7 @@
          position = "115 2";
          extent = "90 18";
          text = "New NavMesh";
-         command = "Canvas.pushDialog(CreateNewNavMeshDlg);";
+         command = "$GameCanvas.pushDialog(CreateNewNavMeshDlg);";
       };
 
       new GuiContainer(){

--- a/Templates/Full/game/tools/navEditor/main.cs
+++ b/Templates/Full/game/tools/navEditor/main.cs
@@ -133,7 +133,7 @@ function NavEditorPlugin::onActivated(%this)
    if(ServerNavMeshSet.getCount() == 0)
 	  MessageBoxYesNo("No NavMesh", "There is no NavMesh in this level. Would you like to create one?" SPC
 	                                "If not, please use the Nav Editor to create a new NavMesh.",
-	                                "Canvas.pushDialog(CreateNewNavMeshDlg);");
+	                                "$GameCanvas.pushDialog(CreateNewNavMeshDlg);");
    NavTreeView.open(ServerNavMeshSet, true);
 
    // Push our keybindings to the top. (See initializeNavEditor for where this

--- a/Templates/Full/game/tools/riverEditor/RiverEditorToolbar.gui
+++ b/Templates/Full/game/tools/riverEditor/RiverEditorToolbar.gui
@@ -174,7 +174,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(RiverDefaultWidthSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(RiverDefaultWidthSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes Default River Width";
             hovertime = "750";
@@ -252,7 +252,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(RiverDefaultDepthSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(RiverDefaultDepthSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes Default River Depth";
             hovertime = "750";

--- a/Templates/Full/game/tools/roadEditor/RoadEditorToolbar.gui
+++ b/Templates/Full/game/tools/roadEditor/RoadEditorToolbar.gui
@@ -173,7 +173,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(RoadDefaultWidthSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(RoadDefaultWidthSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes Default Road Width";
             hovertime = "750";

--- a/Templates/Full/game/tools/roadEditor/main.cs
+++ b/Templates/Full/game/tools/roadEditor/main.cs
@@ -166,7 +166,7 @@ function RoadEditorPlugin::setEditorFunction( %this )
    %terrainExists = parseMissionGroup( "TerrainBlock" );
 
    if( %terrainExists == false )
-      MessageBoxYesNoCancel("No Terrain","Would you like to create a New Terrain?", "Canvas.pushDialog(CreateNewTerrainGui);");
+      MessageBoxYesNoCancel("No Terrain","Would you like to create a New Terrain?", "$GameCanvas.pushDialog(CreateNewTerrainGui);");
    
    return %terrainExists;
 }

--- a/Templates/Full/game/tools/shapeEditor/gui/shapeEdAdvancedWindow.ed.gui
+++ b/Templates/Full/game/tools/shapeEditor/gui/shapeEdAdvancedWindow.ed.gui
@@ -1818,13 +1818,13 @@ new GuiControl(ShapeEdWaitGui,EditorGuiGroup) {
 function ShapeEdWaitGui::show(%this, %text)
 {
    %this-->message.setText( %text );
-   Canvas.pushDialog( %this );
-   Canvas.repaint();
+   $GameCanvas.pushDialog( %this );
+   $GameCanvas.repaint();
 }
 
 function ShapeEdWaitGui::hide(%this)
 {
-   Canvas.popDialog( %this );
+   $GameCanvas.popDialog( %this );
 }
 
 function ShapeEdWaitGui::onWake(%this)

--- a/Templates/Full/game/tools/shapeEditor/main.cs
+++ b/Templates/Full/game/tools/shapeEditor/main.cs
@@ -207,7 +207,7 @@ function ShapeEditorPlugin::open(%this, %filename)
       ShapeEditor.selectShape(%filename, ShapeEditor.isDirty());
 
       // 'fitToShape' only works after the GUI has been rendered, so force a repaint first
-      Canvas.repaint();
+      $GameCanvas.repaint();
       ShapeEdShapeView.fitToShape();
    }
 }
@@ -233,7 +233,7 @@ function ShapeEditorPlugin::onActivated(%this)
                ShapeEdShapeTreeView.onSelect(%obj);
 
             // 'fitToShape' only works after the GUI has been rendered, so force a repaint first
-            Canvas.repaint();
+            $GameCanvas.repaint();
             ShapeEdShapeView.fitToShape();
          }
          break;

--- a/Templates/Full/game/tools/worldEditor/gui/EditorGui.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/EditorGui.ed.gui
@@ -205,7 +205,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(CameraSpeedDropdownCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(CameraSpeedDropdownCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes the Camera Speed";
             hovertime = "750";

--- a/Templates/Full/game/tools/worldEditor/gui/GenericPromptDialog.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/GenericPromptDialog.ed.gui
@@ -44,7 +44,7 @@
       minSize = "50 50";
       EdgeSnap = "1";
       text = "Error";
-      closeCommand = "Canvas.popDialog(GenericPromptDialog);";
+      closeCommand = "$GameCanvas.popDialog(GenericPromptDialog);";
 
       new GuiTextCtrl() {
          canSaveDynamicFields = "0";
@@ -82,7 +82,7 @@
          MinExtent = "8 2";
          canSave = "1";
          Visible = "1";
-         Command = "Canvas.popDialog(GenericPromptDialog);";
+         Command = "$GameCanvas.popDialog(GenericPromptDialog);";
          tooltipprofile = "ToolsGuiToolTipProfile";
          hovertime = "1000";
          text = "OK";
@@ -102,7 +102,7 @@
          MinExtent = "8 2";
          canSave = "1";
          Visible = "0";
-         Command = "Canvas.popDialog(GenericPromptDialog);";
+         Command = "$GameCanvas.popDialog(GenericPromptDialog);";
          tooltipprofile = "ToolsGuiToolTipProfile";
          hovertime = "1000";
          text = "Cancel";

--- a/Templates/Full/game/tools/worldEditor/gui/ProceduralTerrainPainterGui.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/ProceduralTerrainPainterGui.gui
@@ -43,7 +43,7 @@
       canCollapse = "0";  
       CollapseGroup = "-1";  
       CollapseGroupNum = "-1";  
-      closeCommand = "Canvas.popDialog(ProceduralTerrainPainterGui);";  
+      closeCommand = "$GameCanvas.popDialog(ProceduralTerrainPainterGui);";  
       text = "Generate layer mask";  
   
       new GuiButtonCtrl() {  
@@ -394,12 +394,12 @@ $TPPCoverage = 100;
   
 function autoLayers() 
 {  
-   Canvas.pushDialog(ProceduralTerrainPainterGui);  
+   $GameCanvas.pushDialog(ProceduralTerrainPainterGui);  
 }  
   
 function generateProceduralTerrainMask() 
 {  
-   Canvas.popDialog(ProceduralTerrainPainterGui);  
+   $GameCanvas.popDialog(ProceduralTerrainPainterGui);  
    ETerrainEditor.autoMaterialLayer($TPPHeightMin, $TPPHeightMax, $TPPSlopeMin, $TPPSlopeMax, $TPPCoverage);  
 }  
 

--- a/Templates/Full/game/tools/worldEditor/gui/TerrainBrushSoftnessCurveDlg.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/TerrainBrushSoftnessCurveDlg.ed.gui
@@ -179,7 +179,7 @@
          MinExtent = "8 2";
          canSave = "1";
          Visible = "1";
-         Command = "Canvas.popDialog( TerrainBrushSoftnessCurveDlg );";
+         Command = "$GameCanvas.popDialog( TerrainBrushSoftnessCurveDlg );";
          hovertime = "1000";
          text = "Cancel";
          groupNum = "-1";
@@ -222,7 +222,7 @@ function TerrainBrushSoftnessCurveDlg::onOk( %this )
    ETerrainEditor.softSelectFilter = %curve.getValue(); 
    ETerrainEditor.resetSelWeights(true); 
       
-   Canvas.popDialog( %this );
+   $GameCanvas.popDialog( %this );
 }
 
 function TerrainBrushSoftnessCurveDlg::resetCurve( %this )

--- a/Templates/Full/game/tools/worldEditor/gui/TerrainEditToolbar.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/TerrainEditToolbar.ed.gui
@@ -196,7 +196,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(TerrainBrushSizeSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(TerrainBrushSizeSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes size of the brush (CTRL + Mouse Wheel)";
             hovertime = "750";
@@ -283,7 +283,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(TerrainBrushPressureSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(TerrainBrushPressureSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes the pressure (CTRL + SHIFT + Mouse Wheel)";
             hovertime = "750";
@@ -370,7 +370,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(TerrainBrushSoftnessSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(TerrainBrushSoftnessSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes the softness (SHIFT + Mouse Wheel)";
             hovertime = "750";
@@ -393,7 +393,7 @@
          MinExtent = "8 2";
          canSave = "1";
          Visible = "1";
-         Command = "Canvas.pushDialog( TerrainBrushSoftnessCurveDlg );";
+         Command = "$GameCanvas.pushDialog( TerrainBrushSoftnessCurveDlg );";
          tooltipprofile = "ToolsGuiToolTipProfile";
          ToolTip = "Changes the softness curve";
          hovertime = "750";
@@ -480,7 +480,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(TerrainSetHeightSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(TerrainSetHeightSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes the height for the SetHeight tool (ALT + Left Mouse)";
             hovertime = "750";

--- a/Templates/Full/game/tools/worldEditor/gui/TerrainEditorVSettingsGui.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/TerrainEditorVSettingsGui.ed.gui
@@ -27,7 +27,7 @@ new GuiControl(TerrainEditorValuesSettingsGui, EditorGuiGroup) {
       canMinimize = "0";
       canMaximize = "0";
       minSize = "50 50";
-      closeCommand = "Canvas.popDIalog(TerrainEditorValuesSettingsGui);";
+      closeCommand = "$GameCanvas.popDIalog(TerrainEditorValuesSettingsGui);";
 
       new GuiControl() {
          profile = "ToolsGuiWindowProfile";
@@ -158,7 +158,7 @@ new GuiControl(TerrainEditorValuesSettingsGui, EditorGuiGroup) {
          extent = "80 20";
          minExtent = "8 8";
          visible = "1";
-         command = "Canvas.popDIalog(TerrainEditorValuesSettingsGui);";
+         command = "$GameCanvas.popDIalog(TerrainEditorValuesSettingsGui);";
          helpTag = "0";
          text = "OK";
          groupNum = "-1";

--- a/Templates/Full/game/tools/worldEditor/gui/TerrainPainterToolbar.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/TerrainPainterToolbar.ed.gui
@@ -196,7 +196,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(PaintBrushSizeSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(PaintBrushSizeSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes the size of the brush (CTRL + Mouse Wheel)";
             hovertime = "750";
@@ -302,7 +302,7 @@
             buttonType = "PushButton";
             useMouseEvents = "0";
             bitmap = "tools/gui/images/dropslider";
-            Command = "Canvas.pushDialog(PaintBrushSlopeMinContainer);";
+            Command = "$GameCanvas.pushDialog(PaintBrushSlopeMinContainer);";
          };
          new GuiTextCtrl() {
             Profile = "ToolsGuiTextProfile";
@@ -363,7 +363,7 @@
             buttonType = "PushButton";
             useMouseEvents = "0";
             bitmap = "tools/gui/images/dropslider";
-            Command = "Canvas.pushDialog(PaintBrushSlopeMaxContainer);";
+            Command = "$GameCanvas.pushDialog(PaintBrushSlopeMaxContainer);";
          };
       };
 
@@ -444,7 +444,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(PaintBrushPressureSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(PaintBrushPressureSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes the pressure (CTRL + SHIFT + Mouse Wheel)";
             hovertime = "750";

--- a/Templates/Full/game/tools/worldEditor/gui/TimeAdjustGui.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/TimeAdjustGui.ed.gui
@@ -41,7 +41,7 @@
       tooltipprofile = "ToolsGuiToolTipProfile";
       hovertime = "1000";
       canSaveDynamicFields = "0";
-      closeCommand = "Canvas.popDialog(TimeAdjustGui);";
+      closeCommand = "$GameCanvas.popDialog(TimeAdjustGui);";
 
       new GuiSliderCtrl(TimeAdjustSliderCtrl) {
          range = "0 1";
@@ -208,7 +208,7 @@ function TimeAdjustSliderCtrl::onAction(%this)
 function toggleTimeAdjustGui()
 {
    if ( TimeAdjustGui.isAwake() )
-      Canvas.popDialog( TimeAdjustGui );
+      $GameCanvas.popDialog( TimeAdjustGui );
    else
-      Canvas.pushDialog( TimeAdjustGui );
+      $GameCanvas.pushDialog( TimeAdjustGui );
 }

--- a/Templates/Full/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
@@ -242,7 +242,7 @@
             MinExtent = "8 2";
             canSave = "1";
             Visible = "1";
-            Command = "Canvas.pushDialog(softSnapSizeSliderCtrlContainer);";
+            Command = "$GameCanvas.pushDialog(softSnapSizeSliderCtrlContainer);";
             tooltipprofile = "ToolsGuiToolTipProfile";
             ToolTip = "Changes size of the soft snap region";
             hovertime = "750";

--- a/Templates/Full/game/tools/worldEditor/gui/guiCreateNewTerrainGui.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/guiCreateNewTerrainGui.gui
@@ -43,7 +43,7 @@
       canMinimize = "0";
       canMaximize = "0";
       minSize = "50 50";
-      closeCommand = "Canvas.popDialog( CreateNewTerrainGui );";
+      closeCommand = "$GameCanvas.popDialog( CreateNewTerrainGui );";
       EdgeSnap = "0";
       text = "Create New Terrain";
 
@@ -136,7 +136,7 @@
          canSave = "1";
          isDecoy = "0";
          Visible = "1";
-         Command = "Canvas.popDialog( CreateNewTerrainGui );";
+         Command = "$GameCanvas.popDialog( CreateNewTerrainGui );";
          tooltipprofile = "ToolsGuiToolTipProfile";
          hovertime = "1000";
          text = "Cancel";
@@ -348,5 +348,5 @@ function CreateNewTerrainGui::create( %this )
       EWorldEditor.dropSelection( true );
    }
 
-   Canvas.popDialog( %this );
+   $GameCanvas.popDialog( %this );
 }

--- a/Templates/Full/game/tools/worldEditor/gui/guiTerrainExportGui.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/guiTerrainExportGui.gui
@@ -266,14 +266,14 @@ function TerrainExportGui::onWake( %this )
 
 function TerrainExportGui::close( %this )
 {
-   Canvas.popDialog( %this );
+   $GameCanvas.popDialog( %this );
 }
 
 function TerrainExportGui::showExportDialog( %this )
 {
    %this.findAllTerrains();
 
-   Canvas.pushDialog( %this );
+   $GameCanvas.pushDialog( %this );
 }
 
 function TerrainExportGui::openFolderCallback( %this, %path )

--- a/Templates/Full/game/tools/worldEditor/gui/guiTerrainImportGui.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/guiTerrainImportGui.gui
@@ -44,7 +44,7 @@
       canMinimize = "0";
       canMaximize = "0";
       minSize = "4 4";
-      closeCommand = "Canvas.popDialog( TerrainImportGui );";
+      closeCommand = "$GameCanvas.popDialog( TerrainImportGui );";
       EdgeSnap = "0";
       text = "Import Terrain Height Map";
 
@@ -502,7 +502,7 @@
          canSave = "1";
          isDecoy = "0";
          Visible = "1";
-         Command = "Canvas.popDialog( TerrainImportGui );";
+         Command = "$GameCanvas.popDialog( TerrainImportGui );";
          tooltipprofile = "ToolsGuiToolTipProfile";
          hovertime = "1000";
          text = "Cancel";
@@ -593,7 +593,7 @@ function TerrainImportGui::import( %this )
                                   %materialNames,
                                   %flipYAxis );
 
-   Canvas.popDialog( %this );
+   $GameCanvas.popDialog( %this );
 
    if ( isObject( %obj ) )
    {

--- a/Templates/Full/game/tools/worldEditor/gui/objectBuilderGui.ed.gui
+++ b/Templates/Full/game/tools/worldEditor/gui/objectBuilderGui.ed.gui
@@ -509,7 +509,7 @@ function ObjectBuilderGui::process(%this)
    %this.adjustSizes();
 
    //
-   Canvas.pushDialog(%this);
+   $GameCanvas.pushDialog(%this);
 }
 
 function ObjectBuilderGui::processNewObject(%this, %obj)
@@ -581,13 +581,13 @@ function ObjectBuilderGui::onOK(%this)
       %this.processNewObject(%this.newObject);
 
    %this.reset();
-   Canvas.popDialog(%this);
+   $GameCanvas.popDialog(%this);
 }
 
 function ObjectBuilderGui::onCancel(%this)
 {
    %this.reset();
-   Canvas.popDialog(%this);
+   $GameCanvas.popDialog(%this);
 }
 
 function ObjectBuilderGui::addField(%this, %name, %type, %text, %value, %ext)
@@ -914,7 +914,7 @@ function ObjectBuilderGui::buildLevelInfo(%this)
    {
       GenericPromptDialog-->GenericPromptWindow.text = "Warning";
       GenericPromptDialog-->GenericPromptText.text   = "There is already an existing LevelInfo in the scene.";
-      Canvas.pushDialog( GenericPromptDialog );
+      $GameCanvas.pushDialog( GenericPromptDialog );
       return;
    } 
 
@@ -929,7 +929,7 @@ function ObjectBuilderGui::buildTimeOfDay(%this)
    {
       GenericPromptDialog-->GenericPromptWindow.text = "Warning";
       GenericPromptDialog-->GenericPromptText.text   = "There is already an existing TimeOfDay in the scene.";
-      Canvas.pushDialog( GenericPromptDialog );
+      $GameCanvas.pushDialog( GenericPromptDialog );
       return;
    }
    

--- a/Templates/Full/game/tools/worldEditor/scripts/AddFMODProjectDlg.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/AddFMODProjectDlg.ed.cs
@@ -74,7 +74,7 @@ function AddFMODProjectDlg::show( %this )
    
    // Show it.
       
-   Canvas.pushDialog( %this, 0, true );
+   $GameCanvas.pushDialog( %this, 0, true );
 }
 
 //-----------------------------------------------------------------------------
@@ -95,7 +95,7 @@ function AddFMODProjectDlg::onSleep( %this )
 
 function AddFMODProjectDlg::onCancel( %this )
 {
-   Canvas.popDialog( %this );
+   $GameCanvas.popDialog( %this );
 }
 
 //-----------------------------------------------------------------------------
@@ -169,7 +169,7 @@ function AddFMODProjectDlg::onOK( %this )
       %this.persistenceMgr.saveDirty();
    }
       
-   Canvas.popDialog( %this );
+   $GameCanvas.popDialog( %this );
    
    // Trigger a reinit on the datablock editor, just in case.
    

--- a/Templates/Full/game/tools/worldEditor/scripts/EditorChooseLevelGui.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/EditorChooseLevelGui.ed.cs
@@ -52,7 +52,7 @@ function EditorChooseLevelGui::onWake()
    }
    
    //If no valid name, then push the level chooser
-   Canvas.pushDialog(EditorChooseLevelContainer);
+   $GameCanvas.pushDialog(EditorChooseLevelContainer);
 }  
  
 function EditorChooseLevelContainer::onWake(%this)

--- a/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -563,7 +563,7 @@ function EditorGui::onWake( %this )
       %this.onNewLevelLoaded( %levelName );
       
    if (isObject(DemoEditorAlert) && DemoEditorAlert.helpTag<2)
-      Canvas.pushDialog(DemoEditorAlert);
+      $GameCanvas.pushDialog(DemoEditorAlert);
 }
 
 function EditorGui::onSleep( %this )
@@ -1900,21 +1900,21 @@ function EditorTreeTabBook::onTabSelected( %this )
 function Editor::open(%this)
 {
    // prevent the mission editor from opening while the GuiEditor is open.
-   if(Canvas.getContent() == GuiEditorGui.getId())
+   if($GameCanvas.getContent() == GuiEditorGui.getId())
       return;
       
    if( !EditorGui.isInitialized )
       EditorGui.init();
 
    %this.editorEnabled();
-   Canvas.setContent(EditorGui);   
+   $GameCanvas.setContent(EditorGui);   
    EditorGui.syncCameraGui();
 }
 
 function Editor::close(%this, %gui)
 {
    %this.editorDisabled();
-   Canvas.setContent(%gui);
+   $GameCanvas.setContent(%gui);
    if(isObject(MessageHud))
       MessageHud.close();   
    EditorGui.writeCameraSettings();
@@ -1951,7 +1951,7 @@ function Editor::lightScene(%this, %callback, %forceAlways)
    $RelightCallback = %callback;
    RelightStatus.visible = true;
    RelightProgress.setValue(0);
-   Canvas.repaint();  
+   $GameCanvas.repaint();  
    lightScene("EditorLightingComplete", %forceAlways);
    updateEditorLightingProgress();
 } 
@@ -2623,10 +2623,10 @@ function CameraSpeedDropdownCtrlContainer::onWake(%this)
 
 function EditorDropdownSliderContainer::onMouseDown(%this)
 {
-   Canvas.popDialog(%this);
+   $GameCanvas.popDialog(%this);
 }
 
 function EditorDropdownSliderContainer::onRightMouseDown(%this)
 {
-   Canvas.popDialog(%this);
+   $GameCanvas.popDialog(%this);
 }

--- a/Templates/Full/game/tools/worldEditor/scripts/editor.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editor.ed.cs
@@ -40,6 +40,7 @@
 
 function Editor::create()
 {
+	$GameCanvas = Canvas;
    // Not much to do here, build it and they will come...
    // Only one thing... the editor is a gui control which
    // expect the Canvas to exist, so it must be constructed
@@ -89,7 +90,7 @@ function Editor::checkActiveLoadDone()
 {
    if(isObject(EditorGui) && EditorGui.loadingMission)
    {
-      Canvas.setContent(EditorGui);
+      $GameCanvas.setContent(EditorGui);
       EditorGui.loadingMission = false;
       return true;
    }
@@ -99,7 +100,7 @@ function Editor::checkActiveLoadDone()
 //------------------------------------------------------------------------------
 function toggleEditor(%make)
 {
-   if (Canvas.isFullscreen())
+   if ($GameCanvas.isFullscreen())
    {
       MessageBoxOK("Windowed Mode Required", "Please switch to windowed mode to access the Mission Editor.");
       return;
@@ -116,7 +117,7 @@ function toggleEditor(%make)
       {
          // Flag saying, when level is chosen, launch it with the editor open.
          ChooseLevelDlg.launchInEditor = true;
-         Canvas.pushDialog( ChooseLevelDlg );         
+         $GameCanvas.pushDialog( ChooseLevelDlg );         
       }
       else
       {
@@ -145,8 +146,8 @@ function toggleEditor(%make)
          {
             if ( !$GuiEditorBtnPressed )
             {
-               canvas.pushDialog( EditorLoadingGui );
-               canvas.repaint();
+               $GameCanvas.pushDialog( EditorLoadingGui );
+               $GameCanvas.repaint();
             }
             else
             {
@@ -164,7 +165,7 @@ function toggleEditor(%make)
                commandToServer('dropCameraAtPlayer', true);
                
             
-            canvas.popDialog(EditorLoadingGui);
+            $GameCanvas.popDialog(EditorLoadingGui);
          }
          
          popInstantGroup();

--- a/Templates/Full/game/tools/worldEditor/scripts/editors/creator.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editors/creator.ed.cs
@@ -178,7 +178,7 @@ function EWCreatorWindow::createStatic( %this, %file )
 
    if(isFunction("getObjectLimit") && MissionGroup.getFullCount() >= getObjectLimit())
    {
-      MessageBoxOKBuy( "Object Limit Reached", "You have exceeded the object limit of " @ getObjectLimit() @ " for this demo. You can remove objects if you would like to add more.", "", "Canvas.showPurchaseScreen(\"objectlimit\");" );
+      MessageBoxOKBuy( "Object Limit Reached", "You have exceeded the object limit of " @ getObjectLimit() @ " for this demo. You can remove objects if you would like to add more.", "", "$GameCanvas.showPurchaseScreen(\"objectlimit\");" );
       return;
    }
 
@@ -202,7 +202,7 @@ function EWCreatorWindow::createPrefab( %this, %file )
 
    if(isFunction("getObjectLimit") && MissionGroup.getFullCount() >= getObjectLimit())
    {
-      MessageBoxOKBuy( "Object Limit Reached", "You have exceeded the object limit of " @ getObjectLimit() @ " for this demo. You can remove objects if you would like to add more.", "", "Canvas.showPurchaseScreen(\"objectlimit\");" );
+      MessageBoxOKBuy( "Object Limit Reached", "You have exceeded the object limit of " @ getObjectLimit() @ " for this demo. You can remove objects if you would like to add more.", "", "$GameCanvas.showPurchaseScreen(\"objectlimit\");" );
       return;
    }
 
@@ -226,7 +226,7 @@ function EWCreatorWindow::createObject( %this, %cmd )
 
    if(isFunction("getObjectLimit") && MissionGroup.getFullCount() >= getObjectLimit())
    {
-      MessageBoxOKBuy( "Object Limit Reached", "You have exceeded the object limit of " @ getObjectLimit() @ " for this demo. You can remove objects if you would like to add more.", "", "Canvas.showPurchaseScreen(\"objectlimit\");" );
+      MessageBoxOKBuy( "Object Limit Reached", "You have exceeded the object limit of " @ getObjectLimit() @ " for this demo. You can remove objects if you would like to add more.", "", "$GameCanvas.showPurchaseScreen(\"objectlimit\");" );
       return;
    }
       

--- a/Templates/Full/game/tools/worldEditor/scripts/editors/terrainEditor.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editors/terrainEditor.ed.cs
@@ -389,7 +389,7 @@ function TerrainEditorPlugin::setEditorFunction(%this)
    %terrainExists = parseMissionGroup( "TerrainBlock" );
 
    if( %terrainExists == false )
-      MessageBoxYesNoCancel("No Terrain","Would you like to create a New Terrain?", "Canvas.pushDialog(CreateNewTerrainGui);");
+      MessageBoxYesNoCancel("No Terrain","Would you like to create a New Terrain?", "$GameCanvas.pushDialog(CreateNewTerrainGui);");
 
    return %terrainExists;
 }
@@ -399,7 +399,7 @@ function TerrainPainterPlugin::setEditorFunction(%this, %overrideGroup)
    %terrainExists = parseMissionGroup( "TerrainBlock" );
 
    if( %terrainExists == false )
-      MessageBoxYesNoCancel("No Terrain","Would you like to create a New Terrain?", "Canvas.pushDialog(CreateNewTerrainGui);");
+      MessageBoxYesNoCancel("No Terrain","Would you like to create a New Terrain?", "$GameCanvas.pushDialog(CreateNewTerrainGui);");
 
    return %terrainExists;
 }
@@ -416,7 +416,7 @@ function EPainterIconBtn::onMouseDragged( %this )
 
    %xOffset = getWord( %payload.extent, 0 ) / 2;
    %yOffset = getWord( %payload.extent, 1 ) / 2;
-   %cursorpos = Canvas.getCursorPos();
+   %cursorpos = $GameCanvas.getCursorPos();
    %xPos = getWord( %cursorpos, 0 ) - %xOffset;
    %yPos = getWord( %cursorpos, 1 ) - %yOffset;
 
@@ -439,7 +439,7 @@ function EPainterIconBtn::onMouseDragged( %this )
 
    %ctrl.add( %payload );
 
-   Canvas.getContent().add( %ctrl );
+   $GameCanvas.getContent().add( %ctrl );
    %ctrl.startDragging( %xOffset, %yOffset );
 }
 

--- a/Templates/Full/game/tools/worldEditor/scripts/editors/worldEditor.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editors/worldEditor.ed.cs
@@ -157,7 +157,7 @@ function WorldEditor::init(%this)
          extent = "0 0";
          minExtent = "0 0";
          maxPopupHeight = "200";
-         command = "canvas.popDialog(WEContextPopupDlg);";
+         command = "$GameCanvas.popDialog(WEContextPopupDlg);";
       };
    };
    WEContextPopup.setVisible(false);

--- a/Templates/Full/game/tools/worldEditor/scripts/interfaces/terrainMaterialDlg.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/interfaces/terrainMaterialDlg.ed.cs
@@ -25,7 +25,7 @@
 
 function TerrainMaterialDlg::show( %this, %matIndex, %terrMat, %onApplyCallback )
 {
-   Canvas.pushDialog( %this );
+   $GameCanvas.pushDialog( %this );
    
    %this.matIndex = %matIndex; 
    %this.onApplyCallback = %onApplyCallback;
@@ -56,7 +56,7 @@ function TerrainMaterialDlg::show( %this, %matIndex, %terrMat, %onApplyCallback 
 
 function TerrainMaterialDlg::showByObjectId( %this, %matObjectId, %onApplyCallback )
 {
-   Canvas.pushDialog( %this );
+   $GameCanvas.pushDialog( %this );
      
    %this.matIndex = -1;
    %this.onApplyCallback = %onApplyCallback;
@@ -146,8 +146,8 @@ function TerrainMaterialDlg::dialogApply( %this )
    // Delete the snapshot.
    TerrainMaterialDlgSnapshot.delete();
 
-   // Remove ourselves from the canvas.
-   Canvas.popDialog( TerrainMaterialDlg ); 
+   // Remove ourselves from the $GameCanvas.
+   $GameCanvas.popDialog( TerrainMaterialDlg ); 
                             
    call( %this.onApplyCallback, %this.activeMat, %this.matIndex );
 }
@@ -178,7 +178,7 @@ function TerrainMaterialDlg::dialogCancel( %this )
       TerrainMaterialSet.add( %mat );
    }
    
-   Canvas.popDialog( TerrainMaterialDlg );  
+   $GameCanvas.popDialog( TerrainMaterialDlg );  
 }
 
 //-----------------------------------------------------------------------------

--- a/Templates/Full/game/tools/worldEditor/scripts/menuHandlers.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/menuHandlers.ed.cs
@@ -259,7 +259,7 @@ function EditorSaveMission()
    // just save the mission without renaming it
    if(isFunction("getObjectLimit") && MissionGroup.getFullCount() >= getObjectLimit())
    {
-      MessageBoxOKBuy( "Object Limit Reached", "You have exceeded the object limit of " @ getObjectLimit() @ " for this demo. You can remove objects if you would like to add more.", "", "Canvas.showPurchaseScreen(\"objectlimit\");" );
+      MessageBoxOKBuy( "Object Limit Reached", "You have exceeded the object limit of " @ getObjectLimit() @ " for this demo. You can remove objects if you would like to add more.", "", "$GameCanvas.showPurchaseScreen(\"objectlimit\");" );
       return;
    }
    
@@ -320,14 +320,14 @@ function EditorSaveMissionMenuDisableSave()
 {
    GenericPromptDialog-->GenericPromptWindow.text = "Warning";
    GenericPromptDialog-->GenericPromptText.setText("Saving disabled in demo mode."); 
-   Canvas.pushDialog( GenericPromptDialog ); 
+   $GameCanvas.pushDialog( GenericPromptDialog ); 
 }
 
 function EditorSaveMissionAs( %missionName )
 {
    if(isFunction("getObjectLimit") && MissionGroup.getFullCount() >= getObjectLimit())
    {
-      MessageBoxOKBuy( "Object Limit Reached", "You have exceeded the object limit of " @ getObjectLimit() @ " for this demo. You can remove objects if you would like to add more.", "", "Canvas.showPurchaseScreen(\"objectlimit\");" );
+      MessageBoxOKBuy( "Object Limit Reached", "You have exceeded the object limit of " @ getObjectLimit() @ " for this demo. You can remove objects if you would like to add more.", "", "$GameCanvas.showPurchaseScreen(\"objectlimit\");" );
       return;
    }
    

--- a/Templates/Full/game/tools/worldEditor/scripts/menus.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/menus.ed.cs
@@ -128,12 +128,12 @@ function EditorGui::buildMenus(%this)
       }
    }
    
-   %fileMenu.appendItem("Create Blank Terrain" TAB "" TAB "Canvas.pushDialog( CreateNewTerrainGui );");        
-   %fileMenu.appendItem("Import Terrain Heightmap" TAB "" TAB "Canvas.pushDialog( TerrainImportGui );");
+   %fileMenu.appendItem("Create Blank Terrain" TAB "" TAB "$GameCanvas.pushDialog( CreateNewTerrainGui );");        
+   %fileMenu.appendItem("Import Terrain Heightmap" TAB "" TAB "$GameCanvas.pushDialog( TerrainImportGui );");
    
    if(!isWebDemo())
    {
-      %fileMenu.appendItem("Export Terrain Heightmap" TAB "" TAB "Canvas.pushDialog( TerrainExportGui );");
+      %fileMenu.appendItem("Export Terrain Heightmap" TAB "" TAB "$GameCanvas.pushDialog( TerrainExportGui );");
       %fileMenu.appendItem("-");
       %fileMenu.appendItem("Export To COLLADA..." TAB "" TAB "EditorExportToCollada();");
          //item[5] = "Import Terraform Data..." TAB "" TAB "Heightfield::import();";
@@ -179,8 +179,8 @@ function EditorGui::buildMenus(%this)
       item[12] = "Editor Settings..." TAB "" TAB "ESettingsWindow.ToggleVisibility();";
       item[13] = "Snap Options..." TAB "" TAB "ESnapOptions.ToggleVisibility();";
       item[14] = "-";
-      item[15] = "Game Options..." TAB "" TAB "Canvas.pushDialog(optionsDlg);";
-      item[16] = "PostEffect Manager" TAB "" TAB "Canvas.pushDialog(PostFXManager);";
+      item[15] = "Game Options..." TAB "" TAB "$GameCanvas.pushDialog(optionsDlg);";
+      item[16] = "PostEffect Manager" TAB "" TAB "$GameCanvas.pushDialog(PostFXManager);";
    };
    %this.menuBar.insert(%editMenu, %this.menuBar.getCount());
       


### PR DESCRIPTION
\game\tools\worldEditor\scripts\editor.ed.cs function Editor::create() sets $GameCanvas = Canvas; with the rest following conversion conventions for https://github.com/GarageGames/Torque3D/pull/1297 . (see https://github.com/GarageGames/Torque3D/pull/1297/files#diff-e50af352c48fb4969d220ecd5a7521b9L79 on down)

 :