### PR TITLE
Adds a debug visualization mode for the active physics world.

### DIFF
--- a/Templates/Empty/game/tools/worldEditor/main.cs
+++ b/Templates/Empty/game/tools/worldEditor/main.cs
@@ -114,11 +114,13 @@ function initializeWorldEditor()
    EVisibility.addOption( "Debug Render: Decals", "$Decals::debugRender", "" );
    EVisibility.addOption( "Debug Render: Light Frustums", "$Light::renderLightFrustums", "" );
    EVisibility.addOption( "Debug Render: Bounding Boxes", "$Scene::renderBoundingBoxes", "" );
+   EVisibility.addOption( "Debug Render: Physics World", "$PhysicsWorld::render", "togglePhysicsDebugViz" );
    EVisibility.addOption( "AL: Disable Shadows", "$Shadows::disable", "" );   
    EVisibility.addOption( "AL: Light Color Viz", "$AL_LightColorVisualizeVar", "toggleLightColorViz" );
    EVisibility.addOption( "AL: Light Specular Viz", "$AL_LightSpecularVisualizeVar", "toggleLightSpecularViz" );
    EVisibility.addOption( "AL: Normals Viz", "$AL_NormalsVisualizeVar", "toggleNormalsViz" );
    EVisibility.addOption( "AL: Depth Viz", "$AL_DepthVisualizeVar", "toggleDepthViz" );
+   EVisibility.addOption( "AL: Glow Buffer", "$AL_GlowVisualizeVar", "toggleGlowViz" );
    EVisibility.addOption( "AL: PSSM Cascade Viz", "$AL::PSSMDebugRender", "" );
    EVisibility.addOption( "Frustum Lock", "$Scene::lockCull", "" );
    EVisibility.addOption( "Disable Zone Culling", "$Scene::disableZoneCulling", "" );

--- a/Templates/Empty/game/tools/worldEditor/scripts/visibilityLayer.ed.cs
+++ b/Templates/Empty/game/tools/worldEditor/scripts/visibilityLayer.ed.cs
@@ -191,3 +191,11 @@ function EVisibility::addClassOptions( %this )
       %selList.addGuiControl( %selCheckBox );
    }
 }
+
+function togglePhysicsDebugViz( %enable )
+{
+   if(physicsPluginPresent())
+   {
+      physicsDebugDraw(%enable);
+   }
+}

--- a/Templates/Full/game/tools/worldEditor/main.cs
+++ b/Templates/Full/game/tools/worldEditor/main.cs
@@ -114,6 +114,7 @@ function initializeWorldEditor()
    EVisibility.addOption( "Debug Render: Decals", "$Decals::debugRender", "" );
    EVisibility.addOption( "Debug Render: Light Frustums", "$Light::renderLightFrustums", "" );
    EVisibility.addOption( "Debug Render: Bounding Boxes", "$Scene::renderBoundingBoxes", "" );
+   EVisibility.addOption( "Debug Render: Physics World", "$PhysicsWorld::render", "togglePhysicsDebugViz" );
    EVisibility.addOption( "AL: Disable Shadows", "$Shadows::disable", "" );   
    EVisibility.addOption( "AL: Light Color Viz", "$AL_LightColorVisualizeVar", "toggleLightColorViz" );
    EVisibility.addOption( "AL: Light Specular Viz", "$AL_LightSpecularVisualizeVar", "toggleLightSpecularViz" );

--- a/Templates/Full/game/tools/worldEditor/scripts/visibilityLayer.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/visibilityLayer.ed.cs
@@ -191,3 +191,11 @@ function EVisibility::addClassOptions( %this )
       %selList.addGuiControl( %selCheckBox );
    }
 }
+
+function togglePhysicsDebugViz( %enable )
+{
+   if(physicsPluginPresent())
+   {
+      physicsDebugDraw(%enable);
+   }
+}


### PR DESCRIPTION
Allows you to see the active collision info for the physics engine.

(Also catches that the glow buffer mode wasn't added to the empty template, apparently?)