### PR TITLE
GFXGLDevice setShader fix.

### DIFF
--- a/Engine/source/gfx/gl/gfxGLDevice.cpp
+++ b/Engine/source/gfx/gl/gfxGLDevice.cpp
@@ -811,9 +811,9 @@ GFXShader* GFXGLDevice::createShader()
    return shader;
 }
 
-void GFXGLDevice::setShader( GFXShader *shader )
+void GFXGLDevice::setShader(GFXShader *shader, bool force)
 {
-   if(mCurrentShader == shader)
+   if(mCurrentShader == shader && !force)
       return;
 
    if ( shader )

--- a/Engine/source/gfx/gl/gfxGLDevice.h
+++ b/Engine/source/gfx/gl/gfxGLDevice.h
@@ -90,7 +90,7 @@ public:
    virtual F32 getPixelShaderVersion() const { return mPixelShaderVersion; }
    virtual void  setPixelShaderVersion( F32 version ) { mPixelShaderVersion = version; }
    
-   virtual void setShader(GFXShader* shd);
+   virtual void setShader(GFXShader *shader, bool force = false);
    
    /// @attention GL cannot check if the given format supports blending or filtering!
    virtual GFXFormat selectSupportedFormat(GFXTextureProfile *profile,


### PR DESCRIPTION
Ok i stuffed up the other PR, branch was a mess. Anyways...attempt number 2 :)

This took ages to track down, compiling on VS 2013 was displaying nothing but the clear screen color when loading a level with GL. Long story short, the materials where not able to set their shader because the GFXGLDevice setShader function was wrong (missing the bool force).