### PR TITLE
Stop precipitation from processing ticks when it's hidden

### DIFF
--- a/Engine/source/T3D/fx/precipitation.cpp
+++ b/Engine/source/T3D/fx/precipitation.cpp
@@ -1293,7 +1293,7 @@ void Precipitation::interpolateTick(F32 delta)
 void Precipitation::processTick(const Move *)
 {
    //nothing to do on the server
-   if (isServerObject() || mDataBlock == NULL)
+   if (isServerObject() || mDataBlock == NULL || isHidden())
       return;
 
    const U32 currTime = Platform::getVirtualMilliseconds();


### PR DESCRIPTION
This fixes the crash in #1044. The cause was the precipitation calling `getContainer()->castRay` after having been hidden (i.e. the container was NULL).