### PR TITLE
Fixed warning.

### DIFF
--- a/Engine/source/console/console.h
+++ b/Engine/source/console/console.h
@@ -1100,9 +1100,9 @@ struct ConsoleDocFragment
    static ConsoleDocFragment* smFirst;
    
    ConsoleDocFragment( const char* text, const char* inClass = NULL, const char* definition = NULL )
-      : mText( text ),
-        mClass( inClass ),
+      : mClass( inClass ),
         mDefinition( definition ),
+        mText( text ),
         mNext( smFirst )
    {
       smFirst = this;


### PR DESCRIPTION
Sort struct initialization to match fields declaration avoids a warnings on GCC.


This is a bit tricky, because with this little change I had removed a good amount of warnings, console.h were included almost anywhere.
I have run some demo and all seem to work fine.