### PR TITLE
Convert un-modified function arguments to const references.

### DIFF
--- a/Engine/source/T3D/aiPlayer.cpp
+++ b/Engine/source/T3D/aiPlayer.cpp
@@ -259,7 +259,7 @@ void AIPlayer::setAimObject( GameBase *targetObject )
  * @param targetObject The object to target
  * @param offset       The offest from the target location to aim at
  */
-void AIPlayer::setAimObject( GameBase *targetObject, Point3F offset )
+void AIPlayer::setAimObject(GameBase *targetObject, const Point3F& offset)
 {
    mAimObject = targetObject;
    mTargetInLOS = false;

--- a/Engine/source/T3D/aiPlayer.h
+++ b/Engine/source/T3D/aiPlayer.h
@@ -161,7 +161,7 @@ public:
 
    // Targeting and aiming sets/gets
    void setAimObject( GameBase *targetObject );
-   void setAimObject( GameBase *targetObject, Point3F offset );
+   void setAimObject(GameBase *targetObject, const Point3F& offset);
    GameBase* getAimObject() const  { return mAimObject; }
    void setAimLocation( const Point3F &location );
    Point3F getAimLocation() const { return mAimLocation; }

--- a/Engine/source/T3D/camera.cpp
+++ b/Engine/source/T3D/camera.cpp
@@ -393,7 +393,7 @@ void Camera::getEyeCameraTransform(IDisplayDevice *displayDevice, U32 eyeId, Mat
    }
 }
 
-DisplayPose Camera::calcCameraDeltaPose(GameConnection *con, DisplayPose inPose)
+DisplayPose Camera::calcCameraDeltaPose(GameConnection *con, const DisplayPose& inPose)
 {
    // NOTE: this is intended to be similar to updateMove
    DisplayPose outPose;

--- a/Engine/source/T3D/camera.h
+++ b/Engine/source/T3D/camera.h
@@ -237,7 +237,7 @@ class Camera: public ShapeBase
       virtual void interpolateTick( F32 delta);
       virtual void getCameraTransform( F32* pos,MatrixF* mat );
       virtual void getEyeCameraTransform( IDisplayDevice *display, U32 eyeId, MatrixF *outMat );
-      virtual DisplayPose calcCameraDeltaPose(GameConnection *con, DisplayPose inPose);
+      virtual DisplayPose calcCameraDeltaPose(GameConnection *con, const DisplayPose& inPose);
 
       virtual void writePacketData( GameConnection* conn, BitStream* stream );
       virtual void readPacketData( GameConnection* conn, BitStream* stream );

--- a/Engine/source/T3D/fx/fxFoliageReplicator.cpp
+++ b/Engine/source/T3D/fx/fxFoliageReplicator.cpp
@@ -248,7 +248,7 @@ fxFoliageCulledList::fxFoliageCulledList(Box3F SearchBox, fxFoliageCulledList* I
 
 //------------------------------------------------------------------------------
 
-void fxFoliageCulledList::FindCandidates(Box3F SearchBox, fxFoliageCulledList* InVec)
+void fxFoliageCulledList::FindCandidates(const Box3F& SearchBox, fxFoliageCulledList* InVec)
 {
    // Search the Culled List.
    for (U32 i = 0; i < InVec->GetListCount(); i++)
@@ -1028,7 +1028,7 @@ void fxFoliageReplicator::SetupBuffers()
 
 //------------------------------------------------------------------------------
 
-Box3F fxFoliageReplicator::FetchQuadrant(Box3F Box, U32 Quadrant)
+Box3F fxFoliageReplicator::FetchQuadrant(const Box3F& Box, U32 Quadrant)
 {
    Box3F QuadrantBox;
 

--- a/Engine/source/T3D/fx/fxFoliageReplicator.h
+++ b/Engine/source/T3D/fx/fxFoliageReplicator.h
@@ -86,7 +86,7 @@ public:
    fxFoliageCulledList(Box3F SearchBox, fxFoliageCulledList* InVec);
    ~fxFoliageCulledList() {};
 
-   void FindCandidates(Box3F SearchBox, fxFoliageCulledList* InVec);
+   void FindCandidates(const Box3F& SearchBox, fxFoliageCulledList* InVec);
 
    U32 GetListCount(void) { return mCulledObjectSet.size(); };
    fxFoliageItem* GetElement(U32 index) { return mCulledObjectSet[index]; };
@@ -157,7 +157,7 @@ protected:
 
    void SyncFoliageReplicators(void);
 
-   Box3F FetchQuadrant(Box3F Box, U32 Quadrant);
+   Box3F FetchQuadrant(const Box3F& Box, U32 Quadrant);
    void ProcessQuadrant(fxFoliageQuadrantNode* pParentNode, fxFoliageCulledList* pCullList, U32 Quadrant);
    void ProcessNodeChildren(fxFoliageQuadrantNode* pParentNode, fxFoliageCulledList* pCullList);
 

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -5586,7 +5586,7 @@ void Player::getMuzzleTransform(U32 imageSlot,MatrixF* mat)
    *mat = nmat;
 }
 
-DisplayPose Player::calcCameraDeltaPose(GameConnection *con, DisplayPose inPose)
+DisplayPose Player::calcCameraDeltaPose(GameConnection *con, const DisplayPose& inPose)
 {
    // NOTE: this is intended to be similar to updateMove
    DisplayPose outPose;

--- a/Engine/source/T3D/player.h
+++ b/Engine/source/T3D/player.h
@@ -684,7 +684,7 @@ public:
    void getEyeBaseTransform(MatrixF* mat, bool includeBank);
    void getRenderEyeTransform(MatrixF* mat);
    void getRenderEyeBaseTransform(MatrixF* mat, bool includeBank);
-   virtual DisplayPose calcCameraDeltaPose(GameConnection *con, DisplayPose inPose);
+   virtual DisplayPose calcCameraDeltaPose(GameConnection *con, const DisplayPose& inPose);
    void getCameraParameters(F32 *min, F32 *max, Point3F *offset, MatrixF *rot);
    void getMuzzleTransform(U32 imageSlot,MatrixF* mat);
    void getRenderMuzzleTransform(U32 imageSlot,MatrixF* mat);   

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -1192,13 +1192,13 @@ void ShapeBase::onDeleteNotify( SimObject *obj )
    Parent::onDeleteNotify( obj );      
 }
 
-void ShapeBase::onImpact(SceneObject* obj, VectorF vec)
+void ShapeBase::onImpact(SceneObject* obj, const VectorF& vec)
 {
    if (!isGhost())
       mDataBlock->onImpact_callback( this, obj, vec, vec.len() );
 }
 
-void ShapeBase::onImpact(VectorF vec)
+void ShapeBase::onImpact(const VectorF& vec)
 {
    if (!isGhost())
       mDataBlock->onImpact_callback( this, NULL, vec, vec.len() );
@@ -1995,7 +1995,7 @@ void ShapeBase::getEyeCameraTransform(IDisplayDevice *displayDevice, U32 eyeId, 
    *outMat = temp;
 }
 
-DisplayPose ShapeBase::calcCameraDeltaPose(GameConnection *con, DisplayPose inPose)
+DisplayPose ShapeBase::calcCameraDeltaPose(GameConnection *con, const DisplayPose& inPose)
 {
    // NOTE: this is intended to be similar to updateMove
    // WARNING: does not take into account any move values

--- a/Engine/source/T3D/shapeBase.h
+++ b/Engine/source/T3D/shapeBase.h
@@ -1103,8 +1103,8 @@ protected:
    virtual void shakeCamera( U32 imageSlot );
    virtual void updateDamageLevel();
    virtual void updateDamageState();
-   virtual void onImpact(SceneObject* obj, VectorF vec);
-   virtual void onImpact(VectorF vec);
+   virtual void onImpact(SceneObject* obj, const VectorF& vec);
+   virtual void onImpact(const VectorF& vec);
    /// @}
 
    /// The inner prep render function that does the 
@@ -1587,7 +1587,7 @@ public:
    virtual void getEyeCameraTransform( IDisplayDevice *display, U32 eyeId, MatrixF *outMat );
 
    /// Calculates a delta camera angle and view position based on inPose
-   virtual DisplayPose calcCameraDeltaPose(GameConnection *con, DisplayPose inPose);
+   virtual DisplayPose calcCameraDeltaPose(GameConnection *con, const DisplayPose& inPose);
 
    /// Gets the index of a node inside a mounted image given the name
    /// @param   imageSlot   Image slot

--- a/Engine/source/collision/boxConvex.cpp
+++ b/Engine/source/collision/boxConvex.cpp
@@ -76,7 +76,7 @@ Point3F BoxConvex::getVertex(S32 v)
    return p;
 }
 
-inline bool isOnPlane(Point3F p,PlaneF& plane)
+inline bool isOnPlane(const Point3F& p,PlaneF& plane)
 {
    F32 dist = mDot(plane,p) + plane.d;
    return dist < 0.1 && dist > -0.1;

--- a/Engine/source/environment/editors/guiMeshRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiMeshRoadEditorCtrl.cpp
@@ -1091,7 +1091,7 @@ F32 GuiMeshRoadEditorCtrl::getNodeDepth()
    return 0.0f;
 }
 
-void GuiMeshRoadEditorCtrl::setNodePosition( Point3F pos )
+void GuiMeshRoadEditorCtrl::setNodePosition(const Point3F& pos)
 {
    if ( mSelRoad && mSelNode != -1 )
    {

--- a/Engine/source/environment/editors/guiMeshRoadEditorCtrl.h
+++ b/Engine/source/environment/editors/guiMeshRoadEditorCtrl.h
@@ -100,7 +100,7 @@ class GuiMeshRoadEditorCtrl : public EditTSCtrl
       void setNodeDepth( F32 depth );
 		
 		Point3F getNodePosition();
-		void setNodePosition( Point3F pos );
+      void setNodePosition(const Point3F& pos);
 
       VectorF getNodeNormal();
       void setNodeNormal( const VectorF &normal );

--- a/Engine/source/environment/editors/guiRiverEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRiverEditorCtrl.cpp
@@ -1235,7 +1235,7 @@ F32 GuiRiverEditorCtrl::getNodeDepth()
    return 0.0f;
 }
 
-void GuiRiverEditorCtrl::setNodePosition( Point3F pos )
+void GuiRiverEditorCtrl::setNodePosition(const Point3F& pos)
 {
    if ( mSelRiver && mSelNode != -1 )
    {

--- a/Engine/source/environment/editors/guiRiverEditorCtrl.h
+++ b/Engine/source/environment/editors/guiRiverEditorCtrl.h
@@ -110,7 +110,7 @@ class GuiRiverEditorCtrl : public EditTSCtrl
       void setNodeDepth( F32 depth );
 
 		Point3F getNodePosition();
-		void setNodePosition( Point3F pos );
+      void setNodePosition(const Point3F& pos);
 
 		VectorF getNodeNormal();
       void setNodeNormal( const VectorF &normal );

--- a/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
@@ -979,7 +979,7 @@ F32 GuiRoadEditorCtrl::getNodeWidth()
    return 0.0f;   
 }
 
-void GuiRoadEditorCtrl::setNodePosition( Point3F pos )
+void GuiRoadEditorCtrl::setNodePosition(const Point3F& pos)
 {
    if ( mSelRoad && mSelNode != -1 )
    {

--- a/Engine/source/environment/editors/guiRoadEditorCtrl.h
+++ b/Engine/source/environment/editors/guiRoadEditorCtrl.h
@@ -97,7 +97,7 @@ class GuiRoadEditorCtrl : public EditTSCtrl
       void setNodeWidth( F32 width );
 
 		Point3F getNodePosition();
-		void setNodePosition( Point3F pos );
+      void setNodePosition(const Point3F& pos);
 
       void setTextureFile( StringTableEntry file );
 	

--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -735,14 +735,14 @@ void GFXDevice::setLight(U32 stage, GFXLightInfo* light)
 //-----------------------------------------------------------------------------
 // Set Light Material
 //-----------------------------------------------------------------------------
-void GFXDevice::setLightMaterial(GFXLightMaterial mat)
+void GFXDevice::setLightMaterial(const GFXLightMaterial& mat)
 {
    mCurrentLightMaterial = mat;
    mLightMaterialDirty = true;
    mStateDirty = true;
 }
 
-void GFXDevice::setGlobalAmbientColor(ColorF color)
+void GFXDevice::setGlobalAmbientColor(const ColorF& color)
 {
    if(mGlobalAmbientColor != color)
    {

--- a/Engine/source/gfx/gfxDevice.h
+++ b/Engine/source/gfx/gfxDevice.h
@@ -901,8 +901,8 @@ public:
    /// because of the state caching stuff.
    /// @{
    void setLight(U32 stage, GFXLightInfo* light);
-   void setLightMaterial(GFXLightMaterial mat);
-   void setGlobalAmbientColor(ColorF color);
+   void setLightMaterial(const GFXLightMaterial& mat);
+   void setGlobalAmbientColor(const ColorF& color);
 
    /// @}
    

--- a/Engine/source/gui/containers/guiContainer.h
+++ b/Engine/source/gui/containers/guiContainer.h
@@ -91,7 +91,7 @@ class  GuiContainer : public GuiControl
       inline void setAnchorRight(bool val) { mSizingOptions.mAnchorRight = val; }
 
       ControlSizing getSizingOptions() const { return mSizingOptions; }
-      void setSizingOptions(ControlSizing val) { mSizingOptions = val; }
+      void setSizingOptions(const ControlSizing& val) { mSizingOptions = val; }
 
       /// @}   
 

--- a/Engine/source/gui/containers/guiSplitContainer.cpp
+++ b/Engine/source/gui/containers/guiSplitContainer.cpp
@@ -444,7 +444,7 @@ bool GuiSplitContainer::layoutControls( RectI &clientRect )
 
 //-----------------------------------------------------------------------------
 
-void GuiSplitContainer::solvePanelConstraints( Point2I newDragPos, GuiContainer * firstPanel, GuiContainer * secondPanel, RectI clientRect )
+void GuiSplitContainer::solvePanelConstraints(Point2I newDragPos, GuiContainer * firstPanel, GuiContainer * secondPanel, const RectI& clientRect)
 {
    if( !firstPanel || !secondPanel )
       return;

--- a/Engine/source/gui/containers/guiSplitContainer.h
+++ b/Engine/source/gui/containers/guiSplitContainer.h
@@ -84,7 +84,7 @@ public:
    virtual inline Point2I getSplitPoint() { return mSplitPoint; };
    /// The Splitters entire Client Rectangle, this takes into account padding of this control
    virtual inline RectI getSplitRect() { return mSplitRect; };
-   virtual void solvePanelConstraints( Point2I newDragPos, GuiContainer * firstPanel, GuiContainer * secondPanel, RectI clientRect );   
+   virtual void solvePanelConstraints(Point2I newDragPos, GuiContainer * firstPanel, GuiContainer * secondPanel, const RectI& clientRect);
    virtual Point2I getMinExtent() const;   
 
 protected:

--- a/Engine/source/gui/containers/guiTabBookCtrl.cpp
+++ b/Engine/source/gui/containers/guiTabBookCtrl.cpp
@@ -548,7 +548,7 @@ void GuiTabBookCtrl::renderTabs( const Point2I &offset, const RectI &tabRect )
 
 //-----------------------------------------------------------------------------
 
-void GuiTabBookCtrl::renderTab( RectI tabRect, GuiTabPageCtrl *tab )
+void GuiTabBookCtrl::renderTab(const RectI& tabRect, GuiTabPageCtrl *tab)
 {
    StringTableEntry text = tab->getText();
    ColorI oldColor;

--- a/Engine/source/gui/containers/guiTabBookCtrl.h
+++ b/Engine/source/gui/containers/guiTabBookCtrl.h
@@ -158,7 +158,7 @@ class GuiTabBookCtrl : public GuiContainer
       /// Tab rendering subroutine, renders one tab with specified options
       /// @param   tabRect   the rectangle to render the tab into
       /// @param   tab   pointer to the tab page control for which to render the tab
-      void renderTab( RectI tabRect, GuiTabPageCtrl* tab );
+      void renderTab(const RectI& tabRect, GuiTabPageCtrl* tab);
 
       /// @}
 

--- a/Engine/source/gui/controls/guiGradientCtrl.cpp
+++ b/Engine/source/gui/controls/guiGradientCtrl.cpp
@@ -521,7 +521,7 @@ void GuiGradientCtrl::reInitSwatches( GuiGradientCtrl::PickMode )
 	}
 }
 
-void GuiGradientCtrl::addColorRange( Point2I pos, ColorF color )
+void GuiGradientCtrl::addColorRange(Point2I pos, const ColorF& color)
 {
 	if( pos.x + mSwatchFactor < mBlendRangeBox.point.x &&
 		pos.x + mSwatchFactor > mBlendRangeBox.extent.x )

--- a/Engine/source/gui/controls/guiGradientCtrl.h
+++ b/Engine/source/gui/controls/guiGradientCtrl.h
@@ -148,7 +148,7 @@ public:
 	void inspectPreApply();
 	void inspectPostApply();
 	void reInitSwatches( GuiGradientCtrl::PickMode );
-	void addColorRange( Point2I pos, ColorF color );
+   void addColorRange(Point2I pos, const ColorF& color);
 	void removeColorRange( GuiGradientSwatchCtrl* swatch );
 	void sortColorRange();
 

--- a/Engine/source/gui/controls/guiListBoxCtrl.cpp
+++ b/Engine/source/gui/controls/guiListBoxCtrl.cpp
@@ -677,7 +677,7 @@ DefineEngineMethod( GuiListBoxCtrl, setItemColor, void, (S32 index, ColorF color
    object->setItemColor( index, color );
 }
 
-void GuiListBoxCtrl::setItemColor( S32 index, ColorF color )
+void GuiListBoxCtrl::setItemColor(S32 index, const ColorF& color)
 {
    if ((index >= mItems.size()) || index < 0)
    {
@@ -1090,7 +1090,7 @@ void GuiListBoxCtrl::onRender( Point2I offset, const RectI &updateRect )
    GFX->setClipRect( oldClipRect );
 }
 
-void GuiListBoxCtrl::onRenderItem( RectI itemRect, LBItem *item )
+void GuiListBoxCtrl::onRenderItem(const RectI& itemRect, LBItem *item)
 {
    if( item->isSelected )
       GFX->getDrawUtil()->drawRectFill( itemRect, mProfile->mFillColorSEL );

--- a/Engine/source/gui/controls/guiListBoxCtrl.h
+++ b/Engine/source/gui/controls/guiListBoxCtrl.h
@@ -107,7 +107,7 @@ public:
    S32               insertItemWithColor( S32 index, StringTableEntry text, ColorF color = ColorF(-1, -1, -1), void *itemData = NULL);
    S32               findItemText( StringTableEntry text, bool caseSensitive = false );
 
-   void              setItemColor(S32 index, ColorF color);
+   void              setItemColor(S32 index, const ColorF& color);
    void              clearItemColor(S32 index);
 
    void              deleteItem( S32 index );
@@ -128,7 +128,7 @@ public:
 
    // Rendering
    virtual void      onRender( Point2I offset, const RectI &updateRect );
-   virtual void      onRenderItem( RectI itemRect, LBItem *item );
+   virtual void      onRenderItem(const RectI& itemRect, LBItem *item);
    void              drawBox( const Point2I &box, S32 size, ColorI &outlineColor, ColorI &boxColor );
    bool              renderTooltip( const Point2I &hoverPos, const Point2I& cursorPos, const char* tipText );
 	void					addFilteredItem( String item );

--- a/Engine/source/gui/editor/guiMenuBar.cpp
+++ b/Engine/source/gui/editor/guiMenuBar.cpp
@@ -1623,7 +1623,7 @@ void GuiMenuBar::closeMenu()
 }
 
 //  Called when a menu item is highlighted by the mouse
-void GuiMenuBar::highlightedMenuItem(S32 selectionIndex, RectI bounds, Point2I cellSize)
+void GuiMenuBar::highlightedMenuItem(S32 selectionIndex, const RectI& bounds, Point2I cellSize)
 {
    S32 selstore = selectionIndex;
 
@@ -1777,7 +1777,7 @@ void GuiMenuBar::onAction()
 
 //------------------------------------------------------------------------------
 //  Performs an action when a menu item that is a submenu is selected/highlighted
-void GuiMenuBar::onSubmenuAction(S32 selectionIndex, RectI bounds, Point2I cellSize)
+void GuiMenuBar::onSubmenuAction(S32 selectionIndex, const RectI& bounds, Point2I cellSize)
 {
    if(!mouseOverSubmenu)
       return;

--- a/Engine/source/gui/editor/guiMenuBar.h
+++ b/Engine/source/gui/editor/guiMenuBar.h
@@ -182,12 +182,12 @@ public:
    static void addSubmenuItem(Menu *menu, MenuItem *submenu, MenuItem *newMenuItem );
    static void removeSubmenuItem(MenuItem *menuItem, MenuItem *submenuItem);
    static void clearSubmenuItems(MenuItem *menuitem);
-   void onSubmenuAction(S32 selectionIndex, RectI bounds, Point2I cellSize);
+   void onSubmenuAction(S32 selectionIndex, const RectI& bounds, Point2I cellSize);
    void closeSubmenu();
    void checkSubmenuMouseMove(const GuiEvent &event);
    MenuItem *findHitMenuItem(Point2I mousePoint);
 
-   void highlightedMenuItem(S32 selectionIndex, RectI bounds, Point2I cellSize); //  Called whenever a menu item is highlighted by the mouse
+   void highlightedMenuItem(S32 selectionIndex, const RectI& bounds, Point2I cellSize); //  Called whenever a menu item is highlighted by the mouse
 
 	// display/mouse functions
 

--- a/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
@@ -918,7 +918,7 @@ void DICreateUndoAction::initPersistFields()
    Parent::initPersistFields();
 }
 
-void DICreateUndoAction::addDecal( DecalInstance decal )
+void DICreateUndoAction::addDecal(const DecalInstance& decal)
 {
 	mDecalInstance = decal;
 	mDatablockId = decal.mDataBlock->getId();
@@ -1006,7 +1006,7 @@ void DIDeleteUndoAction::initPersistFields()
    Parent::initPersistFields();
 }
 
-void DIDeleteUndoAction::deleteDecal( DecalInstance decal )
+void DIDeleteUndoAction::deleteDecal(const DecalInstance& decal)
 {
 	mDecalInstance = decal;
 	mDatablockId = decal.mDataBlock->getId();
@@ -1094,7 +1094,7 @@ void DBDeleteUndoAction::initPersistFields()
    Parent::initPersistFields();
 }
 
-void DBDeleteUndoAction::deleteDecal( DecalInstance decal )
+void DBDeleteUndoAction::deleteDecal(const DecalInstance& decal)
 {
 	mDecalInstanceVec.increment();
    mDecalInstanceVec.last() = decal;

--- a/Engine/source/gui/worldEditor/guiDecalEditorCtrl.h
+++ b/Engine/source/gui/worldEditor/guiDecalEditorCtrl.h
@@ -129,7 +129,7 @@ public:
    DICreateUndoAction( const UTF8* actionName = "Create Decal " );
    virtual ~DICreateUndoAction();
 
-   void addDecal( DecalInstance decal );
+   void addDecal(const DecalInstance& decal);
 
    // UndoAction
    virtual void undo();
@@ -159,7 +159,7 @@ public:
    virtual ~DIDeleteUndoAction();
 
    ///
-   void deleteDecal( DecalInstance decal );
+   void deleteDecal(const DecalInstance& decal);
 
    // UndoAction
    virtual void undo();
@@ -188,7 +188,7 @@ public:
    DBDeleteUndoAction( const UTF8* actionName = "Delete Decal Datablock" );
    virtual ~DBDeleteUndoAction();
 
-   void deleteDecal( DecalInstance decal );
+   void deleteDecal(const DecalInstance& decal);
 
    // UndoAction
    virtual void undo();

--- a/Engine/source/navigation/navMesh.cpp
+++ b/Engine/source/navigation/navMesh.cpp
@@ -681,7 +681,7 @@ void NavMesh::updateConfig()
    cfg.tileSize = mTileSize / cfg.cs;
 }
 
-S32 NavMesh::getTile(Point3F pos)
+S32 NavMesh::getTile(const Point3F& pos)
 {
    if(mBuilding)
       return -1;

--- a/Engine/source/navigation/navMesh.h
+++ b/Engine/source/navigation/navMesh.h
@@ -118,7 +118,7 @@ public:
    /// @}
 
    /// Return the index of the tile included by this point.
-   S32 getTile(Point3F pos);
+   S32 getTile(const Point3F& pos);
 
    /// Return the box of a given tile.
    Box3F getTileBox(U32 id);

--- a/Engine/source/navigation/torqueRecast.h
+++ b/Engine/source/navigation/torqueRecast.h
@@ -28,10 +28,10 @@
 #include "math/mBox.h"
 
 inline Point3F DTStoRC(F32 x, F32 y, F32 z) { return Point3F(x, z, -y); }
-inline Point3F DTStoRC(const Point3F& point)       { return Point3F(point.x, point.z, -point.y); }
+inline Point3F DTStoRC(const Point3F& point){ return Point3F(point.x, point.z, -point.y); }
 inline Point3F RCtoDTS(const F32* xyz)      { return Point3F(xyz[0], -xyz[2], xyz[1]); }
 inline Point3F RCtoDTS(F32 x, F32 y, F32 z) { return Point3F(x, -z, y); }
-inline Point3F RCtoDTS(const Point3F& point)       { return Point3F(point.x, -point.z, point.y); }
+inline Point3F RCtoDTS(const Point3F& point){ return Point3F(point.x, -point.z, point.y); }
 inline Box3F DTStoRC(const Box3F& box)
 {
    return Box3F(box.minExtents.x, box.minExtents.z, -box.maxExtents.y,

--- a/Engine/source/navigation/torqueRecast.h
+++ b/Engine/source/navigation/torqueRecast.h
@@ -28,11 +28,11 @@
 #include "math/mBox.h"
 
 inline Point3F DTStoRC(F32 x, F32 y, F32 z) { return Point3F(x, z, -y); }
-inline Point3F DTStoRC(Point3F point)       { return Point3F(point.x, point.z, -point.y); }
+inline Point3F DTStoRC(const Point3F& point)       { return Point3F(point.x, point.z, -point.y); }
 inline Point3F RCtoDTS(const F32* xyz)      { return Point3F(xyz[0], -xyz[2], xyz[1]); }
 inline Point3F RCtoDTS(F32 x, F32 y, F32 z) { return Point3F(x, -z, y); }
-inline Point3F RCtoDTS(Point3F point)       { return Point3F(point.x, -point.z, point.y); }
-inline Box3F DTStoRC(Box3F box)
+inline Point3F RCtoDTS(const Point3F& point)       { return Point3F(point.x, -point.z, point.y); }
+inline Box3F DTStoRC(const Box3F& box)
 {
    return Box3F(box.minExtents.x, box.minExtents.z, -box.maxExtents.y,
                   box.maxExtents.x, box.maxExtents.z, -box.minExtents.y);

--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -339,7 +339,7 @@ bool TerrainBlock::setFile( const FileName &terrFileName )
    return true;
 }
 
-void TerrainBlock::setFile( Resource<TerrainFile> terr )
+void TerrainBlock::setFile(const Resource<TerrainFile>& terr)
 {
    mFile = terr;
    mTerrFileName = terr.getPath();

--- a/Engine/source/terrain/terrData.h
+++ b/Engine/source/terrain/terrData.h
@@ -413,7 +413,7 @@ public:
 
    bool setFile( const FileName& terrFileName );
 
-   void setFile( Resource<TerrainFile> file );
+   void setFile(const Resource<TerrainFile>& file);
 
    bool save(const char* filename);
 

--- a/Engine/source/util/triBoxCheck.h
+++ b/Engine/source/util/triBoxCheck.h
@@ -38,7 +38,7 @@ bool triBoxOverlap(const Point3F &boxcenter, const Point3F &boxhalfsize, const P
 
 /// Massage stuff into right format for triBoxOverlap test. This is really
 /// just a helper function - use the other version if you want to be fast!
-inline bool triBoxOverlap(Box3F box, Point3F a, Point3F b, Point3F c)
+inline bool triBoxOverlap(Box3F box, const Point3F& a, const Point3F& b, const Point3F& c)
 {
    Point3F halfSize(box.len_x() / 2.f, box.len_y() / 2.f, box.len_z() / 2.f);
 

--- a/Engine/source/util/triRayCheck.cpp
+++ b/Engine/source/util/triRayCheck.cpp
@@ -125,8 +125,8 @@ bool intersect_triangle(Point3F orig, Point3F dir,
 }
 
 //*** Taken from TSE, and based on the above
-bool castRayTriangle(Point3F orig, Point3F dir,
-   Point3F vert0, Point3F vert1, Point3F vert2,
+bool castRayTriangle(const Point3F& orig, const Point3F& dir,
+   const Point3F& vert0, const Point3F& vert1, const Point3F& vert2,
    F32 &t, Point2F &bary)
 {
    Point3F tvec, qvec;

--- a/Engine/source/util/triRayCheck.h
+++ b/Engine/source/util/triRayCheck.h
@@ -38,7 +38,7 @@ bool intersect_triangle(Point3F orig, Point3F dir,
                    F32& t, F32& u, F32& v);
 
 //*** Taken from TSE, but based on the above
-bool castRayTriangle(Point3F orig, Point3F dir, Point3F vert0, Point3F vert1, Point3F vert2, F32 &t, Point2F &bary);
+bool castRayTriangle(const Point3F& orig, const Point3F& dir, const Point3F& vert0, const Point3F& vert1, const Point3F& vert2, F32 &t, Point2F &bary);
 bool castRayTriangle(const Point3D &orig, const Point3D &dir, const Point3D &vert0, const Point3D &vert1, const Point3D &vert2);
 
 #endif // _TRIRAYCHECK_H_


### PR DESCRIPTION
Issue found with PVS-Studio:

A lot of instances where some function args are not actually modified in any way, meaning that it is better for performance to convert them into const references. This prevents an additional copy, which can help performance.