### PR TITLE
 C4189 warning cleanups

### DIFF
--- a/Engine/source/console/astNodes.cpp
+++ b/Engine/source/console/astNodes.cpp
@@ -258,7 +258,6 @@ void IfStmtNode::propagateSwitchExpr(ExprNode *left, bool string)
 
 U32 IfStmtNode::compileStmt(CodeStream &codeStream, U32 ip)
 {
-   U32 start = ip;
    U32 endifIp, elseIp;
    addBreakLine(codeStream);
    
@@ -340,7 +339,6 @@ U32 LoopStmtNode::compileStmt(CodeStream &codeStream, U32 ip)
    addBreakLine(codeStream);
    codeStream.pushFixScope(true);
    
-   U32 start = ip;
    if(initExpr)
       ip = initExpr->compile(codeStream, ip, TypeReqNone);
 
@@ -1565,8 +1563,6 @@ U32 FunctionDeclStmtNode::compileStmt(CodeStream &codeStream, U32 ip)
    
    CodeBlock::smInFunction = false;
    
-   
-   U32 start = ip;
    codeStream.emit(OP_FUNC_DECL);
    codeStream.emitSTE(fnName);
    codeStream.emitSTE(nameSpace);

--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -435,11 +435,12 @@ static void setFieldComponent( SimObject* object, StringTableEntry field, const 
 
 ConsoleValueRef CodeBlock::exec(U32 ip, const char *functionName, Namespace *thisNamespace, U32 argc, ConsoleValueRef *argv, bool noCalls, StringTableEntry packageName, S32 setFrame)
 {
+/*
 #ifdef TORQUE_DEBUG
    U32 stackStart = STR.mStartStackSize;
    U32 consoleStackStart = CSTK.mStackPos;
 #endif
-
+*/
    //Con::printf("CodeBlock::exec(%s,%u)", functionName ? functionName : "??", ip);
 
    static char traceBuffer[1024];
@@ -2244,12 +2245,12 @@ execFinished:
    }
 
    decRefCount();
-
+/*
 #ifdef TORQUE_DEBUG
    //AssertFatal(!(STR.mStartStackSize > stackStart), "String stack not popped enough in script exec");
    //AssertFatal(!(STR.mStartStackSize < stackStart), "String stack popped too much in script exec");
 #endif
-
+*/
    return returnValue;
 }
 

--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -435,12 +435,12 @@ static void setFieldComponent( SimObject* object, StringTableEntry field, const 
 
 ConsoleValueRef CodeBlock::exec(U32 ip, const char *functionName, Namespace *thisNamespace, U32 argc, ConsoleValueRef *argv, bool noCalls, StringTableEntry packageName, S32 setFrame)
 {
-/*
-#ifdef TORQUE_DEBUG
+
+#ifdef TORQUE_VALIDATE_STACK
    U32 stackStart = STR.mStartStackSize;
    U32 consoleStackStart = CSTK.mStackPos;
 #endif
-*/
+
    //Con::printf("CodeBlock::exec(%s,%u)", functionName ? functionName : "??", ip);
 
    static char traceBuffer[1024];
@@ -2245,12 +2245,12 @@ execFinished:
    }
 
    decRefCount();
-/*
-#ifdef TORQUE_DEBUG
-   //AssertFatal(!(STR.mStartStackSize > stackStart), "String stack not popped enough in script exec");
-   //AssertFatal(!(STR.mStartStackSize < stackStart), "String stack popped too much in script exec");
+
+#ifdef TORQUE_VALIDATE_STACK
+   AssertFatal(!(STR.mStartStackSize > stackStart), "String stack not popped enough in script exec");
+   AssertFatal(!(STR.mStartStackSize < stackStart), "String stack popped too much in script exec");
 #endif
-*/
+
    return returnValue;
 }
 

--- a/Engine/source/gui/3d/guiTSControl.cpp
+++ b/Engine/source/gui/3d/guiTSControl.cpp
@@ -578,14 +578,12 @@ void GuiTSCtrl::onRender(Point2I offset, const RectI &updateRect)
       GFXTextureObject *texObject = mStereoGuiTarget->getTexture(0);
       const FovPort *currentFovPort = GFX->getStereoFovPort();
       const MatrixF *eyeTransforms = GFX->getStereoEyeTransforms();
-      const MatrixF *worldEyeTransforms = GFX->getInverseStereoEyeTransforms();
       const Point3F *eyeOffset = GFX->getStereoEyeOffsets();
 
       for (U32 i=0; i<2; i++)
       {
          GFX->activateStereoTarget(i);
          Frustum gfxFrustum = originalFrustum;
-         const F32 frustumDepth = gfxFrustum.getNearDist();
          MathUtils::makeFovPortFrustum(&gfxFrustum, true, gfxFrustum.getNearDist(), gfxFrustum.getFarDist(), currentFovPort[i], eyeTransforms[i]);
          GFX->setFrustum(gfxFrustum);
 

--- a/Engine/source/gui/3d/guiTSControl.cpp
+++ b/Engine/source/gui/3d/guiTSControl.cpp
@@ -579,11 +579,11 @@ void GuiTSCtrl::onRender(Point2I offset, const RectI &updateRect)
       const FovPort *currentFovPort = GFX->getStereoFovPort();
       const MatrixF *eyeTransforms = GFX->getStereoEyeTransforms();
       const Point3F *eyeOffset = GFX->getStereoEyeOffsets();
+      Frustum gfxFrustum = originalFrustum;
 
       for (U32 i=0; i<2; i++)
       {
          GFX->activateStereoTarget(i);
-         Frustum gfxFrustum = originalFrustum;
          MathUtils::makeFovPortFrustum(&gfxFrustum, true, gfxFrustum.getNearDist(), gfxFrustum.getFarDist(), currentFovPort[i], eyeTransforms[i]);
          GFX->setFrustum(gfxFrustum);
 

--- a/Engine/source/gui/3d/guiTSControl.cpp
+++ b/Engine/source/gui/3d/guiTSControl.cpp
@@ -616,11 +616,11 @@ void GuiTSCtrl::onRender(Point2I offset, const RectI &updateRect)
             F32 screenBottom = rectHeight * 0.5;
 
             const F32 fillConv = 0.0f;
-            const F32 frustumDepth = gfxFrustum.getNearDist() + 0.012;
-            verts[0].point.set( screenLeft  - fillConv, frustumDepth, screenTop    - fillConv );
-            verts[1].point.set( screenRight - fillConv, frustumDepth, screenTop    - fillConv );
-            verts[2].point.set( screenLeft  - fillConv, frustumDepth, screenBottom - fillConv );
-            verts[3].point.set( screenRight - fillConv, frustumDepth, screenBottom - fillConv );
+            const F32 frustumDepthAdjusted = gfxFrustum.getNearDist() + 0.012;
+            verts[0].point.set( screenLeft  - fillConv, frustumDepthAdjusted, screenTop    - fillConv );
+            verts[1].point.set( screenRight - fillConv, frustumDepthAdjusted, screenTop    - fillConv );
+            verts[2].point.set( screenLeft  - fillConv, frustumDepthAdjusted, screenBottom - fillConv );
+            verts[3].point.set( screenRight - fillConv, frustumDepthAdjusted, screenBottom - fillConv );
 
             verts[0].color = verts[1].color = verts[2].color = verts[3].color = ColorI(255,255,255,255);
 

--- a/Engine/source/math/mSphere.cpp
+++ b/Engine/source/math/mSphere.cpp
@@ -77,8 +77,11 @@ bool SphereF::intersectsRay( const Point3F &start, const Point3F &end ) const
    // value for getting the exact
    // intersection point, by interpolating
    // start to end by t.
+
+   /*
    F32 t = 0;
    TORQUE_UNUSED(t);
+   */
 
    // if t1 is less than zero, the object is in the ray's negative direction
    // and consequently the ray misses the sphere

--- a/Engine/source/navigation/guiNavEditorCtrl.cpp
+++ b/Engine/source/navigation/guiNavEditorCtrl.cpp
@@ -308,7 +308,6 @@ void GuiNavEditorCtrl::on3DMouseDown(const Gui3DMouseEvent & event)
    U8 keys = Input::getModifierKeys();
    bool shift = keys & SI_LSHIFT;
    bool ctrl = keys & SI_LCTRL;
-   bool alt = keys & SI_LALT;
 
    if(mMode == mLinkMode && !mMesh.isNull())
    {

--- a/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
+++ b/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
@@ -812,12 +812,10 @@ void TerrainMacroMapFeatGLSL::processPix(   Vector<ShaderComponent*> &componentL
    meta->addStatement( new GenOp( "      @ *= @.y * @.w;\r\n",
                                     detailColor, detailInfo, inDet ) );
 
-   Var *baseColor = (Var*)LangElement::find( "baseColor" );
    Var *outColor = (Var*)LangElement::find( "col" );
 
    meta->addStatement( new GenOp( "      @ = lerp( @, @ + @, @ );\r\n",
                                     outColor, outColor, outColor, detailColor, detailBlend ) );
-   //outColor, outColor, baseColor, detailColor, detailBlend ) );
 
    meta->addStatement( new GenOp( "   }\r\n" ) );
 

--- a/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
+++ b/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
@@ -542,7 +542,6 @@ void TerrainDetailMapFeatHLSL::processPix(   Vector<ShaderComponent*> &component
    meta->addStatement( new GenOp( "      @ *= @.y * @.w;\r\n",
                                     detailColor, detailInfo, inDet ) );
 
-   Var *baseColor = (Var*)LangElement::find( "baseColor" );
    Var *outColor = (Var*)LangElement::find( "col" );
 
    meta->addStatement( new GenOp( "      @ += @ * @;\r\n",

--- a/Engine/source/ts/tsMesh.cpp
+++ b/Engine/source/ts/tsMesh.cpp
@@ -223,8 +223,8 @@ void TSMesh::innerRender( TSMaterialList *materials, const TSRenderState &rdata,
       // We need to have a material.
       if ( draw.matIndex & TSDrawPrimitive::NoMaterial )
          continue;
-/*
-#ifdef TORQUE_DEBUG
+
+#ifdef TORQUE_DEBUG_BREAK_INSPECT
       // for inspection if you happen to be running in a debugger and can't do bit 
       // operations in your head.
       S32 triangles = draw.matIndex & TSDrawPrimitive::Triangles;
@@ -237,8 +237,9 @@ void TSMesh::innerRender( TSMaterialList *materials, const TSRenderState &rdata,
       TORQUE_UNUSED(fan);
       TORQUE_UNUSED(indexed);
       TORQUE_UNUSED(type);
+      //define TORQUE_DEBUG_BREAK_INSPECT, and insert debug break here to inspect the above elements at runtime
 #endif
-*/
+
       const U32 matIndex = draw.matIndex & TSDrawPrimitive::MaterialMask;
       BaseMatInstance *matInst = materials->getMaterialInst( matIndex );
 

--- a/Engine/source/ts/tsMesh.cpp
+++ b/Engine/source/ts/tsMesh.cpp
@@ -223,7 +223,7 @@ void TSMesh::innerRender( TSMaterialList *materials, const TSRenderState &rdata,
       // We need to have a material.
       if ( draw.matIndex & TSDrawPrimitive::NoMaterial )
          continue;
-
+/*
 #ifdef TORQUE_DEBUG
       // for inspection if you happen to be running in a debugger and can't do bit 
       // operations in your head.
@@ -238,7 +238,7 @@ void TSMesh::innerRender( TSMaterialList *materials, const TSRenderState &rdata,
       TORQUE_UNUSED(indexed);
       TORQUE_UNUSED(type);
 #endif
-
+*/
       const U32 matIndex = draw.matIndex & TSDrawPrimitive::MaterialMask;
       BaseMatInstance *matInst = materials->getMaterialInst( matIndex );
 


### PR DESCRIPTION
Addresses roughly half of the C4189 warnings though the following methodologies:

1) truly unused vars removed
2) vars leading to remmed out code for debugging remmed in turn.

left out:
vars in macros.