### PR TITLE
From Dušan Jocić: early out of treeview entries to prevent crashes

### DIFF
--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -4641,6 +4641,8 @@ S32 GuiTreeViewCtrl::findItemByValue(const char *name)
 {
    for (S32 i = 0; i < mItems.size(); i++) 
    {
+      if (!mItems[i])
+         continue;
 	   if( mItems[i]->mState.test( Item::InspectorData ) )
 		   continue;
 	   if (mItems[i] && dStrcmp(mItems[i]->getValue(),name) == 0) 


### PR DESCRIPTION
"when you change some item or remove, it does not resize the array and in that way it create problem with value"