### PR TITLE
Local variables shadowing other locals

### DIFF
--- a/Engine/source/T3D/accumulationVolume.cpp
+++ b/Engine/source/T3D/accumulationVolume.cpp
@@ -169,7 +169,7 @@ void AccumulationVolume::buildSilhouette( const SceneCameraState& cameraState, V
    // depending on whether we project orthogonally or in perspective.
 
    TempAlloc< U32 > indices( mPolyhedron.getNumPoints() );
-   U32 numPoints;
+   U32 numSilhouettePoints;
 
    if( cameraState.getFrustum().isOrtho() )
    {
@@ -181,7 +181,7 @@ void AccumulationVolume::buildSilhouette( const SceneCameraState& cameraState, V
       // And extract the silhouette.
 
       SilhouetteExtractorOrtho< PolyhedronType > extractor( mPolyhedron );
-      numPoints = extractor.extractSilhouette( osViewDir, indices, indices.size );
+      numSilhouettePoints = extractor.extractSilhouette( osViewDir, indices, indices.size );
    }
    else
    {
@@ -194,7 +194,7 @@ void AccumulationVolume::buildSilhouette( const SceneCameraState& cameraState, V
 
       // Do a perspective-correct silhouette extraction.
 
-      numPoints = mSilhouetteExtractor.extractSilhouette(
+      numSilhouettePoints = mSilhouetteExtractor.extractSilhouette(
          camView,
          indices, indices.size );
    }
@@ -220,8 +220,8 @@ void AccumulationVolume::buildSilhouette( const SceneCameraState& cameraState, V
 
    // Now store the points.
 
-   outPoints.setSize( numPoints );
-   for( U32 i = 0; i < numPoints; ++ i )
+   outPoints.setSize( numSilhouettePoints );
+   for( U32 i = 0; i < numSilhouettePoints; ++ i )
       outPoints[ i ] = mWSPoints[ indices[ i ] ];
 }
 

--- a/Engine/source/T3D/decal/decalManager.cpp
+++ b/Engine/source/T3D/decal/decalManager.cpp
@@ -1297,21 +1297,21 @@ void DecalManager::prepRenderImage( SceneRenderState* state )
 
       for ( U32 j = currentBatch.startDecal; j < lastDecal; j++ )
       {
-         DecalInstance *dinst = mDecalQueue[j];
+         DecalInstance *inst = mDecalQueue[j];
 
-         for ( U32 k = 0; k < dinst->mIndxCount; k++ )
+         for ( U32 k = 0; k < inst->mIndxCount; k++ )
          {
-            *( pbPtr + ioffset + k ) = dinst->mIndices[k] + voffset;            
+            *( pbPtr + ioffset + k ) = inst->mIndices[k] + voffset;            
          }
 
-         ioffset += dinst->mIndxCount;
+         ioffset += inst->mIndxCount;
 
-         dMemcpy( vpPtr + voffset, dinst->mVerts, sizeof( DecalVertex ) * dinst->mVertCount );
-         voffset += dinst->mVertCount;
+         dMemcpy( vpPtr + voffset, inst->mVerts, sizeof( DecalVertex ) * inst->mVertCount );
+         voffset += inst->mVertCount;
 
          // Ugly hack for ProjectedShadow!
-         if ( (dinst->mFlags & CustomDecal) && dinst->mCustomTex != NULL )
-            customTex = *dinst->mCustomTex;
+         if ( (inst->mFlags & CustomDecal) && inst->mCustomTex != NULL )
+            customTex = *inst->mCustomTex;
       }
 
       AssertFatal( ioffset == currentBatch.iCount, "bad" );

--- a/Engine/source/T3D/fx/groundCover.cpp
+++ b/Engine/source/T3D/fx/groundCover.cpp
@@ -228,8 +228,6 @@ void GroundCoverCell::_rebuildVB()
 
       // Fill this puppy!
       GCVertex* vertPtr = vb.lock( 0, verts );
-      
-      GFXVertexColor color;
 
       Vector<Placement>::const_iterator last = iter + bb;
       for ( ; iter != last; iter++ )
@@ -1184,9 +1182,9 @@ GroundCoverCell* GroundCover::_generateCell( const Point2I& index,
             terrainBlock = dynamic_cast< TerrainBlock* >( terrainBlocks.first() );
          else
          {
-            for ( U32 i = 0; i < terrainBlocks.size(); i++ )
+            for ( U32 j = 0; j < terrainBlocks.size(); j++ )
             {
-               TerrainBlock *terrain = dynamic_cast< TerrainBlock* >( terrainBlocks[ i ] );
+               TerrainBlock *terrain = dynamic_cast< TerrainBlock* >( terrainBlocks[ j ] );
                if( !terrain )
                   continue;
 

--- a/Engine/source/T3D/fx/lightning.cpp
+++ b/Engine/source/T3D/fx/lightning.cpp
@@ -214,10 +214,10 @@ void LightningStrikeEvent::unpack(NetConnection* con, BitStream* stream)
       // target id
       S32 mTargetID    = stream->readRangedU32(0, NetConnection::MaxGhostCount);
 
-      NetObject* pObject = con->resolveGhost(mTargetID);
-      if( pObject != NULL )
+      NetObject* pTarget = con->resolveGhost(mTargetID);
+      if( pTarget != NULL )
       {
-         mTarget = dynamic_cast<SceneObject*>(pObject);
+         mTarget = dynamic_cast<SceneObject*>(pTarget);
       }
       if( bool(mTarget) == false )
       {

--- a/Engine/source/T3D/gameBase/gameBase.cpp
+++ b/Engine/source/T3D/gameBase/gameBase.cpp
@@ -415,9 +415,9 @@ F32 GameBase::getUpdatePriority(CameraScopeQuery *camInfo, U32 updateMask, S32 u
       // Projectiles are more interesting if they
       // are heading for us.
       wInterest = 0.30f;
-      F32 dot = -mDot(pos,getVelocity());
-      if (dot > 0.0f)
-         wInterest += 0.20 * dot;
+      F32 vdot = -mDot(pos,getVelocity());
+      if (vdot > 0.0f)
+         wInterest += 0.20 * vdot;
    }
    else
    {

--- a/Engine/source/T3D/occlusionVolume.cpp
+++ b/Engine/source/T3D/occlusionVolume.cpp
@@ -132,7 +132,7 @@ void OcclusionVolume::buildSilhouette( const SceneCameraState& cameraState, Vect
    // depending on whether we project orthogonally or in perspective.
 
    TempAlloc< U32 > indices( mPolyhedron.getNumPoints() );
-   U32 numPoints;
+   U32 numSilhouettePoints;
 
    if( cameraState.getFrustum().isOrtho() )
    {
@@ -144,7 +144,7 @@ void OcclusionVolume::buildSilhouette( const SceneCameraState& cameraState, Vect
       // And extract the silhouette.
 
       SilhouetteExtractorOrtho< PolyhedronType > extractor( mPolyhedron );
-      numPoints = extractor.extractSilhouette( osViewDir, indices, indices.size );
+      numSilhouettePoints = extractor.extractSilhouette( osViewDir, indices, indices.size );
    }
    else
    {
@@ -157,7 +157,7 @@ void OcclusionVolume::buildSilhouette( const SceneCameraState& cameraState, Vect
 
       // Do a perspective-correct silhouette extraction.
 
-      numPoints = mSilhouetteExtractor.extractSilhouette(
+      numSilhouettePoints = mSilhouetteExtractor.extractSilhouette(
          camView,
          indices, indices.size );
    }
@@ -183,7 +183,7 @@ void OcclusionVolume::buildSilhouette( const SceneCameraState& cameraState, Vect
 
    // Now store the points.
 
-   outPoints.setSize( numPoints );
-   for( U32 i = 0; i < numPoints; ++ i )
+   outPoints.setSize( numSilhouettePoints );
+   for( U32 i = 0; i < numSilhouettePoints; ++ i )
       outPoints[ i ] = mWSPoints[ indices[ i ] ];
 }

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -2674,8 +2674,7 @@ void Player::updateMove(const Move* move)
             delta.headVec[i] += M_2PI_F;
       }
    }
-   MatrixF zRot;
-   zRot.set(EulerF(0.0f, 0.0f, mRot.z));
+   const MatrixF zRot(EulerF(0.0f, 0.0f, mRot.z));
 
    // Desired move direction & speed
    VectorF moveVec;
@@ -2897,9 +2896,8 @@ void Player::updateMove(const Move* move)
 
       // get the head pitch and add it to the moveVec
       // This more accurate swim vector calc comes from Matt Fairfax
-      MatrixF xRot, zRot;
+      MatrixF xRot;
       xRot.set(EulerF(mHead.x, 0, 0));
-      zRot.set(EulerF(0, 0, mRot.z));
       MatrixF rot;
       rot.mul(zRot, xRot);
       rot.getColumn(0,&moveVec);

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -3170,7 +3170,6 @@ void ShapeBase::unpackUpdate(NetConnection *con, BitStream *stream)
             bool datablockChange = image.dataBlock != imageData;
             if (datablockChange || (image.skinNameHandle != skinDesiredNameHandle))
             {
-               MountedImage& image = mMountedImageList[i];
                image.scriptAnimPrefix = scriptDesiredAnimPrefix;
 
                setImage(   i, imageData, 
@@ -3184,7 +3183,6 @@ void ShapeBase::unpackUpdate(NetConnection *con, BitStream *stream)
             {
                // We don't have a new image, but we do have a new script anim prefix to work with.
                // Notify the image of this change.
-               MountedImage& image = mMountedImageList[i];
                image.scriptAnimPrefix = scriptDesiredAnimPrefix;
                updateAnimThread(i, getImageShapeIndex(image));
             }
@@ -3441,8 +3439,8 @@ void ShapeBaseConvex::getFeatures(const MatrixF& mat, const VectorF& n, ConvexFe
    U32 numVerts = emitString[currPos++];
    for (i = 0; i < numVerts; i++) {
       cf->mVertexList.increment();
-      U32 index = emitString[currPos++];
-      mat.mulP(pAccel->vertexList[index], &cf->mVertexList.last());
+      U32 vid = emitString[currPos++];
+      mat.mulP(pAccel->vertexList[vid], &cf->mVertexList.last());
    }
 
    U32 numEdges = emitString[currPos++];

--- a/Engine/source/T3D/vehicles/flyingVehicle.cpp
+++ b/Engine/source/T3D/vehicles/flyingVehicle.cpp
@@ -713,30 +713,32 @@ void FlyingVehicle::updateEmitter(bool active,F32 dt,ParticleEmitterData *emitte
 {
    if (!emitter)
       return;
-   for (S32 j = idx; j < idx + count; j++)
+   for (S32 i = idx; i < idx + count; i++) {
       if (active) {
-         if (mDataBlock->jetNode[j] != -1) {
-            if (!bool(mJetEmitter[j])) {
-               mJetEmitter[j] = new ParticleEmitter;
-               mJetEmitter[j]->onNewDataBlock(emitter,false);
-               mJetEmitter[j]->registerObject();
+         if (mDataBlock->jetNode[i] != -1) {
+            if (!bool(mJetEmitter[i])) {
+               mJetEmitter[i] = new ParticleEmitter;
+               mJetEmitter[i]->onNewDataBlock(emitter,false);
+               mJetEmitter[i]->registerObject();
             }
             MatrixF mat;
             Point3F pos,axis;
             mat.mul(getRenderTransform(),
-                    mShapeInstance->mNodeTransforms[mDataBlock->jetNode[j]]);
+                    mShapeInstance->mNodeTransforms[mDataBlock->jetNode[i]]);
             mat.getColumn(1,&axis);
             mat.getColumn(3,&pos);
-            mJetEmitter[j]->emitParticles(pos,true,axis,getVelocity(),(U32)(dt * 1000));
+            mJetEmitter[i]->emitParticles(pos,true,axis,getVelocity(),(U32)(dt * 1000));
          }
       }
       else {
-         for (S32 j = idx; j < idx + count; j++)
+         for (S32 j = idx; j < idx + count; j++) {
             if (bool(mJetEmitter[j])) {
                mJetEmitter[j]->deleteWhenEmpty();
                mJetEmitter[j] = 0;
             }
+         }
       }
+   }
 }
 
 

--- a/Engine/source/T3D/vehicles/hoverVehicle.cpp
+++ b/Engine/source/T3D/vehicles/hoverVehicle.cpp
@@ -949,28 +949,30 @@ void HoverVehicle::updateEmitter(bool active,F32 dt,ParticleEmitterData *emitter
 {
    if (!emitter)
       return;
-   for (S32 j = idx; j < idx + count; j++)
+   for (S32 i = idx; i < idx + count; i++) {
       if (active) {
-         if (mDataBlock->jetNode[j] != -1) {
-            if (!bool(mJetEmitter[j])) {
-               mJetEmitter[j] = new ParticleEmitter;
-               mJetEmitter[j]->onNewDataBlock( emitter, false );
-               mJetEmitter[j]->registerObject();
+         if (mDataBlock->jetNode[i] != -1) {
+            if (!bool(mJetEmitter[i])) {
+               mJetEmitter[i] = new ParticleEmitter;
+               mJetEmitter[i]->onNewDataBlock( emitter, false );
+               mJetEmitter[i]->registerObject();
             }
             MatrixF mat;
             Point3F pos,axis;
             mat.mul(getRenderTransform(),
-                    mShapeInstance->mNodeTransforms[mDataBlock->jetNode[j]]);
+                    mShapeInstance->mNodeTransforms[mDataBlock->jetNode[i]]);
             mat.getColumn(1,&axis);
             mat.getColumn(3,&pos);
-            mJetEmitter[j]->emitParticles(pos,true,axis,getVelocity(),(U32)(dt * 1000.0f));
+            mJetEmitter[i]->emitParticles(pos,true,axis,getVelocity(),(U32)(dt * 1000.0f));
          }
       }
       else {
-         for (S32 j = idx; j < idx + count; j++)
+         for (S32 j = idx; j < idx + count; j++) {
             if (bool(mJetEmitter[j])) {
                mJetEmitter[j]->deleteWhenEmpty();
                mJetEmitter[j] = 0;
             }
+         }
       }
+   }
 }

--- a/Engine/source/app/net/serverQuery.cpp
+++ b/Engine/source/app/net/serverQuery.cpp
@@ -1275,7 +1275,7 @@ static void processPingsAndQueries( U32 session, bool schedule )
    if ( !gPingList.size() && !waitingForMaster )
    {
       // Start the query phase:
-      for ( U32 j = 0; j < gQueryList.size() && j < gMaxConcurrentQueries; )
+      for ( i = 0; i < gQueryList.size() && i < gMaxConcurrentQueries; )
       {
          Ping &p = gQueryList[i];
          if ( p.time + gPingTimeout < time )
@@ -1284,7 +1284,7 @@ static void processPingsAndQueries( U32 session, bool schedule )
             if ( !si )
             {
                // Server info not found, so remove the query:
-               gQueryList.erase( j );
+               gQueryList.erase( i );
                gServerBrowserDirty = true;
                continue;
             }
@@ -1294,7 +1294,7 @@ static void processPingsAndQueries( U32 session, bool schedule )
             {
                Con::printf( "Query to server %s timed out.", addressString );
                si->status = ServerInfo::Status_TimedOut;
-               gQueryList.erase( j );
+               gQueryList.erase( i );
                gServerBrowserDirty = true;
             }
             else
@@ -1310,11 +1310,11 @@ static void processPingsAndQueries( U32 session, bool schedule )
                   si->status |= ServerInfo::Status_Querying;
                   gServerBrowserDirty = true;
                }
-               j++;
+               i++;
             }
          }
          else
-            j++;
+            i++;
       }
    }
 

--- a/Engine/source/app/net/serverQuery.cpp
+++ b/Engine/source/app/net/serverQuery.cpp
@@ -1275,7 +1275,7 @@ static void processPingsAndQueries( U32 session, bool schedule )
    if ( !gPingList.size() && !waitingForMaster )
    {
       // Start the query phase:
-      for ( U32 i = 0; i < gQueryList.size() && i < gMaxConcurrentQueries; )
+      for ( U32 j = 0; j < gQueryList.size() && j < gMaxConcurrentQueries; )
       {
          Ping &p = gQueryList[i];
          if ( p.time + gPingTimeout < time )
@@ -1284,7 +1284,7 @@ static void processPingsAndQueries( U32 session, bool schedule )
             if ( !si )
             {
                // Server info not found, so remove the query:
-               gQueryList.erase( i );
+               gQueryList.erase( j );
                gServerBrowserDirty = true;
                continue;
             }
@@ -1294,7 +1294,7 @@ static void processPingsAndQueries( U32 session, bool schedule )
             {
                Con::printf( "Query to server %s timed out.", addressString );
                si->status = ServerInfo::Status_TimedOut;
-               gQueryList.erase( i );
+               gQueryList.erase( j );
                gServerBrowserDirty = true;
             }
             else
@@ -1310,11 +1310,11 @@ static void processPingsAndQueries( U32 session, bool schedule )
                   si->status |= ServerInfo::Status_Querying;
                   gServerBrowserDirty = true;
                }
-               i++;
+               j++;
             }
          }
          else
-            i++;
+            j++;
       }
    }
 

--- a/Engine/source/collision/clippedPolyList.cpp
+++ b/Engine/source/collision/clippedPolyList.cpp
@@ -270,10 +270,10 @@ void ClippedPolyList::end()
             iv.mask = 0;
 
             // Test against the remaining planes
-            for (U32 i = p + 1; i < mPlaneList.size(); i++)
-               if (mPlaneList[i].distToPlane(iv.point) > 0) 
+            for (U32 j = p + 1; j < mPlaneList.size(); j++)
+               if (mPlaneList[j].distToPlane(iv.point) > 0) 
                {
-                  iv.mask = 1 << i;
+                  iv.mask = 1 << j;
                   break;
                }
          }

--- a/Engine/source/collision/depthSortList.cpp
+++ b/Engine/source/collision/depthSortList.cpp
@@ -123,7 +123,7 @@ void DepthSortList::setExtents(Poly & poly, PolyExtents & polyExtents)
    polyExtents.zMin = polyExtents.zMax = p.z;
    for (S32 i=poly.vertexStart+1; i<poly.vertexStart+poly.vertexCount; i++)
    {
-      Point3F p = mVertexList[mIndexList[i]].point;
+      p = mVertexList[mIndexList[i]].point;
 
       // x
       if (p.x < polyExtents.xMin)

--- a/Engine/source/collision/earlyOutPolyList.cpp
+++ b/Engine/source/collision/earlyOutPolyList.cpp
@@ -237,9 +237,9 @@ void EarlyOutPolyList::end()
                iv.mask = 0;
 
                // Test against the remaining planes
-               for (U32 i = p + 1; i < mPlaneList.size(); i++)
-                  if (mPlaneList[i].distToPlane(iv.point) > 0) {
-                     iv.mask = 1 << i;
+               for (U32 j = p + 1; j < mPlaneList.size(); j++)
+                  if (mPlaneList[j].distToPlane(iv.point) > 0) {
+                     iv.mask = 1 << j;
                      break;
                   }
             }

--- a/Engine/source/collision/polytope.cpp
+++ b/Engine/source/collision/polytope.cpp
@@ -214,11 +214,11 @@ void Polytope::intersect(SimObject* object,const BSPNode* root)
                   face.vertex = mVertexList.size() - 1;
                else {
                   mEdgeList.increment(2);
-                  Edge& e0 = mEdgeList.last();
+                  e0 = mEdgeList.last();
                   e0.next = frontVolume.edgeList;
                   frontVolume.edgeList = mEdgeList.size() - 1;
 
-                  Edge& e1 = *(&e0 - 1);
+                  e1 = *(&e0 - 1);
                   e1.next = backVolume.edgeList;
                   backVolume.edgeList = frontVolume.edgeList - 1;
 

--- a/Engine/source/console/codeBlock.cpp
+++ b/Engine/source/console/codeBlock.cpp
@@ -392,15 +392,15 @@ bool CodeBlock::read(StringTableEntry fileName, Stream &st)
    if(size)
    {
       globalFloats = new F64[size];
-      for(U32 i = 0; i < size; i++)
-         st.read(&globalFloats[i]);
+      for(U32 j = 0; j < size; j++)
+         st.read(&globalFloats[j]);
    }
    st.read(&size);
    if(size)
    {
       functionFloats = new F64[size];
-      for(U32 i = 0; i < size; i++)
-         st.read(&functionFloats[i]);
+      for(U32 j = 0; j < size; j++)
+         st.read(&functionFloats[j]);
    }
    U32 codeLength;
    st.read(&codeLength);

--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -751,8 +751,8 @@ breakContinue:
                         // script execution.
                         
                         ConsoleValueRef savedArgv[ StringStack::MaxArgs ];
-                        for (int i=0; i<callArgc; i++) {
-                           savedArgv[i] = callArgv[i];
+                        for (int j=0; j<callArgc; j++) {
+                           savedArgv[j] = callArgv[j];
                         }
                         //dMemcpy( savedArgv, callArgv, sizeof( savedArgv[ 0 ] ) * callArgc );
                         
@@ -770,15 +770,15 @@ breakContinue:
                         // --
 
                         //dMemcpy( callArgv, savedArgv, sizeof( callArgv[ 0 ] ) * callArgc );
-                        for (int i=0; i<callArgc; i++) {
-                           callArgv[i] = savedArgv[i];
+                        for (int j=0; j<callArgc; j++) {
+                           callArgv[j] = savedArgv[j];
                         }
                      }
                      else if( dStricmp( redefineBehavior, "renameNew" ) == 0 )
                      {
-                        for( U32 i = 1;; ++ i )
+                        for( U32 j = 1;; ++ j )
                         {
-                           String newName = String::ToString( "%s%i", objectName, i );
+                           String newName = String::ToString( "%s%i", objectName, j );
                            if( !Sim::findObject( newName ) )
                            {
                               objectName = StringTable->insert( newName );

--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -476,7 +476,7 @@ DefineConsoleFunction( strreplace, const char*, ( const char* source, const char
    U32 dstp = 0;
    for(;;)
    {
-      const char *scan = dStrstr(source + scanp, from);
+      scan = dStrstr(source + scanp, from);
       if(!scan)
       {
          dStrcpy(ret + dstp, source + scanp);

--- a/Engine/source/console/engineDoc.cpp
+++ b/Engine/source/console/engineDoc.cpp
@@ -248,13 +248,13 @@ static void dumpFunction(  Stream &stream,
       const char* brief = dStrstr( doc, "@brief" );
       if( !brief )
       {
-         String brief = entry->getBriefDescription( &doc );
+         String briefStr = entry->getBriefDescription( &doc );
          
-         brief.trim();
-         if( !brief.isEmpty() )
+         briefStr.trim();
+         if( !briefStr.isEmpty() )
          {
             stream.writeText( "@brief " );
-            stream.writeText( brief );
+            stream.writeText( briefStr );
             stream.writeText( "\r\n\r\n" );
          }
       }

--- a/Engine/source/console/fieldBrushObject.cpp
+++ b/Engine/source/console/fieldBrushObject.cpp
@@ -449,10 +449,10 @@ void FieldBrushObject::copyFields( SimObject* pSimObject, const char* fieldList 
                 // Yes, so is this field name selected?
 
                 // Iterate fields...
-                for ( U32 fieldIndex = 0; fieldIndex < fields.size(); ++fieldIndex )
+                for ( U32 fieldIndexInner = 0; fieldIndexInner < fields.size(); ++fieldIndexInner)
                 {
                     // Field selected?
-                    if ( staticField.pFieldname == fields[fieldIndex] )
+                    if ( staticField.pFieldname == fields[fieldIndexInner] )
                     {
                         // Yes, so flag as such.
                         fieldSpecified = true;

--- a/Engine/source/console/simFieldDictionary.cpp
+++ b/Engine/source/console/simFieldDictionary.cpp
@@ -246,12 +246,12 @@ void SimFieldDictionary::writeFields(SimObject *obj, Stream &stream, U32 tabStop
       for(Entry *walk = mHashTable[i];walk; walk = walk->next)
       {
          // make sure we haven't written this out yet:
-         U32 i;
-         for(i = 0; i < list.size(); i++)
-            if(list[i].pFieldname == walk->slotName)
+         U32 j;
+         for(j = 0; j < list.size(); j++)
+            if(list[j].pFieldname == walk->slotName)
                break;
 
-         if(i != list.size())
+         if(j != list.size())
             continue;
 
 
@@ -294,12 +294,12 @@ void SimFieldDictionary::printFields(SimObject *obj)
       for(Entry *walk = mHashTable[i];walk; walk = walk->next)
       {
          // make sure we haven't written this out yet:
-         U32 i;
-         for(i = 0; i < list.size(); i++)
-            if(list[i].pFieldname == walk->slotName)
+         U32 j;
+         for(j = 0; j < list.size(); j++)
+            if(list[j].pFieldname == walk->slotName)
                break;
 
-         if(i != list.size())
+         if(j != list.size())
             continue;
 
          flist.push_back(walk);

--- a/Engine/source/core/stringTable.cpp
+++ b/Engine/source/core/stringTable.cpp
@@ -232,7 +232,7 @@ void _StringTable::resize(const U32 _newSize)
    walk = head;
    while(walk) {
       U32 key;
-      Node *temp = walk;
+      temp = walk;
 
       walk = walk->next;
       key = hashString(temp->val);

--- a/Engine/source/core/tSparseArray.h
+++ b/Engine/source/core/tSparseArray.h
@@ -113,8 +113,8 @@ inline void SparseArray<T>::insert(T* pObject, U32 key)
 template <class T>
 inline T* SparseArray<T>::remove(U32 key)
 {
-   U32 remove  = key % mModulus;
-   Node* probe = &mSentryTables[remove];
+   U32 removeK = key % mModulus;
+   Node* probe = &mSentryTables[removeK];
    while (probe->next != NULL) {
       if (probe->next->key == key) {
          Node* remove = probe->next;

--- a/Engine/source/core/volume.cpp
+++ b/Engine/source/core/volume.cpp
@@ -808,7 +808,6 @@ bool MountSystem::isDirectory(const Path& path, FileSystemRef fsRef)
       if (fnRef.isNull())
          return false;
 
-      FileNode::Attributes attr;
       if (fnRef->getAttributes(&attr))
          return attr.flags & FileNode::Directory;
       return false;

--- a/Engine/source/environment/decalRoad.cpp
+++ b/Engine/source/environment/decalRoad.cpp
@@ -1265,7 +1265,7 @@ void DecalRoad::_generateEdges()
    //      
    for ( U32 i = 0; i < mEdges.size(); i++ )
    {
-      RoadEdge *edge = &mEdges[i];
+      edge = &mEdges[i];
       edge->p0 = edge->p1 - edge->rvec * edge->width * 0.5f;
       edge->p2 = edge->p1 + edge->rvec * edge->width * 0.5f;
       _getTerrainHeight( edge->p0 );
@@ -1467,20 +1467,20 @@ void DecalRoad::_captureVerts()
    for ( U32 i = 0; i < clipperList.size(); i++ )
    {   
       ClippedPolyList *clipper = &clipperList[i];
-      RoadEdge &edge = mEdges[i];
-      RoadEdge &nextEdge = mEdges[i+1];      
+      RoadEdge &theEdge = mEdges[i];
+      RoadEdge &theNextEdge = mEdges[i+1];      
 
-      VectorF segFvec = nextEdge.p1 - edge.p1;
+      VectorF segFvec = theNextEdge.p1 - theEdge.p1;
       F32 segLen = segFvec.len();
       segFvec.normalize();
 
       F32 texLen = segLen / mTextureLength;
       texEnd = texStart + texLen;
 
-      BiQuadToSqr quadToSquare(  Point2F( edge.p0.x, edge.p0.y ), 
-                                 Point2F( edge.p2.x, edge.p2.y ), 
-                                 Point2F( nextEdge.p2.x, nextEdge.p2.y ), 
-                                 Point2F( nextEdge.p0.x, nextEdge.p0.y ) );  
+      BiQuadToSqr quadToSquare(  Point2F( theEdge.p0.x, theEdge.p0.y ), 
+                                 Point2F( theEdge.p2.x, theEdge.p2.y ), 
+                                 Point2F( theNextEdge.p2.x, theNextEdge.p2.y ), 
+                                 Point2F( theNextEdge.p0.x, theNextEdge.p0.y ) );  
 
       //
       if ( i % mSegmentsPerBatch == 0 )
@@ -1572,12 +1572,12 @@ void DecalRoad::_captureVerts()
    Box3F box;
    for ( U32 i = 0; i < mBatches.size(); i++ )
    {
-      const RoadBatch &batch = mBatches[i];
+      const RoadBatch &theBatch = mBatches[i];
 
       if ( i == 0 )      
-         box = batch.bounds;               
+         box = theBatch.bounds;               
       else      
-         box.intersect( batch.bounds );               
+         box.intersect( theBatch.bounds );
    }
 
    Point3F pos = getPosition();

--- a/Engine/source/environment/meshRoad.cpp
+++ b/Engine/source/environment/meshRoad.cpp
@@ -1684,32 +1684,32 @@ void MeshRoad::_generateSlices()
    //      
    for ( U32 i = 0; i < mSlices.size(); i++ )
    {
-      MeshRoadSlice *slice = &mSlices[i];
-      slice->p0 = slice->p1 - slice->rvec * slice->width * 0.5f;
-      slice->p2 = slice->p1 + slice->rvec * slice->width * 0.5f;
-      slice->pb0 = slice->p0 - slice->uvec * slice->depth;
-      slice->pb2 = slice->p2 - slice->uvec * slice->depth;
+      MeshRoadSlice *pSlice = &mSlices[i];
+      pSlice->p0 = pSlice->p1 - pSlice->rvec * pSlice->width * 0.5f;
+      pSlice->p2 = pSlice->p1 + pSlice->rvec * pSlice->width * 0.5f;
+      pSlice->pb0 = pSlice->p0 - pSlice->uvec * pSlice->depth;
+      pSlice->pb2 = pSlice->p2 - pSlice->uvec * pSlice->depth;
    }
 
    // Generate the object/world bounds
    Box3F box;
    for ( U32 i = 0; i < mSlices.size(); i++ )
    {
-      const MeshRoadSlice &slice = mSlices[i];
+      const MeshRoadSlice &theSlice = mSlices[i];
 
       if ( i == 0 )
       {
-         box.minExtents = slice.p0;
-         box.maxExtents = slice.p2;
-         box.extend( slice.pb0 );
-         box.extend( slice.pb2 );
+         box.minExtents = theSlice.p0;
+         box.maxExtents = theSlice.p2;
+         box.extend( theSlice.pb0 );
+         box.extend( theSlice.pb2 );
       }
       else
       {
-         box.extend( slice.p0 ); 
-         box.extend( slice.p2 );
-         box.extend( slice.pb0 );
-         box.extend( slice.pb2 );
+         box.extend( theSlice.p0 ); 
+         box.extend( theSlice.p2 );
+         box.extend( theSlice.pb0 );
+         box.extend( theSlice.pb2 );
       }
    }
 

--- a/Engine/source/environment/scatterSky.cpp
+++ b/Engine/source/environment/scatterSky.cpp
@@ -686,13 +686,13 @@ void ScatterSky::prepRenderImage( SceneRenderState *state )
       mMatrixSet->setSceneProjection(GFX->getProjectionMatrix());
       mMatrixSet->setWorld(GFX->getWorldMatrix());
 
-      ObjectRenderInst *ri = renderPass->allocInst<ObjectRenderInst>();
-      ri->renderDelegate.bind( this, &ScatterSky::_renderMoon );
-      ri->type = RenderPassManager::RIT_Sky;
+      ObjectRenderInst *mri = renderPass->allocInst<ObjectRenderInst>();
+      mri->renderDelegate.bind( this, &ScatterSky::_renderMoon );
+      mri->type = RenderPassManager::RIT_Sky;
       // Render after sky objects and before CloudLayer!
-      ri->defaultKey = 5;
-      ri->defaultKey2 = 0;
-      renderPass->addInst(ri);
+      mri->defaultKey = 5;
+      mri->defaultKey2 = 0;
+      renderPass->addInst(mri);
    }
 }
 
@@ -1333,7 +1333,6 @@ void ScatterSky::_getColor( const Point3F &pos, ColorF *outColor )
    for ( U32 i = 0; i < 2; i++ )
    {
       F32 fHeight = v3SamplePoint.len();
-      F32 fDepth = mExp( scaleOverScaleDepth * (mSphereInnerRadius - smViewerHeight) );
       F32 fLightAngle = mDot( mLightDir, v3SamplePoint ) / fHeight;
       F32 fCameraAngle = mDot( v3Ray, v3SamplePoint ) / fHeight;
 

--- a/Engine/source/forest/forestCollision.cpp
+++ b/Engine/source/forest/forestCollision.cpp
@@ -151,8 +151,8 @@ void ForestConvex::getFeatures( const MatrixF &mat, const VectorF &n, ConvexFeat
    for (i = 0; i < numVerts; i++) 
    {
       cf->mVertexList.increment();
-      U32 index = emitString[currPos++];
-      mat.mulP(pAccel->vertexList[index], &cf->mVertexList.last());
+      U32 idx = emitString[currPos++];
+      mat.mulP(pAccel->vertexList[idx], &cf->mVertexList.last());
    }
 
    U32 numEdges = emitString[currPos++];

--- a/Engine/source/forest/forestWindEmitter.cpp
+++ b/Engine/source/forest/forestWindEmitter.cpp
@@ -150,10 +150,10 @@ void ForestWind::processTick()
       mCurrentInterp = 0;
       mCurrentTarget.set( 0, 0 );
    
-      Point2F windDir( mDirection.x, mDirection.y );
-      windDir.normalizeSafe();
+      Point2F myWindDir( mDirection.x, mDirection.y );
+      myWindDir.normalizeSafe();
 
-      mCurrentTarget = finalVec + windDir;
+      mCurrentTarget = finalVec + myWindDir;
    }
    else
    {

--- a/Engine/source/gfx/D3D9/gfxD3D9TextureManager.cpp
+++ b/Engine/source/gfx/D3D9/gfxD3D9TextureManager.cpp
@@ -615,7 +615,7 @@ bool GFXD3D9TextureManager::_loadTexture(GFXTextureObject *aTexture, DDSFile *dd
             U32 srcHeight = dds->getHeight();
             U8* srcBytes = dds->mSurfaces[0]->mMips[i];
             U8* dstBytes = (U8*)lockedRect.pBits;
-            for (U32 i = 0; i<srcHeight; i++)          
+            for (U32 j = 0; j<srcHeight; j++)          
             {
                dMemcpy( dstBytes, srcBytes, srcPitch );
                dstBytes += lockedRect.Pitch;

--- a/Engine/source/gfx/gfxDrawUtil.cpp
+++ b/Engine/source/gfx/gfxDrawUtil.cpp
@@ -1049,9 +1049,9 @@ void GFXDrawUtil::_drawSolidPolyhedron( const GFXStateBlockDesc &desc, const Any
             continue;
       }
 
-      U32 numPoints = poly.extractFace( i, &indices[ idx ], numIndices - idx );
-      numIndicesForPoly[ numPolys ] = numPoints;
-      idx += numPoints;
+      U32 numExtracted = poly.extractFace( i, &indices[ idx ], numIndices - idx );
+      numIndicesForPoly[ numPolys ] = numExtracted;
+      idx += numExtracted;
 
       numPolys ++;
    }

--- a/Engine/source/gui/3d/guiTSControl.cpp
+++ b/Engine/source/gui/3d/guiTSControl.cpp
@@ -618,11 +618,11 @@ void GuiTSCtrl::onRender(Point2I offset, const RectI &updateRect)
             F32 screenBottom = rectHeight * 0.5;
 
             const F32 fillConv = 0.0f;
-            const F32 frustumDepth = gfxFrustum.getNearDist() + 0.012;
-            verts[0].point.set( screenLeft  - fillConv, frustumDepth, screenTop    - fillConv );
-            verts[1].point.set( screenRight - fillConv, frustumDepth, screenTop    - fillConv );
-            verts[2].point.set( screenLeft  - fillConv, frustumDepth, screenBottom - fillConv );
-            verts[3].point.set( screenRight - fillConv, frustumDepth, screenBottom - fillConv );
+            const F32 frustumDepthEx = gfxFrustum.getNearDist() + 0.012;
+            verts[0].point.set( screenLeft  - fillConv, frustumDepthEx, screenTop    - fillConv );
+            verts[1].point.set( screenRight - fillConv, frustumDepthEx, screenTop    - fillConv );
+            verts[2].point.set( screenLeft  - fillConv, frustumDepthEx, screenBottom - fillConv );
+            verts[3].point.set( screenRight - fillConv, frustumDepthEx, screenBottom - fillConv );
 
             verts[0].color = verts[1].color = verts[2].color = verts[3].color = ColorI(255,255,255,255);
 

--- a/Engine/source/gui/containers/guiWindowCtrl.cpp
+++ b/Engine/source/gui/containers/guiWindowCtrl.cpp
@@ -357,12 +357,12 @@ void GuiWindowCtrl::moveToCollapseGroup(GuiWindowCtrl* hitWindow, bool orientati
       }
       else
       {
-         S32 groupVec = hitWindow->mCollapseGroup;
+         S32 group = hitWindow->mCollapseGroup;
          
          if(orientation == 0)
-            parent->mCollapseGroupVec[groupVec].push_front(this);
+            parent->mCollapseGroupVec[group].push_front(this);
          else
-            parent->mCollapseGroupVec[groupVec].push_back(this);
+            parent->mCollapseGroupVec[group].push_back(this);
       }
    }
    

--- a/Engine/source/gui/controls/guiDecoyCtrl.cpp
+++ b/Engine/source/gui/controls/guiDecoyCtrl.cpp
@@ -142,7 +142,6 @@ void GuiDecoyCtrl::onMouseMove(const GuiEvent &event)
    if(mIsDecoy == true)
    {
 	    mVisible = false;
-		GuiControl *parent = getParent();
 		GuiControl *tempControl = parent->findHitControl(localPoint);
 
 		//the decoy control has the responsibility of keeping track of the decoyed controls status

--- a/Engine/source/gui/controls/guiDirectoryFileListCtrl.cpp
+++ b/Engine/source/gui/controls/guiDirectoryFileListCtrl.cpp
@@ -189,7 +189,7 @@ DefineEngineMethod( GuiDirectoryFileListCtrl, getSelectedFiles, const char*, (),
    // Fetch the remaining entries
    for( S32 i = 1; i < ItemVector.size(); i++ )
    {
-      StringTableEntry itemText = object->getItemText( ItemVector[i] );
+      itemText = object->getItemText( ItemVector[i] );
       if( !itemText )
          continue;
 

--- a/Engine/source/gui/controls/guiPopUpCtrl.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrl.cpp
@@ -1028,9 +1028,9 @@ void GuiPopUpMenuCtrl::onRender( Point2I offset, const RectI &updateRect )
       if ( drawbox )
       {
          Point2I coloredboxsize( 15, 10 );
-         RectI r( offset.x + mProfile->mTextOffset.x, offset.y + ( (getHeight() - coloredboxsize.y ) / 2 ), coloredboxsize.x, coloredboxsize.y );
-         drawUtil->drawRectFill( r, boxColor);
-         drawUtil->drawRect( r, ColorI(0,0,0));
+         RectI rect( offset.x + mProfile->mTextOffset.x, offset.y + ( (getHeight() - coloredboxsize.y ) / 2 ), coloredboxsize.x, coloredboxsize.y );
+         drawUtil->drawRectFill( rect, boxColor);
+         drawUtil->drawRect( rect, ColorI(0,0,0));
 
          localStart.x += coloredboxsize.x + mProfile->mTextOffset.x;
       }
@@ -1054,18 +1054,18 @@ void GuiPopUpMenuCtrl::onRender( Point2I offset, const RectI &updateRect )
 
          // Draw the second column to the right
          getColumn( mText, buff, 1, "\t" );
-         S32 txt_w = mProfile->mFont->getStrWidth( buff );
+         S32 txtW = mProfile->mFont->getStrWidth( buff );
          if ( mProfile->getChildrenProfile() && mProfile->mBitmapArrayRects.size() )
          {
             // We're making use of a bitmap border, so take into account the
             // right cap of the border.
             RectI* bitmapBounds = mProfile->mBitmapArrayRects.address();
-            Point2I textpos = localToGlobalCoord( Point2I( getWidth() - txt_w - bitmapBounds[2].extent.x, localStart.y ) );
+            Point2I textpos = localToGlobalCoord( Point2I( getWidth() - txtW - bitmapBounds[2].extent.x, localStart.y ) );
             drawUtil->drawText( mProfile->mFont, textpos, buff, mProfile->mFontColors );
 
          } else
          {
-            Point2I textpos = localToGlobalCoord( Point2I( getWidth() - txt_w - 12, localStart.y ) );
+            Point2I textpos = localToGlobalCoord( Point2I( getWidth() - txtW - 12, localStart.y ) );
             drawUtil->drawText( mProfile->mFont, textpos, buff, mProfile->mFontColors );
          }
 

--- a/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
@@ -1210,9 +1210,9 @@ void GuiPopUpMenuCtrlEx::onRender(Point2I offset, const RectI &updateRect)
       if ( drawbox )
       {
          Point2I coloredboxsize( 15, 10 );
-         RectI r( offset.x + mProfile->mTextOffset.x, offset.y + ( (getHeight() - coloredboxsize.y ) / 2 ), coloredboxsize.x, coloredboxsize.y );
-         drawUtil->drawRectFill( r, boxColor);
-         drawUtil->drawRect( r, ColorI(0,0,0));
+         RectI rect( offset.x + mProfile->mTextOffset.x, offset.y + ( (getHeight() - coloredboxsize.y ) / 2 ), coloredboxsize.x, coloredboxsize.y );
+         drawUtil->drawRectFill( rect, boxColor);
+         drawUtil->drawRect( rect, ColorI(0,0,0));
 
          localStart.x += coloredboxsize.x + mProfile->mTextOffset.x;
       }
@@ -1236,18 +1236,18 @@ void GuiPopUpMenuCtrlEx::onRender(Point2I offset, const RectI &updateRect)
 
          // Draw the second column to the right
          getColumn( mText, buff, 1, "\t" );
-         S32 txt_w = mProfile->mFont->getStrWidth( buff );
+         S32 txtW = mProfile->mFont->getStrWidth( buff );
          if ( mProfile->getChildrenProfile() && mProfile->mBitmapArrayRects.size() )
          {
             // We're making use of a bitmap border, so take into account the
             // right cap of the border.
             RectI* bitmapBounds = mProfile->mBitmapArrayRects.address();
-            Point2I textpos = localToGlobalCoord( Point2I( getWidth() - txt_w - bitmapBounds[2].extent.x, localStart.y ) );
+            Point2I textpos = localToGlobalCoord( Point2I( getWidth() - txtW - bitmapBounds[2].extent.x, localStart.y ) );
             drawUtil->drawText( mProfile->mFont, textpos, buff, mProfile->mFontColors );
 
          } else
          {
-            Point2I textpos = localToGlobalCoord( Point2I( getWidth() - txt_w - 12, localStart.y ) );
+            Point2I textpos = localToGlobalCoord( Point2I( getWidth() - txtW - 12, localStart.y ) );
             drawUtil->drawText( mProfile->mFont, textpos, buff, mProfile->mFontColors );
          }
 

--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -3035,7 +3035,7 @@ void GuiTreeViewCtrl::onMouseUp(const GuiEvent &event)
    {
       Parent::onMouseMove( event );
          
-      BitSet32 hitFlags = 0;
+      hitFlags = 0;
       if( !_hitTest( event.mousePoint, newItem2, hitFlags ) )
       {
          if( !mShowRoot )
@@ -3113,7 +3113,7 @@ void GuiTreeViewCtrl::onMouseUp(const GuiEvent &event)
       for (S32 i = 0; i <mSelectedItems.size();i++) 
       {
          newItem = newItem2;
-         Item * item = mSelectedItems[i];
+         item = mSelectedItems[i];
 
          if (mDebug) Con::printf("----------------------------");
       
@@ -4222,9 +4222,9 @@ bool GuiTreeViewCtrl::renderTooltip( const Point2I &hoverPos, const Point2I& cur
 
             FrameAllocatorMarker txtAlloc;
             U32 bufLen = item->getDisplayTextLength() + 1;
-            char *buf = (char*)txtAlloc.alloc(bufLen);
-            item->getDisplayText(bufLen, buf);
-            textExt.x = mProfile->mFont->getStrWidth(buf);
+            char *buff = (char*)txtAlloc.alloc(bufLen);
+            item->getDisplayText(bufLen, buff);
+            textExt.x = mProfile->mFont->getStrWidth(buff);
             textExt.y = mProfile->mFont->getHeight();
 
             if( pScrollParent->isRectCompletelyVisible(RectI(textStart, textExt)) )

--- a/Engine/source/gui/core/guiCanvas.cpp
+++ b/Engine/source/gui/core/guiCanvas.cpp
@@ -1530,7 +1530,7 @@ void GuiCanvas::popDialogControl(GuiControl *gui)
 
    if (size() > 0)
    {
-      GuiControl *ctrl = static_cast<GuiControl *>(last());
+      ctrl = static_cast<GuiControl *>(last());
       if( ctrl->getFirstResponder() )
          ctrl->getFirstResponder()->setFirstResponder();
    }
@@ -1547,7 +1547,7 @@ void GuiCanvas::popDialogControl(GuiControl *gui)
 
    if (size() > 0)
    {
-      GuiControl *ctrl = static_cast<GuiControl*>(last());
+      ctrl = static_cast<GuiControl*>(last());
       ctrl->buildAcceleratorMap();
    }
    refreshMouseControl();

--- a/Engine/source/gui/editor/guiEditCtrl.cpp
+++ b/Engine/source/gui/editor/guiEditCtrl.cpp
@@ -490,10 +490,10 @@ void GuiEditCtrl::onMouseDragged( const GuiEvent &event )
       return;
    }
 
-   Point2I mousePoint = globalToLocalCoord( event.mousePoint );
+   Point2I localMousePoint = globalToLocalCoord( event.mousePoint );
 
    //find the control we clicked
-   GuiControl *ctrl = mContentControl->findHitControl( mousePoint, getCurrentAddSet()->mLayer );
+   GuiControl *ctrl = mContentControl->findHitControl( localMousePoint, getCurrentAddSet()->mLayer );
 
    bool handledEvent = ctrl->onMouseDraggedEditor( event, localToGlobalCoord( Point2I(0,0) ) );
    if( handledEvent == true )
@@ -511,7 +511,7 @@ void GuiEditCtrl::onMouseDragged( const GuiEvent &event )
       // If we haven't yet crossed the mouse delta to actually start the
       // clone, check if we have now.
       
-      S32 delta = mAbs( ( mousePoint - mDragBeginPoint ).len() );
+      S32 delta = mAbs( ( localMousePoint - mDragBeginPoint ).len() );
       if( delta >= 4 )
       {
          cloneSelection();
@@ -588,7 +588,7 @@ void GuiEditCtrl::onMouseDragged( const GuiEvent &event )
    }
    else if (mMouseDownMode == MovingSelection && mSelectedControls.size())
    {
-      Point2I delta = mousePoint - mLastMousePos;
+      Point2I delta = localMousePoint - mLastMousePos;
       RectI selectionBounds = getSelectionBounds();
       
       // Apply snaps.
@@ -632,7 +632,7 @@ void GuiEditCtrl::onMouseDragged( const GuiEvent &event )
       // find the current control under the mouse
 
       canHitSelectedControls( false );
-      GuiControl *inCtrl = mContentControl->findHitControl(mousePoint, getCurrentAddSet()->mLayer);
+      GuiControl *inCtrl = mContentControl->findHitControl(localMousePoint, getCurrentAddSet()->mLayer);
       canHitSelectedControls( true );
 
       // find the nearest control up the heirarchy from the control the mouse is in
@@ -651,7 +651,7 @@ void GuiEditCtrl::onMouseDragged( const GuiEvent &event )
       mLastMousePos += delta;
    }
    else
-      mLastMousePos = mousePoint;
+      mLastMousePos = localMousePoint;
 }
 
 //-----------------------------------------------------------------------------
@@ -702,7 +702,7 @@ void GuiEditCtrl::onPreRender()
 void GuiEditCtrl::onRender(Point2I offset, const RectI &updateRect)
 {   
    Point2I ctOffset;
-   Point2I cext;
+   Point2I ctExt;
    bool keyFocused = isFirstResponder();
 
    GFXDrawUtil *drawer = GFX->getDrawUtil();
@@ -712,9 +712,9 @@ void GuiEditCtrl::onRender(Point2I offset, const RectI &updateRect)
       if( getCurrentAddSet() != getContentControl() )
       {
          // draw a white frame inset around the current add set.
-         cext = getCurrentAddSet()->getExtent();
+         ctExt = getCurrentAddSet()->getExtent();
          ctOffset = getCurrentAddSet()->localToGlobalCoord(Point2I(0,0));
-         RectI box(ctOffset.x, ctOffset.y, cext.x, cext.y);
+         RectI box(ctOffset.x, ctOffset.y, ctExt.x, ctExt.y);
 
 			box.inset( -5, -5 );
          drawer->drawRect( box, ColorI( 50, 101, 152, 128 ) );
@@ -732,9 +732,9 @@ void GuiEditCtrl::onRender(Point2I offset, const RectI &updateRect)
       for(i = mSelectedControls.begin(); i != mSelectedControls.end(); i++)
       {
          GuiControl *ctrl = (*i);
-         cext = ctrl->getExtent();
+         ctExt = ctrl->getExtent();
          ctOffset = ctrl->localToGlobalCoord(Point2I(0,0));
-         RectI box(ctOffset.x,ctOffset.y, cext.x, cext.y);
+         RectI box(ctOffset.x,ctOffset.y, ctExt.x, ctExt.y);
          ColorI nutColor = multisel ? ColorI( 255, 255, 255, 100 ) : ColorI( 0, 0, 0, 100 );
          ColorI outlineColor = multisel ? ColorI( 0, 0, 0, 100 ) : ColorI( 255, 255, 255, 100 );
          if(!keyFocused)
@@ -847,8 +847,8 @@ void GuiEditCtrl::onRender(Point2I offset, const RectI &updateRect)
             
             if( mSnapTargets[ axis ] )
             {
-               RectI bounds = mSnapTargets[ axis ]->getGlobalBounds();
-               drawer->drawRect( bounds, ColorF( .5, .5, .5, .5 ) );
+               RectI targetBounds = mSnapTargets[ axis ]->getGlobalBounds();
+               drawer->drawRect( targetBounds, ColorF( .5, .5, .5, .5 ) );
             }
          }
       }

--- a/Engine/source/gui/editor/guiFilterCtrl.cpp
+++ b/Engine/source/gui/editor/guiFilterCtrl.cpp
@@ -218,13 +218,13 @@ void GuiFilterCtrl::onRender(Point2I offset, const RectI &updateRect)
    // draw the knots
    for (U32 k=0; k < mFilter.size(); k++)
    {
-      RectI r;
-      r.point.x = (S32)(((F32)ext.x/(F32)(mFilter.size()-1)*(F32)k));
-      r.point.y = (S32)(ext.y - ((F32)ext.y * mFilter[k]));
-      r.point += pos + Point2I(-2,-2);
-      r.extent = Point2I(5,5);
+      RectI rect;
+      rect.point.x = (S32)(((F32)ext.x/(F32)(mFilter.size()-1)*(F32)k));
+      rect.point.y = (S32)(ext.y - ((F32)ext.y * mFilter[k]));
+      rect.point += pos + Point2I(-2,-2);
+      rect.extent = Point2I(5,5);
 
-      GFX->getDrawUtil()->drawRectFill(r, ColorI(255,0,0));
+      GFX->getDrawUtil()->drawRectFill(rect, ColorI(255,0,0));
    }
 
    renderChildControls(offset, updateRect);

--- a/Engine/source/gui/editor/guiInspector.cpp
+++ b/Engine/source/gui/editor/guiInspector.cpp
@@ -599,10 +599,10 @@ void GuiInspector::refresh()
             
             if( !group && !isGroupFiltered( itr->pGroupname ) )
             {
-               GuiInspectorGroup *group = new GuiInspectorGroup( itr->pGroupname, this );
+               GuiInspectorGroup *newGroup = new GuiInspectorGroup( itr->pGroupname, this );
 
-               group->registerObject();
-               if( !group->getNumFields() )
+               newGroup->registerObject();
+               if( !newGroup->getNumFields() )
                {
                   #ifdef DEBUG_SPEW
                   Platform::outputDebugString( "[GuiInspector] Removing empty group '%s'",
@@ -610,12 +610,12 @@ void GuiInspector::refresh()
                   #endif
                      
                   // The group ended up having no fields.  Remove it.
-                  group->deleteObject();
+                  newGroup->deleteObject();
                }
                else
                {
-                  mGroups.push_back( group );
-                  addObject( group );
+                  mGroups.push_back( newGroup );
+                  addObject( newGroup );
                }
             }
          }

--- a/Engine/source/gui/editor/guiInspectorTypes.cpp
+++ b/Engine/source/gui/editor/guiInspectorTypes.cpp
@@ -978,19 +978,16 @@ GuiControl* GuiInspectorTypeEaseF::constructEditControl()
    retCtrl->setField("Validate", szBuffer );
 
    mBrowseButton = new GuiButtonCtrl();
-   {
-      RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
-      char szBuffer[512];
-      dSprintf( szBuffer, sizeof( szBuffer ), "GetEaseF(%d.getText(), \"%d.apply\", %d.getRoot());", retCtrl->getId(), getId(), getId() );
-      mBrowseButton->setField( "Command", szBuffer );
-      mBrowseButton->setField( "text", "E" );
-      mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiInspectorButtonProfile" );
-      mBrowseButton->registerObject();
-      addObject( mBrowseButton );
+   RectI browseRect( Point2I( ( getLeft() + getWidth()) - 26, getTop() + 2), Point2I(20, getHeight() - 4) );
+   dSprintf( szBuffer, sizeof( szBuffer ), "GetEaseF(%d.getText(), \"%d.apply\", %d.getRoot());", retCtrl->getId(), getId(), getId() );
+   mBrowseButton->setField( "Command", szBuffer );
+   mBrowseButton->setField( "text", "E" );
+   mBrowseButton->setDataField( StringTable->insert("Profile"), NULL, "GuiInspectorButtonProfile" );
+   mBrowseButton->registerObject();
+   addObject( mBrowseButton );
 
-      // Position
-      mBrowseButton->resize( browseRect.point, browseRect.extent );
-   }
+   // Position
+   mBrowseButton->resize( browseRect.point, browseRect.extent );
 
    return retCtrl;
 }

--- a/Engine/source/gui/worldEditor/gizmo.cpp
+++ b/Engine/source/gui/worldEditor/gizmo.cpp
@@ -443,7 +443,7 @@ bool Gizmo::collideAxisGizmo( const Gui3DMouseEvent & event )
    PlaneF clipPlane( mOrigin, toGizmoVec );
 
    mSelectionIdx = -1;
-   Point3F end = camPos + event.vec * smProjectDistance;
+   const Point3F end = camPos + event.vec * smProjectDistance;
 
    if ( mProfile->mode == RotateMode )
    {
@@ -612,7 +612,6 @@ bool Gizmo::collideAxisGizmo( const Gui3DMouseEvent & event )
             Point3F(mOrigin + (p1 + p2) * scale)
          };
 
-         Point3F end = camPos + event.vec * smProjectDistance;
          F32 t = plane.intersect(camPos, end);
          if ( t >= 0 && t <= 1 )
          {

--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -1543,7 +1543,7 @@ void WorldEditor::renderSplinePath(SimPath::Path *path)
 
          // Reset for next pass...
          vIdx = 0;
-         void *lockPtr = vb.lock();
+         lockPtr = vb.lock();
          if(!lockPtr) return;
       }
    }
@@ -3010,7 +3010,7 @@ bool WorldEditor::alignByAxis( S32 axis )
 
    for(S32 i=0; i<mSelected->size(); ++i)
    {
-      SceneObject* object = dynamic_cast< SceneObject* >( ( *mSelected )[ i ] );
+      object = dynamic_cast< SceneObject* >( ( *mSelected )[ i ] );
       if( !object )
          continue;
          

--- a/Engine/source/lighting/advanced/hlsl/advancedLightingFeaturesHLSL.cpp
+++ b/Engine/source/lighting/advanced/hlsl/advancedLightingFeaturesHLSL.cpp
@@ -350,18 +350,18 @@ void DeferredBumpFeatHLSL::processPix( Vector<ShaderComponent*> &componentList,
 
          if ( fd.features.hasFeature( MFT_DetailNormalMap ) )
          {
-            Var *bumpMap = (Var*)LangElement::find( "detailBumpMap" );
-            if ( !bumpMap ) {
-               bumpMap = new Var;
-               bumpMap->setType( "sampler2D" );
-               bumpMap->setName( "detailBumpMap" );
-               bumpMap->uniform = true;
-               bumpMap->sampler = true;
-               bumpMap->constNum = Var::getTexUnitNum();
+            Var *detailBumpMap = (Var*)LangElement::find( "detailBumpMap" );
+            if ( !detailBumpMap ) {
+               detailBumpMap = new Var;
+               detailBumpMap->setType( "sampler2D" );
+               detailBumpMap->setName( "detailBumpMap" );
+               detailBumpMap->uniform = true;
+               detailBumpMap->sampler = true;
+               detailBumpMap->constNum = Var::getTexUnitNum();
             }
 
             texCoord = getInTexCoord( "detCoord", "float2", true, componentList );
-            LangElement *texOp = new GenOp( "tex2D(@, @)", bumpMap, texCoord );
+            LangElement *texOp = new GenOp( "tex2D(@, @)", detailBumpMap, texCoord );
 
             Var *detailBump = new Var;
             detailBump->setName( "detailBump" );

--- a/Engine/source/lighting/shadowMap/pssmLightShadowMap.cpp
+++ b/Engine/source/lighting/shadowMap/pssmLightShadowMap.cpp
@@ -250,7 +250,7 @@ void PSSMLightShadowMap::_render(   RenderPassManager* renderPass,
 
    for (U32 i = 0; i < mNumSplits; i++)
    {
-      GFXTransformSaver saver;
+      GFXTransformSaver saver2;
 
       // Calculate a sub-frustum
       Frustum subFrustum(fullFrustum);

--- a/Engine/source/materials/shaderData.cpp
+++ b/Engine/source/materials/shaderData.cpp
@@ -364,18 +364,18 @@ bool ShaderData::_checkDefinition(GFXShader *shader)
       {              
          if( !shader->findShaderConstHandle( String::ToString("$rtParams%d", pos)) )
          {
-            String error = String::ToString("ShaderData(%s) sampler[%d] used but rtParams%d not used in shader compilation. Possible error", getName(), pos, pos);
-            Con::errorf( error );
-            error = true;
+            String errorStr = String::ToString("ShaderData(%s) sampler[%d] used but rtParams%d not used in shader compilation. Possible error", getName(), pos, pos);
+            Con::errorf( errorStr );
+            errorStr = true;
          }
       }     
 
       if(!find)
       {
-         String error = String::ToString("ShaderData(%s) sampler %s not defined", getName(), samplers[i].c_str());
-         Con::errorf(error );
-         GFXAssertFatal(0, error );
-         error = true;
+         String errorStr = String::ToString("ShaderData(%s) sampler %s not defined", getName(), samplers[i].c_str());
+         Con::errorf(errorStr );
+         GFXAssertFatal(0, errorStr );
+         errorStr = true;
       }
    }  
 

--- a/Engine/source/math/mathUtils.cpp
+++ b/Engine/source/math/mathUtils.cpp
@@ -1063,9 +1063,9 @@ bool mRayQuadCollide(   const Quad &quad,
          - (beta * (alpha_11 - 1.0f)) - 1.0f;
       F32 C = alpha;
       F32 D = (B * B) - (4.0f * A * C);
-      F32 Q = -0.5f * (B + (B < 0.0f ? -1.0f : 1.0f) ) * mSqrt(D);
-      u = Q / A;
-      if ((u < 0.0f) || (u > 1.0f)) u = C / Q;
+      F32 Qs = -0.5f * (B + (B < 0.0f ? -1.0f : 1.0f) ) * mSqrt(D);
+      u = Qs / A;
+      if ((u < 0.0f) || (u > 1.0f)) u = C / Qs;
       v = beta / ((u * (beta_11 - 1.0f)) + 1.0f); 
    }
 

--- a/Engine/source/navigation/guiNavEditorCtrl.cpp
+++ b/Engine/source/navigation/guiNavEditorCtrl.cpp
@@ -523,12 +523,12 @@ void GuiNavEditorCtrl::renderScene(const RectI & updateRect)
       return;
 
    // Grab the camera's transform
-   MatrixF mat;
-   connection->getControlCameraTransform(0, &mat);
+   MatrixF camMat;
+   connection->getControlCameraTransform(0, &camMat);
 
    // Get the camera position
    Point3F camPos;
-   mat.getColumn(3,&camPos);
+   camMat.getColumn(3,&camPos);
 
    if(mMode == mLinkMode)
    {

--- a/Engine/source/navigation/navMesh.cpp
+++ b/Engine/source/navigation/navMesh.cpp
@@ -1182,10 +1182,10 @@ bool NavMesh::createCoverPoints()
          float segs[MAX_SEGS*6];
          int nsegs = 0;
          query->getPolyWallSegments(ref, &f, segs, NULL, &nsegs, MAX_SEGS);
-         for(int j = 0; j < nsegs; ++j)
+         for(int k = 0; k < nsegs; ++k)
          {
-            const float* sa = &segs[j*6];
-            const float* sb = &segs[j*6+3];
+            const float* sa = &segs[k*6];
+            const float* sb = &segs[k*6+3];
             Point3F a = RCtoDTS(sa), b = RCtoDTS(sb);
             F32 len = (b - a).len();
             if(len < mWalkableRadius * 2)
@@ -1194,7 +1194,7 @@ bool NavMesh::createCoverPoints()
             edge.normalize();
             // Number of points to try placing - for now, one at each end.
             U32 pointCount = (len > mWalkableRadius * 4) ? 2 : 1;
-            for(U32 i = 0; i < pointCount; i++)
+            for(U32 l = 0; l < pointCount; l++)
             {
                MatrixF mat;
                Point3F pos;
@@ -1204,10 +1204,10 @@ bool NavMesh::createCoverPoints()
                // Otherwise, stand off from edge ends.
                else
                {
-                  if(i % 2)
-                     pos = a + edge * (i/2+1) * mWalkableRadius;
+                  if(l % 2)
+                     pos = a + edge * (l/2+1) * mWalkableRadius;
                   else
-                     pos = b - edge * (i/2+1) * mWalkableRadius;
+                     pos = b - edge * (l/2+1) * mWalkableRadius;
                }
                CoverPointData data;
                if(testEdgeCover(pos, edge, data))

--- a/Engine/source/platformWin32/winConsole.cpp
+++ b/Engine/source/platformWin32/winConsole.cpp
@@ -200,7 +200,7 @@ void WinConsole::process()
                               if (rgCmds[iCmdIndex][0] != '\0')
                               {
                                  // Obliterate current displayed text
-                                 for (S32 i = outpos = 0; i < inpos; i ++)
+                                 for (S32 j = outpos = 0; j < inpos; j ++)
                                  {
                                     outbuf[outpos ++] = '\b';
                                     outbuf[outpos ++] = ' ';
@@ -230,7 +230,7 @@ void WinConsole::process()
                                   iCmdIndex = 0;
 
                               // Obliterate current displayed text
-                              for (S32 i = outpos = 0; i < inpos; i ++)
+                              for (S32 j = outpos = 0; j < inpos; j ++)
                               {
                                  outbuf[outpos ++] = '\b';
                                  outbuf[outpos ++] = ' ';
@@ -274,8 +274,7 @@ void WinConsole::process()
                         // also 512 chars long so that constraint will also be fine for the input buffer.
                         {
                            // Erase the current line.
-                           U32 i;
-                           for (i = 0; i < inpos; i++) {
+                           for (U32 j = 0; j < inpos; j++) {
                               outbuf[outpos++] = '\b';
                               outbuf[outpos++] = ' ';
                               outbuf[outpos++] = '\b';
@@ -289,8 +288,8 @@ void WinConsole::process()
                               inpos = Con::tabComplete(inbuf, inpos, maxlen, true);
                            }
                            // Copy the input buffer to the output.
-                           for (i = 0; i < inpos; i++) {
-                              outbuf[outpos++] = inbuf[i];
+                           for (U32 j = 0; j < inpos; j++) {
+                              outbuf[outpos++] = inbuf[j];
                            }
                         }
                         break;

--- a/Engine/source/scene/sceneContainer.cpp
+++ b/Engine/source/scene/sceneContainer.cpp
@@ -958,7 +958,7 @@ bool SceneContainer::_castRay( U32 type, const Point3F& start, const Point3F& en
          U32 checkX = x % csmNumBins;
          U32 checkY = y % csmNumBins;
 
-         SceneObjectRef* chain = mBinArray[(checkY * csmNumBins) + checkX].nextInBin;
+         chain = mBinArray[(checkY * csmNumBins) + checkX].nextInBin;
          while (chain)
          {
             SceneObject* ptr = chain->object;
@@ -1050,7 +1050,7 @@ bool SceneContainer::_castRay( U32 type, const Point3F& start, const Point3F& en
             {
                U32 checkY = i % csmNumBins;
 
-               SceneObjectRef* chain = mBinArray[(checkY * csmNumBins) + checkX].nextInBin;
+               chain = mBinArray[(checkY * csmNumBins) + checkX].nextInBin;
                while (chain)
                {
                   SceneObject* ptr = chain->object;

--- a/Engine/source/sfx/sfxMemoryStream.cpp
+++ b/Engine/source/sfx/sfxMemoryStream.cpp
@@ -80,13 +80,13 @@ U32 SFXMemoryStream::read( U8* buffer, U32 length )
          
          if( numBytesLeftInCurrentPacket )
          {
-            const U32 numBytesToCopy = getMin( numBytesLeftInCurrentPacket, numBytesLeftToCopy );
-            dMemcpy( &buffer[ bufferOffset ], &mCurrentPacket->data[ mCurrentPacketOffset ], numBytesToCopy );
+            const U32 numBytes = getMin( numBytesLeftInCurrentPacket, numBytesLeftToCopy );
+            dMemcpy( &buffer[ bufferOffset ], &mCurrentPacket->data[ mCurrentPacketOffset ], numBytes );
             
-            bufferOffset                  += numBytesToCopy;
-            mCurrentPacketOffset          += numBytesToCopy;
-            numBytesLeftInCurrentPacket   -= numBytesToCopy;
-            numBytesLeftToCopy            -= numBytesToCopy;
+            bufferOffset                  += numBytes;
+            mCurrentPacketOffset          += numBytes;
+            numBytesLeftInCurrentPacket   -= numBytes;
+            numBytesLeftToCopy            -= numBytes;
          }
          
          // Discard the packet if there's no data left.

--- a/Engine/source/sfx/sfxSoundscape.cpp
+++ b/Engine/source/sfx/sfxSoundscape.cpp
@@ -174,18 +174,18 @@ void SFXSoundscapeManager::update()
          // Activate SFXStates on the ambience.  For state slots that
          // have changed, deactivate states that we have already activated.
          
-         for( U32 i = 0; i < SFXAmbience::MaxStates; ++ i )
+         for( U32 j = 0; j < SFXAmbience::MaxStates; ++ j )
          {
-            SFXState* state = ambience->getState( i );
-            if( soundscape->mStates[ i ] != state )
+            SFXState* state = ambience->getState( j );
+            if( soundscape->mStates[ j ] != state )
             {
-               if( soundscape->mStates[ i ] )
-                  soundscape->mStates[ i ]->deactivate();
+               if( soundscape->mStates[ j ] )
+                  soundscape->mStates[ j ]->deactivate();
 
                if( state )
                   state->activate();
                   
-               soundscape->mStates[ i ] = state;
+               soundscape->mStates[ j ] = state;
             }
          }
          

--- a/Engine/source/sfx/sfxSystem.cpp
+++ b/Engine/source/sfx/sfxSystem.cpp
@@ -675,9 +675,9 @@ void SFXSystem::_onRemoveSource( SFXSource* source )
 {
    // Check if it was a play once source.
    
-   Vector< SFXSource* >::iterator iter = find( mPlayOnceSources.begin(), mPlayOnceSources.end(), source );
-   if ( iter != mPlayOnceSources.end() )
-      mPlayOnceSources.erase_fast( iter );
+   Vector< SFXSource* >::iterator iSource = find( mPlayOnceSources.begin(), mPlayOnceSources.end(), source );
+   if ( iSource != mPlayOnceSources.end() )
+      mPlayOnceSources.erase_fast( iSource );
 
    // Update the stats.
    
@@ -685,9 +685,9 @@ void SFXSystem::_onRemoveSource( SFXSource* source )
    
    if( dynamic_cast< SFXSound* >( source ) )
    {
-      SFXSoundVector::iterator iter = find( mSounds.begin(), mSounds.end(), static_cast< SFXSound* >( source ) );
-      if( iter != mSounds.end() )
-         mSounds.erase_fast( iter );
+      SFXSoundVector::iterator sound = find( mSounds.begin(), mSounds.end(), static_cast< SFXSound* >( source ) );
+      if( sound != mSounds.end() )
+         mSounds.erase_fast( sound );
          
       mStatNumSounds = mSounds.size();
    }

--- a/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
@@ -1123,7 +1123,7 @@ void DiffuseVertColorFeatureHLSL::processVert(  Vector< ShaderComponent* >& comp
 
       ShaderConnector* connectComp = dynamic_cast< ShaderConnector* >( componentList[ C_CONNECTOR ] );
       AssertFatal( connectComp, "DiffuseVertColorFeatureGLSL::processVert - C_CONNECTOR is not a ShaderConnector" );
-      Var* outColor = connectComp->getElement( RT_COLOR );
+      outColor = connectComp->getElement( RT_COLOR );
       outColor->setName( "vertColor" );
       outColor->setStructName( "OUT" );
       outColor->setType( "float4" );
@@ -1435,7 +1435,7 @@ void VertLitHLSL::processVert(   Vector<ShaderComponent*> &componentList,
 
       // Grab the connector color
       ShaderConnector *connectComp = dynamic_cast<ShaderConnector *>( componentList[C_CONNECTOR] );
-      Var *outColor = connectComp->getElement( RT_COLOR );
+      outColor = connectComp->getElement( RT_COLOR );
       outColor->setName( "vertColor" );
       outColor->setStructName( "OUT" );
       outColor->setType( "float4" );

--- a/Engine/source/sim/netGhost.cpp
+++ b/Engine/source/sim/netGhost.cpp
@@ -428,7 +428,7 @@ void NetConnection::ghostWritePacket(BitStream *bstream, PacketNotify *notify)
    //
    for(i = mGhostZeroUpdateIndex - 1; i >= 0 && !bstream->isFull(); i--)
    {
-      GhostInfo *walk = mGhostArray[i];
+      walk = mGhostArray[i];
 		if(walk->flags & (GhostInfo::KillingGhost | GhostInfo::Ghosting))
 		   continue;
 		

--- a/Engine/source/terrain/terrFile.cpp
+++ b/Engine/source/terrain/terrFile.cpp
@@ -110,11 +110,11 @@ void TerrainFile::_buildGridMap()
    mGridMap.compact();
 
    // Assign memory from the pool to each grid level.
-   TerrainSquare *sq = mGridMapPool.address();
+   TerrainSquare *poolsq = mGridMapPool.address();
    for ( S32 i = mGridLevels; i >= 0; i-- )
    {
-      mGridMap[i] = sq;
-      sq += 1 << ( 2 * ( mGridLevels - i ) );
+      mGridMap[i] = poolsq;
+      poolsq += 1 << ( 2 * ( mGridLevels - i ) );
    }
 
    for( S32 i = mGridLevels; i >= 0; i-- )

--- a/Engine/source/ts/collada/colladaAppMesh.cpp
+++ b/Engine/source/ts/collada/colladaAppMesh.cpp
@@ -147,8 +147,8 @@ private:
          end = start;
 
       // Get the set for this input
-      const domInputLocalOffset* localOffset = daeSafeCast<domInputLocalOffset>(input);
-      domUint newSet = localOffset ? localOffset->getSet() : 0;
+      const domInputLocalOffset* newLocalOffset = daeSafeCast<domInputLocalOffset>(input);
+      domUint newSet = newLocalOffset ? newLocalOffset->getSet() : 0;
 
       // Add the input to the right place in the list (somewhere between start and end)
       for (S32 i = start; i <= end; i++) {
@@ -973,7 +973,7 @@ void ColladaAppMesh::lookupSkinData()
    bool tooManyWeightsWarning = false;
    for (S32 iVert = 0; iVert < vertsPerFrame; iVert++) {
       const domUint* vcount = (domUint*)weights_vcount.getRaw(0);
-      const domInt* vindices = (domInt*)weights_v.getRaw(0);
+      vindices = (domInt*)weights_v.getRaw(0);
       vindices += vindicesOffset[vertTuples[iVert].vertex];
 
       S32 nonZeroWeightCount = 0;

--- a/Engine/source/ts/collada/colladaUtils.cpp
+++ b/Engine/source/ts/collada/colladaUtils.cpp
@@ -263,10 +263,10 @@ void AnimData::parseTargetString(const char* target, S32 fullCount, const char* 
          targetValueCount = 1;
       }
    }
-   else if (const char* p = dStrrchr(target, '.')) {
+   else if (const char* d = dStrrchr(target, '.')) {
       // Check for named elements
       for (S32 iElem = 0; elements[iElem][0] != 0; iElem++) {
-         if (!dStrcmp(p, elements[iElem])) {
+         if (!dStrcmp(d, elements[iElem])) {
             targetValueOffset = iElem;
             targetValueCount = 1;
             break;

--- a/Engine/source/ts/tsAnimate.cpp
+++ b/Engine/source/ts/tsAnimate.cpp
@@ -212,11 +212,11 @@ void TSShapeInstance::animateNodes(S32 ss)
    for (i=0; i<mNodeCallbacks.size(); i++)
    {
       AssertFatal(mNodeCallbacks[i].callback, "No callback method defined");
-      S32 nodeIndex = mNodeCallbacks[i].nodeIndex;
-      if (nodeIndex>=start && nodeIndex<end)
+      S32 callbackIndex = mNodeCallbacks[i].nodeIndex;
+      if (callbackIndex>=start && callbackIndex<end)
       {
-         mNodeCallbacks[i].callback->setNodeTransform(this, nodeIndex, smNodeLocalTransforms[nodeIndex]);
-         smNodeLocalTransformDirty.set(nodeIndex);
+         mNodeCallbacks[i].callback->setNodeTransform(this, callbackIndex, smNodeLocalTransforms[callbackIndex]);
+         smNodeLocalTransformDirty.set(callbackIndex);
       }
    }
 

--- a/Engine/source/ts/tsDump.cpp
+++ b/Engine/source/ts/tsDump.cpp
@@ -197,7 +197,7 @@ void TSShapeInstance::dump(Stream & stream)
    dumpLine("\r\n   Sequences:\r\n");
    for (i = 0; i < mShape->sequences.size(); i++)
    {
-      const char *name = "(none)";
+      name = "(none)";
       if (mShape->sequences[i].nameIndex != -1)
          name = mShape->getName(mShape->sequences[i].nameIndex);
       dumpLine(avar("      %3d: %s%s%s\r\n", i, name,
@@ -212,9 +212,9 @@ void TSShapeInstance::dump(Stream & stream)
       for (i=0; i<(S32)ml->size(); i++)
       {
          U32 flags = ml->getFlags(i);
-         const String& name = ml->getMaterialName(i);
+         const String& nameStr = ml->getMaterialName(i);
          dumpLine(avar(
-            "   material #%i: '%s'%s.", i, name.c_str(),
+            "   material #%i: '%s'%s.", i, nameStr.c_str(),
             flags & (TSMaterialList::S_Wrap|TSMaterialList::T_Wrap) ? "" : " not tiled")
          );
          if (flags & TSMaterialList::Translucent)

--- a/Engine/source/ts/tsLastDetail.cpp
+++ b/Engine/source/ts/tsLastDetail.cpp
@@ -420,12 +420,12 @@ void TSLastDetail::_update()
 
       imposterCap->end();
 
-      Point2I texSize( destBmp.getWidth(mip), destBmp.getHeight(mip) );
+      Point2I mipSize( destBmp.getWidth(mip), destBmp.getHeight(mip) );
 
       // Ok... pack in bitmaps till we run out.
-      for ( S32 y=0; y+currDim <= texSize.y; )
+      for ( S32 y=0; y+currDim <= mipSize.y; )
       {
-         for ( S32 x=0; x+currDim <= texSize.x; )
+         for ( S32 x=0; x+currDim <= mipSize.x; )
          {
             // Copy the next bitmap to the dest texture.
             GBitmap* bmp = bitmaps.first();
@@ -434,7 +434,7 @@ void TSLastDetail::_update()
             delete bmp;
 
             // Copy the next normal to the dest texture.
-            GBitmap* normalmap = normalmaps.first();
+            normalmap = normalmaps.first();
             normalmaps.pop_front();
             destNormal.copyRect( normalmap, RectI( 0, 0, currDim, currDim ), Point2I( x, y ), 0, mip );
             delete normalmap;

--- a/Engine/source/ts/tsShape.cpp
+++ b/Engine/source/ts/tsShape.cpp
@@ -533,7 +533,7 @@ void TSShape::init()
          if (accel != NULL) {
             delete [] accel->vertexList;
             delete [] accel->normalList;
-            for (S32 j = 0; j < accel->numVerts; j++)
+            for (j = 0; j < accel->numVerts; j++)
                delete [] accel->emitStrings[j];
             delete [] accel->emitStrings;
             delete accel;
@@ -992,7 +992,7 @@ void TSShape::assembleShape()
          S32 oldSz = groundTranslations.size();
          groundTranslations.setSize(oldSz+seq.numGroundFrames);
          groundRotations.setSize(oldSz+seq.numGroundFrames);
-         for (S32 j=0;j<seq.numGroundFrames;j++)
+         for (j=0;j<seq.numGroundFrames;j++)
          {
             groundTranslations[j+oldSz] = nodeTranslations[seq.firstGroundFrame+j-numNodes];
             groundRotations[j+oldSz] = nodeRotations[seq.firstGroundFrame+j-numNodes];
@@ -1067,9 +1067,9 @@ void TSShape::assembleShape()
       ptr32 = tsalloc.copyToShape32( numDetails * 7, true );
 
       details.setSize( numDetails );
-      for ( U32 i = 0; i < details.size(); i++, ptr32 += 7 )
+      for ( U32 d = 0; d < details.size(); d++, ptr32 += 7 )
       {
-         Detail *det = &(details[i]);
+         Detail *det = &(details[d]);
 
          // Clear the struct... we don't want to leave 
          // garbage in the parts that are unfilled.
@@ -1097,12 +1097,12 @@ void TSShape::assembleShape()
    // Some DTS exporters (MAX - I'm looking at you!) write garbage into the
    // averageError and maxError values which stops LOD from working correctly.
    // Try to detect and fix it
-   for ( U32 i = 0; i < details.size(); i++ )
+   for ( U32 d = 0; d < details.size(); d++ )
    {
-      if ( ( details[i].averageError == 0 ) || ( details[i].averageError > 10000 ) ||
-           ( details[i].maxError == 0 ) || ( details[i].maxError > 10000 ) )
+      if ( ( details[d].averageError == 0 ) || ( details[d].averageError > 10000 ) ||
+           ( details[d].maxError == 0 ) || ( details[d].maxError > 10000 ) )
       {
-         details[i].averageError = details[i].maxError = -1.0f;
+         details[d].averageError = details[d].maxError = -1.0f;
       }
    }
 
@@ -1396,7 +1396,7 @@ void TSShape::disassembleShape()
    {
       // Legacy details => no explicit autobillboard parameters
       U32 legacyDetailSize32 = 7;   // only store the first 7 4-byte values of each detail
-      for ( S32 i = 0; i < details.size(); i++ )
+      for ( i = 0; i < details.size(); i++ )
          tsalloc.copyToBuffer32( (S32*)&details[i], legacyDetailSize32 );
    }
    tsalloc.setGuard();

--- a/Engine/source/ts/tsShapeConstruct.cpp
+++ b/Engine/source/ts/tsShapeConstruct.cpp
@@ -2187,7 +2187,7 @@ void TSShapeConstructor::ChangeSet::write(TSShape* shape, Stream& stream, const 
          for (U32 j = 1; j < cmd.argc; j++)
          {
             // Use relative paths when possible
-            String str( cmd.argv[j] );
+            str = cmd.argv[j];
             if ( str.startsWith( savePath ) )
                str = str.substr( savePath.length() + 1 );
 

--- a/Engine/source/ts/tsShapeOldRead.cpp
+++ b/Engine/source/ts/tsShapeOldRead.cpp
@@ -647,7 +647,7 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
          nodeUniformScales.increment(newScaleMembership.count() * seq.numKeyframes);
 
       // remap node transforms from temporary arrays
-      for (S32 j = 0; j < nodeMap.size(); j++)
+      for (j = 0; j < nodeMap.size(); j++)
       {
          if (nodeMap[j] < 0)
             continue;
@@ -713,7 +713,7 @@ bool TSShape::importSequences(Stream * s, const String& sequencePath)
    S32 oldSz = triggers.size();
    s->read(&sz);
    triggers.setSize(oldSz+sz);
-   for (S32 i=0; i<sz;i++)
+   for (i=0; i<sz;i++)
    {
       s->read(&triggers[i+oldSz].state);
       s->read(&triggers[i+oldSz].pos);


### PR DESCRIPTION
This causes a lot of warnings in VS. My approach to resolving these has been:
- Can the previous variable be used without being redeclared?
- Can either the shadowing or shadowed variable have a more specific/sensible name?
- Should both variables be renamed?

I don't think I've ever reduced the scope of a variable, though that might have been a viable strategy in some of these cases. I don't anticipate issues - I think I've been fairly careful. But scope is one of those tricky things...
