### PR TITLE
followobject position caching

### DIFF
--- a/Engine/source/T3D/aiPlayer.cpp
+++ b/Engine/source/T3D/aiPlayer.cpp
@@ -831,11 +831,15 @@ void AIPlayer::followObject(SceneObject *obj, F32 radius)
    if(!isServerObject())
       return;
 
+   if ((mFollowData.lastPos - obj->getPosition()).len()<mMoveTolerance)
+      return;
+
    if(setPathDestination(obj->getPosition()))
    {
       clearCover();
       mFollowData.object = obj;
       mFollowData.radius = radius;
+      mFollowData.lastPos = obj->getPosition();
    }
 }
 

--- a/Engine/source/T3D/aiPlayer.h
+++ b/Engine/source/T3D/aiPlayer.h
@@ -127,6 +127,7 @@ private:
       FollowData() : object(NULL)
       {
          radius = 5.0f;
+         lastPos = Point3F::Zero;
       }
    };
 

--- a/Engine/source/T3D/aiPlayer.h
+++ b/Engine/source/T3D/aiPlayer.h
@@ -122,6 +122,7 @@ private:
       SimObjectPtr<SceneObject> object;
       /// Distance at whcih to follow.
       F32 radius;
+      Point3F lastPos;
       /// Default constructor.
       FollowData() : object(NULL)
       {


### PR DESCRIPTION
re-use the position of an object we're following (within reason) so we're not constantly regenning a path.