### PR TITLE
Fixed some minor compiler warnings on Linux

### DIFF
--- a/Engine/lib/collada/src/dae/daeStringTable.cpp
+++ b/Engine/lib/collada/src/dae/daeStringTable.cpp
@@ -58,7 +58,7 @@ void daeStringTable::clear()
 {
 	unsigned int i;
 	for (i=0;i<_stringBuffersList.getCount();i++)
-#if _MSC_VER <= 1200
+#if defined(_MSC_VER) && (_MSC_VER <= 1200)
 		delete [] (char *) _stringBuffersList[i];
 #else
 		delete [] _stringBuffersList[i];

--- a/Engine/lib/convexDecomp/NvSimpleTypes.h
+++ b/Engine/lib/convexDecomp/NvSimpleTypes.h
@@ -87,7 +87,7 @@ NvSimpleTypes.h : Defines basic data types for integers and floats.
 	typedef float				NxF32;
 	typedef double				NxF64;
 		
-#elif LINUX
+#elif defined(LINUX)
 	typedef long long			NxI64;
 	typedef signed int			NxI32;
 	typedef signed short		NxI16;
@@ -101,7 +101,7 @@ NvSimpleTypes.h : Defines basic data types for integers and floats.
 	typedef float				NxF32;
 	typedef double				NxF64;
 
-#elif __APPLE__
+#elif defined(__APPLE__)
 	typedef long long			NxI64;
 	typedef signed int			NxI32;
 	typedef signed short		NxI16;
@@ -115,7 +115,7 @@ NvSimpleTypes.h : Defines basic data types for integers and floats.
 	typedef float				NxF32;
 	typedef double				NxF64;
 
-#elif __CELLOS_LV2__
+#elif defined(__CELLOS_LV2__)
 	typedef long long			NxI64;
 	typedef signed int			NxI32;
 	typedef signed short		NxI16;
@@ -129,7 +129,7 @@ NvSimpleTypes.h : Defines basic data types for integers and floats.
 	typedef float				NxF32;
 	typedef double				NxF64;
 
-#elif _XBOX
+#elif defined(_XBOX)
 	typedef __int64				NxI64;
 	typedef signed int			NxI32;
 	typedef signed short		NxI16;

--- a/Engine/source/core/strings/stringFunctions.h
+++ b/Engine/source/core/strings/stringFunctions.h
@@ -36,10 +36,12 @@
 // These standard functions are not defined on Win32 and other Microsoft platforms...
 #define strcasecmp   _stricmp
 #define strncasecmp  _strnicmp
-#endif
-#if (_MSC_VER < 1800) && (defined(TORQUE_OS_WIN) || defined(TORQUE_OS_XBOX) || defined(TORQUE_OS_XENON))
+
+#if _MSC_VER < 1800
 #define strtof       (float)strtod
-#endif
+#endif // _MSC_VER < 1800
+
+#endif // defined(TORQUE_OS_WIN) || defined(TORQUE_OS_XBOX) || defined(TORQUE_OS_XENON)
 
 
 //------------------------------------------------------------------------------

--- a/Engine/source/core/util/FastDelegate.h
+++ b/Engine/source/core/util/FastDelegate.h
@@ -47,10 +47,9 @@
 
 #ifndef FASTDELEGATE_H
 #define FASTDELEGATE_H
-#if _MSC_VER > 1000
+#if defined(_MSC_VER) && (_MSC_VER > 1000)
 #pragma once
-#endif // _MSC_VER > 1000
-
+#endif // defined(_MSC_VER) && (_MSC_VER > 1000)
 
 ////////////////////////////////////////////////////////////////////////////////
 //						Configuration options

--- a/Engine/source/platform/types.gcc.h
+++ b/Engine/source/platform/types.gcc.h
@@ -30,7 +30,7 @@
 
 //--------------------------------------
 // Types
-#if TORQUE_X86
+#if defined(TORQUE_X86)
 typedef signed long long    S64;
 typedef unsigned long long  U64;
 #else


### PR DESCRIPTION
I am building this project on linux, gcc version 4.9.2 (Ubuntu 4.9.2-10ubuntu13), and I was shocked to get more than 20.000 compiler warnings. So I just started to clean some of them.

I plan to add more compiler warning clean commits if this little commits are accepted and merged.