### PR TITLE
From Dušan Jocić: convexDecomp vs2015+ compatibility patch

### DIFF
--- a/Engine/lib/convexDecomp/NvRemoveTjunctions.cpp
+++ b/Engine/lib/convexDecomp/NvRemoveTjunctions.cpp
@@ -60,8 +60,12 @@ NvRemoveTjunctions.cpp : A code snippet to remove tjunctions from a triangle mes
 #include <vector>
 #ifdef __APPLE__
    #include <ext/hash_map>
-#else
+#elif LINUX
    #include <hash_map>
+#elif _MSC_VER < 1500
+   #include <hash_map>
+#elif _MSC_VER > 1800
+   #include <unordered_map>
 #endif
 #include "NvUserMemAlloc.h"
 #include "NvHashMap.h"


### PR DESCRIPTION
(Verified with https://github.com/GarageGames/Torque3D/pull/1376 for sub vs2015)