### PR TITLE
Flips SDL_STATIC on to correct it creating bad symlinks

### DIFF
--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -361,7 +361,11 @@ if(TORQUE_SDL)
     
     #override and hide SDL2 cache variables
     set(SDL_SHARED ON CACHE INTERNAL "" FORCE)
-    set(SDL_STATIC ON CACHE INTERNAL "" FORCE)
+	if(WIN32)
+		set(SDL_STATIC OFF CACHE INTERNAL "" FORCE)
+	else()
+		set(SDL_STATIC ON CACHE INTERNAL "" FORCE)
+	endif()
     add_subdirectory( ${libDir}/sdl ${CMAKE_CURRENT_BINARY_DIR}/sdl2)
 endif()
 

--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -361,7 +361,7 @@ if(TORQUE_SDL)
     
     #override and hide SDL2 cache variables
     set(SDL_SHARED ON CACHE INTERNAL "" FORCE)
-    set(SDL_STATIC OFF CACHE INTERNAL "" FORCE)
+    set(SDL_STATIC ON CACHE INTERNAL "" FORCE)
     add_subdirectory( ${libDir}/sdl ${CMAKE_CURRENT_BINARY_DIR}/sdl2)
 endif()
 


### PR DESCRIPTION
Despite the variable name, it does not, in fact create a static library, it would seem.