### PR TITLE
Basic fix for stereo rendering without a display device

### DIFF
--- a/Engine/source/T3D/gameFunctions.cpp
+++ b/Engine/source/T3D/gameFunctions.cpp
@@ -349,7 +349,13 @@ bool GameProcessCameraQuery(CameraQuery *query)
 
       // Provide some default values
       query->projectionOffset = Point2F::Zero;
-
+      query->stereoTargets[0] = 0;
+      query->stereoTargets[1] = 0;
+      query->eyeOffset[0] = Point3F::Zero;
+      query->eyeOffset[1] = Point3F::Zero;
+      query->hasFovPort = false;
+      query->hasStereoTargets = false;
+      
       F32 cameraFov = 0.0f;
       bool fovSet = false;
 
@@ -383,6 +389,7 @@ bool GameProcessCameraQuery(CameraQuery *query)
          {
             display->getFovPorts(query->fovPort);
             fovSet = true;
+            query->hasFovPort = true;
          }
          
          // Grab the latest overriding render view transforms
@@ -390,6 +397,11 @@ bool GameProcessCameraQuery(CameraQuery *query)
 
          display->getStereoViewports(query->stereoViewports);
          display->getStereoTargets(query->stereoTargets);
+      }
+      else
+      {
+         query->eyeTransforms[0] = query->cameraMatrix;
+         query->eyeTransforms[1] = query->cameraMatrix;
       }
 
       // Use the connection's FOV settings if requried

--- a/Engine/source/T3D/gameFunctions.cpp
+++ b/Engine/source/T3D/gameFunctions.cpp
@@ -397,6 +397,7 @@ bool GameProcessCameraQuery(CameraQuery *query)
 
          display->getStereoViewports(query->stereoViewports);
          display->getStereoTargets(query->stereoTargets);
+         query->hasStereoTargets = true;
       }
       else
       {

--- a/Engine/source/gfx/gfxDevice.h
+++ b/Engine/source/gfx/gfxDevice.h
@@ -354,10 +354,10 @@ public:
    void setStereoEyeTransforms(MatrixF *transforms) { dMemcpy(mStereoEyeTransforms, transforms, sizeof(mStereoEyeTransforms)); dMemcpy(mInverseStereoEyeTransforms, transforms, sizeof(mInverseStereoEyeTransforms)); mInverseStereoEyeTransforms[0].inverse(); mInverseStereoEyeTransforms[1].inverse();  }
 
    /// Set the current eye offset used during stereo rendering. Assumes NumStereoPorts are available.
-   void setFovPort(const FovPort *ports) { dMemcpy(mFovPorts, ports, sizeof(mFovPorts)); }
+   void setStereoFovPort(const FovPort *ports) { dMemcpy(mFovPorts, ports, sizeof(mFovPorts)); }
 
    /// Get the current eye offset used during stereo rendering
-   const FovPort* getSteroFovPort() { return mFovPorts; }
+   const FovPort* getStereoFovPort() { return mFovPorts; }
 
    /// Sets stereo viewports
    void setSteroViewports(const RectI *ports) { dMemcpy(mStereoViewports, ports, sizeof(RectI) * NumStereoPorts); }

--- a/Engine/source/gui/3d/guiTSControl.h
+++ b/Engine/source/gui/3d/guiTSControl.h
@@ -49,6 +49,8 @@ struct CameraQuery
    Point3F     eyeOffset[2];
    MatrixF     eyeTransforms[2];
    bool        ortho;
+   bool        hasFovPort;
+   bool        hasStereoTargets;
    MatrixF     cameraMatrix;
    RectI       stereoViewports[2]; // destination viewports
    GFXTextureTarget* stereoTargets[2];

--- a/Engine/source/scene/reflector.cpp
+++ b/Engine/source/scene/reflector.cpp
@@ -606,7 +606,7 @@ void PlaneReflector::updateReflection( const ReflectParams &params )
       RectI originalVP = GFX->getViewport();
 
       Point2F projOffset = GFX->getCurrentProjectionOffset();
-      const FovPort *currentFovPort = GFX->getSteroFovPort();
+      const FovPort *currentFovPort = GFX->getStereoFovPort();
       MatrixF inverseEyeTransforms[2];
 
       // Calculate world transforms for eyes

--- a/Engine/source/scene/sceneManager.cpp
+++ b/Engine/source/scene/sceneManager.cpp
@@ -240,7 +240,7 @@ void SceneManager::renderScene( SceneRenderState* renderState, U32 objectMask, S
       Frustum originalFrustum = GFX->getFrustum();
 
       Point2F projOffset = GFX->getCurrentProjectionOffset();
-      const FovPort *currentFovPort = GFX->getSteroFovPort();
+      const FovPort *currentFovPort = GFX->getStereoFovPort();
       const MatrixF *eyeTransforms = GFX->getStereoEyeTransforms();
       const MatrixF *worldEyeTransforms = GFX->getInverseStereoEyeTransforms();
 


### PR DESCRIPTION
Fixes stereo rendering when a display device isn't present, reproducing similar behaviour to before the Oculus DK2 changes.
