### PR TITLE
Removing pointless null-pointer tests for objects created with new

### DIFF
--- a/Engine/source/T3D/aiPlayer.cpp
+++ b/Engine/source/T3D/aiPlayer.cpp
@@ -725,24 +725,20 @@ bool AIPlayer::setPathDestination(const Point3F &pos)
 
    // Create a new path.
    NavPath *path = new NavPath();
-   if(path)
+
+   path->mMesh = getNavMesh();
+   path->mFrom = getPosition();
+   path->mTo = pos;
+   path->mFromSet = path->mToSet = true;
+   path->mAlwaysRender = true;
+   path->mLinkTypes = mLinkTypes;
+   path->mXray = true;
+   // Paths plan automatically upon being registered.
+   if(!path->registerObject())
    {
-      path->mMesh = getNavMesh();
-      path->mFrom = getPosition();
-      path->mTo = pos;
-      path->mFromSet = path->mToSet = true;
-      path->mAlwaysRender = true;
-      path->mLinkTypes = mLinkTypes;
-      path->mXray = true;
-      // Paths plan automatically upon being registered.
-      if(!path->registerObject())
-      {
-         delete path;
-         return false;
-      }
-   }
-   else
+      delete path;
       return false;
+   }
 
    if(path->success())
    {

--- a/Engine/source/console/consoleParser.cpp
+++ b/Engine/source/console/consoleParser.cpp
@@ -50,24 +50,21 @@ bool addConsoleParser(char *ext, fnGetCurrentFile gcf, fnGetCurrentLine gcl, fnP
 	AssertFatal(ext && gcf && gcl && p && r, "AddConsoleParser called with one or more NULL arguments");
 
 	ConsoleParser * pParser = new ConsoleParser;
-	if(pParser != NULL)
-	{
-		pParser->ext = ext;
-		pParser->getCurrentFile = gcf;
-		pParser->getCurrentLine = gcl;
-		pParser->parse = p;
-		pParser->restart = r;
-		pParser->setScanBuffer = ssb;
 
-		if(def)
-			gDefaultParser = pParser;
+   pParser->ext = ext;
+   pParser->getCurrentFile = gcf;
+   pParser->getCurrentLine = gcl;
+   pParser->parse = p;
+   pParser->restart = r;
+   pParser->setScanBuffer = ssb;
 
-		pParser->next = gParserList;
-		gParserList = pParser;
+   if (def)
+      gDefaultParser = pParser;
 
-		return true;
-	}
-	return false;
+   pParser->next = gParserList;
+   gParserList = pParser;
+
+   return true;
 }
 
 ConsoleParser * getParserForFile(const char *filename)

--- a/Engine/source/core/stream/fileStream.cpp
+++ b/Engine/source/core/stream/fileStream.cpp
@@ -39,15 +39,12 @@ FileStream *FileStream::createAndOpen(const String &inFileName, Torque::FS::File
 {
    FileStream  *newStream = new FileStream;
 
-   if ( newStream )
-   {
-      bool success = newStream->open( inFileName, inMode );
+   bool success = newStream->open( inFileName, inMode );
 
-      if ( !success )
-      {
-         delete newStream;
-         newStream = NULL;
-      }
+   if ( !success )
+   {
+      delete newStream;
+      newStream = NULL;
    }
 
    return newStream;

--- a/Engine/source/gui/controls/guiListBoxCtrl.cpp
+++ b/Engine/source/gui/controls/guiListBoxCtrl.cpp
@@ -748,11 +748,6 @@ S32 GuiListBoxCtrl::insertItem( S32 index, StringTableEntry text, void *itemData
    }
 
    LBItem *newItem = new LBItem;
-   if( !newItem )
-   {
-      Con::warnf("GuiListBoxCtrl::insertItem - error allocating item memory!" );
-      return -1;
-   }
 
    // Assign item data
    newItem->itemText    = StringTable->insert(text, true);
@@ -792,11 +787,6 @@ S32 GuiListBoxCtrl::insertItemWithColor( S32 index, StringTableEntry text, Color
    }
 
    LBItem *newItem = new LBItem;
-   if( !newItem )
-   {
-      Con::warnf("GuiListBoxCtrl::insertItem - error allocating item memory!" );
-      return -1;
-   }
 
    // Assign item data
    newItem->itemText    = StringTable->insert(text, true);

--- a/Engine/source/gui/editor/guiImageList.cpp
+++ b/Engine/source/gui/editor/guiImageList.cpp
@@ -47,8 +47,6 @@ U32 GuiImageList::Insert( const char* texturePath, GFXTextureProfile *Type )
 {
   TextureEntry *t = new TextureEntry;
 
-  if ( ! t ) return -1;
-
   t->TexturePath = StringTable->insert(texturePath);
   if ( *t->TexturePath ) 
   {

--- a/Engine/source/gui/editor/guiInspector.cpp
+++ b/Engine/source/gui/editor/guiInspector.cpp
@@ -564,31 +564,25 @@ void GuiInspector::refresh()
       ungroup = new GuiInspectorGroup( "Ungrouped", this );
       ungroup->setHeaderHidden( true );
       ungroup->setCanCollapse( false );
-      if( ungroup != NULL )
-      {
-         ungroup->registerObject();
-         mGroups.push_back( ungroup );
-         addObject( ungroup );
-      }   
+
+      ungroup->registerObject();
+      mGroups.push_back( ungroup );
+      addObject( ungroup );
    }
 
    // Put the 'transform' group first
    GuiInspectorGroup *transform = new GuiInspectorGroup( "Transform", this );
-   if( transform != NULL )
-   {
-      transform->registerObject();
-      mGroups.push_back( transform );
-      addObject( transform );
-   }
+
+   transform->registerObject();
+   mGroups.push_back(transform);
+   addObject(transform);
 
    // Always create the 'general' group (for fields without a group)      
    GuiInspectorGroup *general = new GuiInspectorGroup( "General", this );
-   if( general != NULL )
-   {
-      general->registerObject();
-      mGroups.push_back( general );
-      addObject( general );
-   }
+
+   general->registerObject();
+   mGroups.push_back(general);
+   addObject(general);
 
    // Create the inspector groups for static fields.
 
@@ -606,25 +600,23 @@ void GuiInspector::refresh()
             if( !group && !isGroupFiltered( itr->pGroupname ) )
             {
                GuiInspectorGroup *group = new GuiInspectorGroup( itr->pGroupname, this );
-               if( group != NULL )
+
+               group->registerObject();
+               if( !group->getNumFields() )
                {
-                  group->registerObject();
-                  if( !group->getNumFields() )
-                  {
-                     #ifdef DEBUG_SPEW
-                     Platform::outputDebugString( "[GuiInspector] Removing empty group '%s'",
-                        group->getCaption().c_str() );
-                     #endif
+                  #ifdef DEBUG_SPEW
+                  Platform::outputDebugString( "[GuiInspector] Removing empty group '%s'",
+                     group->getCaption().c_str() );
+                  #endif
                      
-                     // The group ended up having no fields.  Remove it.
-                     group->deleteObject();
-                  }
-                  else
-                  {
-                     mGroups.push_back( group );
-                     addObject( group );
-                  }
-               }            
+                  // The group ended up having no fields.  Remove it.
+                  group->deleteObject();
+               }
+               else
+               {
+                  mGroups.push_back( group );
+                  addObject( group );
+               }
             }
          }
       }
@@ -634,12 +626,10 @@ void GuiInspector::refresh()
    if ( !isGroupFiltered( "Dynamic Fields" ) )
    {
       GuiInspectorGroup *dynGroup = new GuiInspectorDynamicGroup( "Dynamic Fields", this);
-      if( dynGroup != NULL )
-      {
-         dynGroup->registerObject();
-         mGroups.push_back( dynGroup );
-         addObject( dynGroup );
-      }
+
+      dynGroup->registerObject();
+      mGroups.push_back( dynGroup );
+      addObject( dynGroup );
    }
 
    if( mShowCustomFields && mTargets.size() == 1 )

--- a/Engine/source/gui/editor/guiInspectorTypes.cpp
+++ b/Engine/source/gui/editor/guiInspectorTypes.cpp
@@ -57,10 +57,6 @@ GuiControl* GuiInspectorTypeMenuBase::constructEditControl()
 {
    GuiControl* retCtrl = new GuiPopUpMenuCtrl();
 
-   // If we couldn't construct the control, bail!
-   if( retCtrl == NULL )
-      return retCtrl;
-
    GuiPopUpMenuCtrl *menu = dynamic_cast<GuiPopUpMenuCtrl*>(retCtrl);
 
    // Let's make it look pretty.
@@ -218,25 +214,21 @@ GuiControl* GuiInspectorTypeMaterialName::construct(const char* command)
    //return retCtrl;
    mBrowseButton = new GuiBitmapButtonCtrl();
 
-   if ( mBrowseButton != NULL )
-   {
-      RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
+   RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
 
-      char szBuffer[512];
-      dSprintf( szBuffer, 512, command, getId());
-		mBrowseButton->setField( "Command", szBuffer );
+   dSprintf( szBuffer, 512, command, getId());
+	mBrowseButton->setField( "Command", szBuffer );
 
-		//temporary static button name
-		char bitmapName[512] = "tools/materialEditor/gui/change-material-btn";
-		mBrowseButton->setBitmap( bitmapName );
+	//temporary static button name
+	char bitmapName[512] = "tools/materialEditor/gui/change-material-btn";
+	mBrowseButton->setBitmap( bitmapName );
 
-      mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiButtonProfile" );
-      mBrowseButton->registerObject();
-      addObject( mBrowseButton );
+   mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiButtonProfile" );
+   mBrowseButton->registerObject();
+   addObject( mBrowseButton );
 
-      // Position
-      mBrowseButton->resize( browseRect.point, browseRect.extent );
-   }
+   // Position
+   mBrowseButton->resize( browseRect.point, browseRect.extent );
 
    return retCtrl;
 }
@@ -328,25 +320,21 @@ GuiControl* GuiInspectorTypeTerrainMaterialName::construct(const char* command)
    //return retCtrl;
    mBrowseButton = new GuiBitmapButtonCtrl();
 
-   if ( mBrowseButton != NULL )
-   {
-      RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
+   RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
 
-      char szBuffer[512];
-      dSprintf( szBuffer, 512, command, getId());
-		mBrowseButton->setField( "Command", szBuffer );
+   dSprintf( szBuffer, 512, command, getId());
+	mBrowseButton->setField( "Command", szBuffer );
 
-		//temporary static button name
-		char bitmapName[512] = "tools/gui/images/layers-btn";
-		mBrowseButton->setBitmap( bitmapName );
+	//temporary static button name
+	char bitmapName[512] = "tools/gui/images/layers-btn";
+	mBrowseButton->setBitmap( bitmapName );
 
-      mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiButtonProfile" );
-      mBrowseButton->registerObject();
-      addObject( mBrowseButton );
+   mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiButtonProfile" );
+   mBrowseButton->registerObject();
+   addObject( mBrowseButton );
 
-      // Position
-      mBrowseButton->resize( browseRect.point, browseRect.extent );
-   }
+   // Position
+   mBrowseButton->resize( browseRect.point, browseRect.extent );
 
    return retCtrl;
 }
@@ -413,10 +401,6 @@ ConsoleDocClass( GuiInspectorTypeCheckBox,
 GuiControl* GuiInspectorTypeCheckBox::constructEditControl()
 {
    GuiControl* retCtrl = new GuiCheckBoxCtrl();
-
-   // If we couldn't construct the control, bail!
-   if( retCtrl == NULL )
-      return retCtrl;
 
    GuiCheckBoxCtrl *check = dynamic_cast<GuiCheckBoxCtrl*>(retCtrl);
 
@@ -485,10 +469,6 @@ GuiControl* GuiInspectorTypeFileName::constructEditControl()
 {
    GuiControl* retCtrl = new GuiTextEditCtrl();
 
-   // If we couldn't construct the control, bail!
-   if( retCtrl == NULL )
-      return retCtrl;
-
    // Let's make it look pretty.
    retCtrl->setDataField( StringTable->insert("profile"), NULL, "GuiInspectorTextEditRightProfile" );
    retCtrl->setDataField( StringTable->insert("tooltipprofile"), NULL, "GuiToolTipProfile" );
@@ -504,20 +484,17 @@ GuiControl* GuiInspectorTypeFileName::constructEditControl()
 
    mBrowseButton = new GuiButtonCtrl();
 
-   if( mBrowseButton != NULL )
-   {
-      RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
-      char szBuffer[512];
-      dSprintf( szBuffer, 512, "getLoadFilename(\"*.*|*.*\", \"%d.apply\", %d.getData());", getId(), getId() );
-      mBrowseButton->setField( "Command", szBuffer );
-      mBrowseButton->setField( "text", "..." );
-      mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiInspectorButtonProfile" );
-      mBrowseButton->registerObject();
-      addObject( mBrowseButton );
+   RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
 
-      // Position
-      mBrowseButton->resize( browseRect.point, browseRect.extent );
-   }
+   dSprintf( szBuffer, 512, "getLoadFilename(\"*.*|*.*\", \"%d.apply\", %d.getData());", getId(), getId() );
+   mBrowseButton->setField( "Command", szBuffer );
+   mBrowseButton->setField( "text", "..." );
+   mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiInspectorButtonProfile" );
+   mBrowseButton->registerObject();
+   addObject( mBrowseButton );
+
+   // Position
+   mBrowseButton->resize( browseRect.point, browseRect.extent );
 
    return retCtrl;
 }
@@ -769,23 +746,20 @@ GuiControl* GuiInspectorTypeShapeFilename::constructEditControl()
 
    // Create "Open in ShapeEditor" button
    mShapeEdButton = new GuiBitmapButtonCtrl();
-   if ( mShapeEdButton != NULL )
-   {
-      char szBuffer[512];
-      dSprintf( szBuffer, sizeof(szBuffer), "ShapeEditorPlugin.open(%d.getText());", retCtrl->getId() );
-      mShapeEdButton->setField( "Command", szBuffer );
 
-      char bitmapName[512] = "tools/worldEditor/images/toolbar/shape-editor";
-      mShapeEdButton->setBitmap( bitmapName );
+   dSprintf(szBuffer, sizeof(szBuffer), "ShapeEditorPlugin.open(%d.getText());", retCtrl->getId());
+   mShapeEdButton->setField("Command", szBuffer);
 
-      mShapeEdButton->setDataField( StringTable->insert("Profile"), NULL, "GuiButtonProfile" );
-      mShapeEdButton->setDataField( StringTable->insert("tooltipprofile"), NULL, "GuiToolTipProfile" );
-      mShapeEdButton->setDataField( StringTable->insert("hovertime"), NULL, "1000" );
-      mShapeEdButton->setDataField( StringTable->insert("tooltip"), NULL, "Open this file in the Shape Editor" );
+   char bitmapName[512] = "tools/worldEditor/images/toolbar/shape-editor";
+   mShapeEdButton->setBitmap(bitmapName);
 
-      mShapeEdButton->registerObject();
-      addObject( mShapeEdButton );
-   }
+   mShapeEdButton->setDataField(StringTable->insert("Profile"), NULL, "GuiButtonProfile");
+   mShapeEdButton->setDataField(StringTable->insert("tooltipprofile"), NULL, "GuiToolTipProfile");
+   mShapeEdButton->setDataField(StringTable->insert("hovertime"), NULL, "1000");
+   mShapeEdButton->setDataField(StringTable->insert("tooltip"), NULL, "Open this file in the Shape Editor");
+
+   mShapeEdButton->registerObject();
+   addObject(mShapeEdButton);
 
    return retCtrl;
 }
@@ -841,10 +815,6 @@ GuiInspectorTypeCommand::GuiInspectorTypeCommand()
 GuiControl* GuiInspectorTypeCommand::constructEditControl()
 {
    GuiButtonCtrl* retCtrl = new GuiButtonCtrl();
-
-   // If we couldn't construct the control, bail!
-   if( retCtrl == NULL )
-      return retCtrl;
 
    // Let's make it look pretty.
    retCtrl->setDataField( StringTable->insert("profile"), NULL, "GuiInspectorTextEditProfile" );
@@ -926,25 +896,21 @@ GuiControl* GuiInspectorTypeRectUV::constructEditControl()
    //return retCtrl;
    mBrowseButton = new GuiBitmapButtonCtrl();
 
-   if ( mBrowseButton != NULL )
-   {
-      RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
+   RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
 
-      char szBuffer[512];
-      dSprintf( szBuffer, 512, "uvEditor.showDialog(\"%d.apply\", %d, %d.getText());", getId(), mInspector->getInspectObject()->getId(), retCtrl->getId());
-		mBrowseButton->setField( "Command", szBuffer );
+   dSprintf( szBuffer, 512, "uvEditor.showDialog(\"%d.apply\", %d, %d.getText());", getId(), mInspector->getInspectObject()->getId(), retCtrl->getId());
+	mBrowseButton->setField( "Command", szBuffer );
 
-		//temporary static button name
-		char bitmapName[512] = "tools/gui/images/uv-editor-btn";
-		mBrowseButton->setBitmap( bitmapName );
+	//temporary static button name
+	char bitmapName[512] = "tools/gui/images/uv-editor-btn";
+	mBrowseButton->setBitmap( bitmapName );
 
-      mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiButtonProfile" );
-      mBrowseButton->registerObject();
-      addObject( mBrowseButton );
+   mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiButtonProfile" );
+   mBrowseButton->registerObject();
+   addObject( mBrowseButton );
 
-      // Position
-      mBrowseButton->resize( browseRect.point, browseRect.extent );
-   }
+   // Position
+   mBrowseButton->resize( browseRect.point, browseRect.extent );
 
    return retCtrl;
 }
@@ -1084,10 +1050,6 @@ GuiControl* GuiInspectorTypeColor::constructEditControl()
 {
    GuiControl* retCtrl = new GuiTextEditCtrl();
 
-   // If we couldn't construct the control, bail!
-   if( retCtrl == NULL )
-      return retCtrl;
-
    // Let's make it look pretty.
    retCtrl->setDataField( StringTable->insert("profile"), NULL, "GuiInspectorTextEditProfile" );
 
@@ -1101,46 +1063,42 @@ GuiControl* GuiInspectorTypeColor::constructEditControl()
 
    mBrowseButton = new GuiSwatchButtonCtrl();
 
-   if ( mBrowseButton != NULL )
-   {
-      RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
-      mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiInspectorSwatchButtonProfile" );
-      mBrowseButton->registerObject();
-      addObject( mBrowseButton );
+   RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
+   mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiInspectorSwatchButtonProfile" );
+   mBrowseButton->registerObject();
+   addObject( mBrowseButton );
 		
-		char szColor[512];
-      if( _getColorConversionFunction() )
-         dSprintf( szColor, 512, "%s( %d.color )", _getColorConversionFunction(), mBrowseButton->getId() );
-      else
-         dSprintf( szColor, 512, "%d.color", mBrowseButton->getId() );
+   char szColor[2048];
+   if( _getColorConversionFunction() )
+      dSprintf( szColor, 512, "%s( %d.color )", _getColorConversionFunction(), mBrowseButton->getId() );
+   else
+      dSprintf( szColor, 512, "%d.color", mBrowseButton->getId() );
          
-      // If the inspector supports the alternate undo recording path,
-      // use this here.
+   // If the inspector supports the alternate undo recording path,
+   // use this here.
 
-		char szBuffer[2048];
-      GuiInspector* inspector = getInspector();
-      if( inspector->isMethod( "onInspectorPreFieldModification" ) )
-      {
-         dSprintf( szBuffer, sizeof( szBuffer ),
-            "%d.onInspectorPreFieldModification(\"%s\",\"%s\"); %s(%s, \"%d.onInspectorPostFieldModification(); %d.applyWithoutUndo\", %d.getRoot(), \"%d.applyWithoutUndo\", \"%d.onInspectorDiscardFieldModification(); %%unused=\");",
-            inspector->getId(), getRawFieldName(), getArrayIndex(),
-            mColorFunction, szColor, inspector->getId(), getId(),
-            getId(),
-            getId(),
-            inspector->getId()
-         );
-      }
-      else
-         dSprintf( szBuffer, sizeof( szBuffer ),
-            "%s(%s, \"%d.apply\", %d.getRoot());",
-            mColorFunction, szColor, getId(), getId() );
-		
-		mBrowseButton->setConsoleCommand( szBuffer );
-      mBrowseButton->setUseMouseEvents( true ); // Allow drag&drop.
-
-      // Position
-      mBrowseButton->resize( browseRect.point, browseRect.extent );
+   GuiInspector* inspector = getInspector();
+   if( inspector->isMethod( "onInspectorPreFieldModification" ) )
+   {
+      dSprintf( szBuffer, sizeof( szBuffer ),
+         "%d.onInspectorPreFieldModification(\"%s\",\"%s\"); %s(%s, \"%d.onInspectorPostFieldModification(); %d.applyWithoutUndo\", %d.getRoot(), \"%d.applyWithoutUndo\", \"%d.onInspectorDiscardFieldModification(); %%unused=\");",
+         inspector->getId(), getRawFieldName(), getArrayIndex(),
+         mColorFunction, szColor, inspector->getId(), getId(),
+         getId(),
+         getId(),
+         inspector->getId()
+      );
    }
+   else
+      dSprintf( szBuffer, sizeof( szBuffer ),
+         "%s(%s, \"%d.apply\", %d.getRoot());",
+         mColorFunction, szColor, getId(), getId() );
+		
+	mBrowseButton->setConsoleCommand( szBuffer );
+   mBrowseButton->setUseMouseEvents( true ); // Allow drag&drop.
+
+   // Position
+   mBrowseButton->resize( browseRect.point, browseRect.extent );
 
    return retCtrl;
 }
@@ -1276,10 +1234,6 @@ void GuiInspectorTypeS32::consoleInit()
 GuiControl* GuiInspectorTypeS32::constructEditControl()
 {
    GuiControl* retCtrl = new GuiTextEditSliderCtrl();
-
-   // If we couldn't construct the control, bail!
-   if( retCtrl == NULL )
-      return retCtrl;
 
    retCtrl->setDataField( StringTable->insert("profile"), NULL, "GuiInspectorTextEditProfile" );
 

--- a/Engine/source/gui/editor/guiShapeEdPreview.cpp
+++ b/Engine/source/gui/editor/guiShapeEdPreview.cpp
@@ -514,8 +514,6 @@ bool GuiShapeEdPreview::mountShape(const char* modelName, const char* nodeName, 
       return false;
 
    TSShapeInstance* tsi = new TSShapeInstance( model, true );
-   if ( !tsi )
-      return false;
 
    if ( slot == -1 )
    {

--- a/Engine/source/gui/editor/inspector/group.cpp
+++ b/Engine/source/gui/editor/inspector/group.cpp
@@ -167,12 +167,10 @@ GuiInspectorField* GuiInspectorGroup::constructField( S32 fieldType )
 
 
       GuiInspectorDatablockField *dbFieldClass = new GuiInspectorDatablockField( typeClassName );
-      if( dbFieldClass != NULL )
-      {
-         // return our new datablock field with correct datablock type enumeration info
-         return dbFieldClass;
-      }
-   }
+
+      // return our new datablock field with correct datablock type enumeration info
+      return dbFieldClass;
+}
 
    // Nope, not a datablock. So maybe it has a valid inspector field override we can use?
    if(!cbt->getInspectorFieldType())

--- a/Engine/source/gui/editor/inspector/variableInspector.cpp
+++ b/Engine/source/gui/editor/inspector/variableInspector.cpp
@@ -52,13 +52,10 @@ void GuiVariableInspector::loadVars( String searchStr )
    group->setCaption( "Global Variables" );
    group->mSearchString = searchStr;
 
-   if( group != NULL )
-   {
-      group->registerObject();
-      mGroups.push_back( group );
-      addObject( group );
-   }   
-
+   group->registerObject();
+   mGroups.push_back( group );
+   addObject( group );
+ 
    //group->inspectGroup();
 }
 

--- a/Engine/source/gui/worldEditor/guiMissionArea.cpp
+++ b/Engine/source/gui/worldEditor/guiMissionArea.cpp
@@ -357,9 +357,6 @@ GBitmap * GuiMissionAreaCtrl::createTerrainBitmap()
 
    GBitmap * bitmap = new GBitmap(mTerrainBlock->getBlockSize(), mTerrainBlock->getBlockSize(), false, GFXFormatR8G8B8 );
 
-   if(!bitmap)
-      return NULL;
-
    // get the min/max
    F32 min, max;
    mTerrainBlock->getMinMaxHeight(&min, &max);

--- a/Engine/source/i18n/lang.cpp
+++ b/Engine/source/i18n/lang.cpp
@@ -250,18 +250,16 @@ S32 LangTable::addLanguage(LangFile *lang, const UTF8 *name /* = NULL */)
 S32 LangTable::addLanguage(const UTF8 *filename, const UTF8 *name /* = NULL */)
 {
 	LangFile * lang = new LangFile(name);
-	if(lang != NULL)
+
+   if(Torque::FS::IsFile(filename))
 	{
-      if(Torque::FS::IsFile(filename))
-		{
-			lang->setLangFile(filename);
+		lang->setLangFile(filename);
 			
-      	S32 ret = addLanguage(lang);
-			if(ret >= 0)
-				return ret;
-		}
-		delete lang;
+      S32 ret = addLanguage(lang);
+		if(ret >= 0)
+			return ret;
 	}
+	delete lang;
 
 	return -1;
 }

--- a/Engine/source/navigation/navMesh.cpp
+++ b/Engine/source/navigation/navMesh.cpp
@@ -865,11 +865,7 @@ unsigned char *NavMesh::buildTileData(const Tile &tile, TileData &data, U32 &dat
    }
 
    unsigned char *areas = new unsigned char[data.geom.getTriCount()];
-   if(!areas)
-   {
-      Con::errorf("Out of memory (area flags) for NavMesh %s", getIdString());
-      return NULL;
-   }
+
    dMemset(areas, 0, data.geom.getTriCount() * sizeof(unsigned char));
 
    // Mark walkable triangles with the appropriate area flags, and rasterize.

--- a/Engine/source/navigation/recastPolyList.cpp
+++ b/Engine/source/navigation/recastPolyList.cpp
@@ -72,8 +72,7 @@ U32 RecastPolyList::addPoint(const Point3F &p)
       else vertcap *= 2;
       // Allocate new vertex storage.
       F32 *newverts = new F32[vertcap*3];
-      if(!newverts)
-         return 0;
+
       dMemcpy(newverts, verts, nverts*3 * sizeof(F32));
       dFree(verts);
       verts = newverts;
@@ -106,8 +105,7 @@ void RecastPolyList::begin(BaseMatInstance *material, U32 surfaceKey)
       else tricap *= 2;
       // Allocate new vertex storage.
       S32 *newtris = new S32[tricap*3];
-      if(!newtris)
-         return;
+
       dMemcpy(newtris, tris, ntris*3 * sizeof(S32));
       dFree(tris);
       tris = newtris;

--- a/Engine/source/sfx/null/sfxNullDevice.cpp
+++ b/Engine/source/sfx/null/sfxNullDevice.cpp
@@ -60,8 +60,6 @@ SFXVoice* SFXNullDevice::createVoice( bool is3D, SFXBuffer *buffer )
    AssertFatal( nullBuffer, "SFXNullDevice::createVoice() - Got bad buffer!" );
 
    SFXNullVoice* voice = new SFXNullVoice( nullBuffer );
-   if ( !voice )
-      return NULL;
 
    _addVoice( voice );
 	return voice;


### PR DESCRIPTION
Issue found with PVS-Studio:

Many instances where we would create a object via a new call, and then check that it was non-null.

This is redundant, as if we ever were in a situation where new failed, we'd be crashing left and right already, so the additional check is wasted processing.