### PR TITLE
fills in profiler timer fallback

### DIFF
--- a/Engine/source/platform/profiler.cpp
+++ b/Engine/source/platform/profiler.cpp
@@ -155,11 +155,13 @@ U32 endHighResolutionTimer(U32 time[2])  {
 
 void startHighResolutionTimer(U32 time[2])
 {
+   time[0] = Platform::getRealMilliseconds();
 }
 
 U32 endHighResolutionTimer(U32 time[2])
 {
-   return 1;
+   U32 ticks = Platform::getRealMilliseconds() - time[0];
+   return ticks;
 }
 
 #endif


### PR DESCRIPTION
 as per remmed out lines in other samples. see https://github.com/GarageGames/Torque3D/issues/1349 for report, and https://gist.github.com/Azaezel/2aafb88cf0d642418051 for result