### PR TITLE
From @LuisAntonRebollo -stops infinite loop on exit with SDL2+OGL on Win.

### DIFF
--- a/Engine/source/gfx/gl/gfxGLCircularVolatileBuffer.h
+++ b/Engine/source/gfx/gl/gfxGLCircularVolatileBuffer.h
@@ -14,7 +14,9 @@ public:
 
    ~GLFenceRange()
    {
-      AssertFatal( mSync == 0, "");
+      //the order of creation/destruction of static variables is indetermined... depends on detail of the build
+      //looks like for some reason on windows + sdl + opengl the order make invalid / wrong the process TODO: Refactor -LAR
+      //AssertFatal( mSync == 0, "");
    }
 
    void init(U32 start, U32 end)
@@ -87,7 +89,9 @@ public:
 
    ~GLOrderedFenceRangeManager( )
    {
-      waitAllRanges( );
+      //the order of creation/destruction of static variables is indetermined... depends on detail of the build
+      //looks like for some reason on windows + sdl + opengl the order make invalid / wrong the process TODO: Refactor -LAR
+      //waitAllRanges( );
    }
 
    void protectOrderedRange( U32 start, U32 end )


### PR DESCRIPTION
Apparently there's different orders of operation going on per O/S context.