### PR TITLE
Fix running on Linux / Intel Mesa drivers

### DIFF
--- a/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
+++ b/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
@@ -83,6 +83,10 @@ void GFXGLDevice::enumerateAdapters( Vector<GFXAdapter*> &adapterList )
     );
 
    SDL_ClearError();
+   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+   SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+
    SDL_GLContext tempContext = SDL_GL_CreateContext( tempWindow );
    if( !tempContext )
    {

--- a/Engine/source/gfx/gl/tGL/tGL.cpp
+++ b/Engine/source/gfx/gl/tGL/tGL.cpp
@@ -29,6 +29,7 @@ namespace GL
 {
    void gglPerformBinds()
    {
+      glewExperimental = GL_TRUE;
       GLenum err = glewInit();
       AssertFatal(GLEW_OK == err, avar("Error: %s\n", glewGetErrorString(err)) );
    }

--- a/Engine/source/gfx/gl/tGL/tGL.h
+++ b/Engine/source/gfx/gl/tGL/tGL.h
@@ -24,8 +24,13 @@
 #define T_GL_H
 #include "GL/glew.h"
 
-// Slower but reliably detects extensions
+#if defined (TORQUE_OS_WIN)
+// This doesn't work on Mesa drivers.
+#define gglHasExtension(EXTENSION) GLEW_##EXTENSION
+#else
+// Slower but reliably detects extensions on Mesa.
 #define gglHasExtension(EXTENSION) glewGetExtension("GL_" # EXTENSION)
+#endif
 
 #endif
 

--- a/Engine/source/gfx/gl/tGL/tGL.h
+++ b/Engine/source/gfx/gl/tGL/tGL.h
@@ -25,7 +25,7 @@
 #include "GL/glew.h"
 
 // Slower but reliably detects extensions
-#define gglHasExtension(EXTENSION) glewGetExtension("GL_##EXTENSION")
+#define gglHasExtension(EXTENSION) glewGetExtension("GL_" # EXTENSION)
 
 #endif
 

--- a/Engine/source/gfx/gl/tGL/tGL.h
+++ b/Engine/source/gfx/gl/tGL/tGL.h
@@ -24,7 +24,8 @@
 #define T_GL_H
 #include "GL/glew.h"
 
-#define gglHasExtension(EXTENSION) GLEW_##EXTENSION
+// Slower but reliably detects extensions
+#define gglHasExtension(EXTENSION) glewGetExtension("GL_##EXTENSION")
 
 #endif
 

--- a/Engine/source/platformSDL/sdlPlatformGL.cpp
+++ b/Engine/source/platformSDL/sdlPlatformGL.cpp
@@ -13,18 +13,16 @@ namespace PlatformGL
            return;
 
        inited = true;
-       const U32 majorOGL = 4;
+       const U32 majorOGL = 3;
        const U32 minorOGL = 2;
        U32 debugFlag = 0;
 #ifdef TORQUE_DEBUG
        debugFlag |= SDL_GL_CONTEXT_DEBUG_FLAG;
 #endif
 
-#if 0  // cause problem with glew, no extension load
        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, majorOGL);
        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, minorOGL);
        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-#endif
        SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, debugFlag);
 
        SDL_ClearError();


### PR DESCRIPTION
This allows Torque3D to run on the open source Linux 3D drivers. There are still many issues but with this small patch it at least starts and is semi-functional.

* Explicitly request a GL 3.2 context
* Enable 'experimental' extensions on glew (This appears necessary to get glew to work with explictly set GL versions)