### PR TITLE
SDL mouse wheel speed fix.

### DIFF
--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -434,7 +434,7 @@ void PlatformWindowSDL::_triggerMouseLocationNotify(const SDL_Event& evt)
 
 void PlatformWindowSDL::_triggerMouseWheelNotify(const SDL_Event& evt)
 {
-   wheelEvent.trigger(getWindowId(), 0, evt.wheel.x, evt.wheel.y);
+   wheelEvent.trigger(getWindowId(), 0, evt.wheel.x, evt.wheel.y * WHEEL_DELTA);
 }
 
 void PlatformWindowSDL::_triggerMouseButtonNotify(const SDL_Event& event)

--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -434,7 +434,7 @@ void PlatformWindowSDL::_triggerMouseLocationNotify(const SDL_Event& evt)
 
 void PlatformWindowSDL::_triggerMouseWheelNotify(const SDL_Event& evt)
 {
-   wheelEvent.trigger(getWindowId(), 0, evt.wheel.x, evt.wheel.y * WHEEL_DELTA);
+   wheelEvent.trigger(getWindowId(), 0, evt.wheel.x, evt.wheel.y * Con::getIntVariable("$pref::Input::MouseWheelSpeed"));
 }
 
 void PlatformWindowSDL::_triggerMouseButtonNotify(const SDL_Event& event)

--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -434,7 +434,8 @@ void PlatformWindowSDL::_triggerMouseLocationNotify(const SDL_Event& evt)
 
 void PlatformWindowSDL::_triggerMouseWheelNotify(const SDL_Event& evt)
 {
-   wheelEvent.trigger(getWindowId(), 0, evt.wheel.x, evt.wheel.y * Con::getIntVariable("$pref::Input::MouseWheelSpeed", 120));
+   S32 wheelDelta = Con::getIntVariable("$pref::Input::MouseWheelSpeed", 120);
+   wheelEvent.trigger(getWindowId(), 0, evt.wheel.x * wheelDelta, evt.wheel.y * wheelDelta);
 }
 
 void PlatformWindowSDL::_triggerMouseButtonNotify(const SDL_Event& event)

--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -434,7 +434,7 @@ void PlatformWindowSDL::_triggerMouseLocationNotify(const SDL_Event& evt)
 
 void PlatformWindowSDL::_triggerMouseWheelNotify(const SDL_Event& evt)
 {
-   wheelEvent.trigger(getWindowId(), 0, evt.wheel.x, evt.wheel.y * Con::getIntVariable("$pref::Input::MouseWheelSpeed"));
+   wheelEvent.trigger(getWindowId(), 0, evt.wheel.x, evt.wheel.y * Con::getIntVariable("$pref::Input::MouseWheelSpeed", 120));
 }
 
 void PlatformWindowSDL::_triggerMouseButtonNotify(const SDL_Event& event)

--- a/Templates/Empty/game/core/scripts/client/defaults.cs
+++ b/Templates/Empty/game/core/scripts/client/defaults.cs
@@ -41,6 +41,7 @@ $pref::Input::KeyboardEnabled = 1;
 $pref::Input::MouseEnabled = 1;
 $pref::Input::JoystickEnabled = 0;
 $pref::Input::KeyboardTurnSpeed = 0.1;
+$pref::Input::MouseWheelSpeed = 120;
 
 $sceneLighting::cacheSize = 20000;
 $sceneLighting::purgeMethod = "lastCreated";

--- a/Templates/Full/game/core/scripts/client/defaults.cs
+++ b/Templates/Full/game/core/scripts/client/defaults.cs
@@ -41,6 +41,7 @@ $pref::Input::KeyboardEnabled = 1;
 $pref::Input::MouseEnabled = 1;
 $pref::Input::JoystickEnabled = 0;
 $pref::Input::KeyboardTurnSpeed = 0.1;
+$pref::Input::MouseWheelSpeed = 120;
 
 $sceneLighting::cacheSize = 20000;
 $sceneLighting::purgeMethod = "lastCreated";


### PR DESCRIPTION
Default scroll speed wasn't delta-modified, so scroll gui controls were very slow when scrolled via mouse wheel.. This corrects the issue.