### PR TITLE
overrides the default CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 2.8.12)
 
 set(TORQUE_APP_NAME "" CACHE STRING "the app name")
 
+set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/temp" CACHE PATH "default install path" FORCE )
+
 if("${TORQUE_APP_NAME}" STREQUAL "")
 	message(FATAL_ERROR "Please set TORQUE_APP_NAME first")
 endif()


### PR DESCRIPTION
it was causing sdl2 INSTALL to attempt to output to  C:/Program Files (x86)/<projectName>/lib windows side, and  /usr/local/lib on linux