### PR TITLE
offsetof is actually a standard thing nowadays it would seem

### DIFF
--- a/Engine/source/console/consoleTypes.h
+++ b/Engine/source/console/consoleTypes.h
@@ -48,11 +48,7 @@
 /// @{
 
 #ifndef Offset
-#if defined(TORQUE_COMPILER_GCC) && (__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1))
-#define Offset(m,T) ((int)(&((T *)1)->m) - 1)
-#else
-#define Offset(x, cls) ((dsize_t)((const char *)&(((cls *)0)->x)-(const char *)0))
-#endif
+#define Offset(x, cls) offsetof(cls, x)
 #endif
 
 class GFXShader;


### PR DESCRIPTION
First reported https://www.reddit.com/r/gamedev/comments/3bv7oq/torque_3d_37_released_linux_opengl_client/cspvouc

@dottools found the following:
http://lxr.free-electrons.com/source/include/linux/stddef.h#L15 
http://lxr.free-electrons.com/source/include/linux/compiler-gcc4.h#L14

MSDN:
https://msdn.microsoft.com/en-us/library/dz4y9b9a.aspx