### PR TITLE
Utilize ++iter rather than iter++ to improve iterator performance.

### DIFF
--- a/Engine/source/console/engineDoc.cpp
+++ b/Engine/source/console/engineDoc.cpp
@@ -706,7 +706,7 @@ static bool dumpEngineDocs( const char *outputFile )
    // Dump pre-declarations for any groups we encountered
    // so that we don't have to explicitly define them.
    HashTable<String,U32>::Iterator iter = smDocGroups.begin();
-   for ( ; iter != smDocGroups.end(); iter++ )
+   for (; iter != smDocGroups.end(); ++iter)
       stream.writeText( String::ToString( "/*! @addtogroup %s */\r\n\r\n", iter->key.c_str() ) );
 
    return true;

--- a/Engine/source/forest/editor/forestSelectionTool.cpp
+++ b/Engine/source/forest/editor/forestSelectionTool.cpp
@@ -56,7 +56,7 @@ Point3F Selection<ForestItem>::getOrigin()
 
    Selection<ForestItem>::iterator itr = begin();
 
-   for ( ; itr != end(); itr++ )
+   for (; itr != end(); ++itr)
    {
       const MatrixF &mat = itr->getTransform();
       Point3F wPos;

--- a/Engine/source/forest/forestCollision.cpp
+++ b/Engine/source/forest/forestCollision.cpp
@@ -355,7 +355,7 @@ bool ForestData::castRay( const Point3F &start, const Point3F &end, RayInfo *out
    shortest.t = F32_MAX;
 
    BucketTable::ConstIterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
    {
       if ( iter->value->castRay( start, end, outInfo, rendered ) )
       {

--- a/Engine/source/forest/forestDataFile.cpp
+++ b/Engine/source/forest/forestDataFile.cpp
@@ -77,7 +77,7 @@ void ForestData::clear()
    // clean up its sub-cells in its destructor.   
 
    BucketTable::Iterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ ) delete iter->value;
+   for (; iter != mBuckets.end(); ++iter) delete iter->value;
    mBuckets.clear();
 
    mIsDirty = true;
@@ -408,7 +408,7 @@ const ForestItem& ForestData::findItem( ForestItemKey key ) const
 
    Vector<const ForestCell*> stack;
    BucketTable::ConstIterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
       stack.push_back( iter->value );
 
    // Now loop till we run out of cells.
@@ -444,7 +444,7 @@ U32 ForestData::getItems( Vector<ForestItem> *outItems ) const
    U32 count = 0;
 
    BucketTable::ConstIterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
       stack.push_back( iter->value );
 
    // Now loop till we run out of cells.
@@ -520,7 +520,7 @@ U32 ForestData::getItems( const Box3F &box, Vector<ForestItem> *outItems ) const
    U32 count = 0;
 
    BucketTable::ConstIterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
       stack.push_back( iter->value );
 
    // Now loop till we run out of cells.
@@ -571,7 +571,7 @@ U32 ForestData::getItems( const Point3F &point, F32 radius, Vector<ForestItem> *
    U32 count = 0;
 
    BucketTable::ConstIterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
          stack.push_back( iter->value );
 
    const F32 radiusSq = radius * radius;
@@ -629,7 +629,7 @@ U32 ForestData::getItems( const Point2F &point, F32 radius, Vector<ForestItem> *
    U32 count = 0;
 
    BucketTable::ConstIterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
          stack.push_back( iter->value );
 
    const F32 radiusSq = radius * radius;
@@ -686,7 +686,7 @@ U32 ForestData::getItems( const ForestItemData *data, Vector<ForestItem> *outIte
    U32 count = 0;
 
    BucketTable::ConstIterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
       stack.push_back( iter->value );
 
    // Now loop till we run out of cells.
@@ -724,7 +724,7 @@ void ForestData::getCells( const Frustum &frustum, Vector<ForestCell*> *outCells
    PROFILE_SCOPE( ForestData_getCells_frustum );
 
    BucketTable::ConstIterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
    {
       if ( !frustum.isCulled( iter->value->getBounds() ) )
          outCells->push_back( iter->value );
@@ -736,7 +736,7 @@ void ForestData::getCells( Vector<ForestCell*> *outCells ) const
    PROFILE_SCOPE( ForestData_getCells_nofrustum );
 
    BucketTable::ConstIterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )         
+   for (; iter != mBuckets.end(); ++iter)
       outCells->push_back( iter->value );
 }
 
@@ -746,7 +746,7 @@ U32 ForestData::getDatablocks( Vector<ForestItemData*> *outVector ) const
    U32 count = 0;
 
    BucketTable::ConstIterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
       stack.push_back( iter->value );
 
    // Now loop till we run out of cells.
@@ -786,7 +786,7 @@ void ForestData::clearPhysicsRep( Forest *forest )
    Vector<ForestCell*> stack;
 
    BucketTable::Iterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
       stack.push_back( iter->value );
 
    // Now loop till we run out of cells.
@@ -812,7 +812,7 @@ void ForestData::buildPhysicsRep( Forest *forest )
    Vector<ForestCell*> stack;
 
    BucketTable::Iterator iter = mBuckets.begin();
-   for ( ; iter != mBuckets.end(); iter++ )
+   for (; iter != mBuckets.end(); ++iter)
       stack.push_back( iter->value );
 
    // Now loop till we run out of cells.

--- a/Engine/source/forest/forestWindMgr.cpp
+++ b/Engine/source/forest/forestWindMgr.cpp
@@ -65,7 +65,7 @@ ForestWindMgr::ForestWindMgr()
 ForestWindMgr::~ForestWindMgr()
 {
    IdToWindMap::Iterator sourceIter = mSources->begin();
-   for( ; sourceIter != mSources->end(); sourceIter++ )      
+   for (; sourceIter != mSources->end(); ++sourceIter)
       delete (*sourceIter).value;
 
    delete mSources;
@@ -185,7 +185,7 @@ void ForestWindMgr::processTick()
       PROFILE_SCOPE( ForestWindMgr_AdvanceTime_Cleanup );
 
       IdToWindMap::Iterator sourceIter = mPrevSources->begin();
-      for( ; sourceIter != mPrevSources->end(); sourceIter++ )
+      for (; sourceIter != mPrevSources->end(); ++sourceIter)
       {
          ForestWindAccumulator *accum = (*sourceIter).value;
 

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -192,13 +192,13 @@ void GFXTextureManager::cleanupPool()
          // This texture is unreferenced, so take the time
          // now to completely remove it from the pool.
          TexturePoolMap::Iterator unref = iter;
-         iter++;
+         ++iter;
          unref->value = NULL;
          mTexturePool.erase( unref );
          continue;
       }
 
-      iter++;
+      ++iter;
    }
 }
 

--- a/Engine/source/gui/worldEditor/tSelection.h
+++ b/Engine/source/gui/worldEditor/tSelection.h
@@ -66,7 +66,7 @@ template<class T> inline void Selection<T>::offset( const Point3F &delta )
 {
    typename Selection<T>::iterator itr = this->begin();
 
-   for ( ; itr != this->end(); itr++ )   
+   for (; itr != this->end(); ++itr)
       offsetObject( *itr, delta );      
 }
 
@@ -75,7 +75,7 @@ template<class T> inline void Selection<T>::rotate( const EulerF &delta )
    typename Selection<T>::iterator itr = this->begin();
    Point3F origin = getOrigin();
 
-   for ( ; itr != this->end(); itr++ )   
+   for (; itr != this->end(); ++itr)
       rotateObject( *itr, delta, origin );
 }
 

--- a/Engine/source/materials/materialDefinition.h
+++ b/Engine/source/materials/materialDefinition.h
@@ -173,7 +173,7 @@ public:
       inline bool hasValidTex() const
       {
          TextureTable::ConstIterator iter = mTextures.begin();
-         for ( ; iter != mTextures.end(); iter++ )
+         for (; iter != mTextures.end(); ++iter)
          {
             if ( iter->value.isValid() )
                return true;


### PR DESCRIPTION
Issue found with PVS-Studio:

Many places utilize post-incrementation with iterators, but it's better performance to use pre-incrementation.

Resolved by changing the iter++ instances to ++iter;