### PR TITLE
Adds a verifyCompatibility method to the Win32FileSystem to report case-sensitivity issues

### DIFF
--- a/Engine/source/platformWin32/winVolume.cpp
+++ b/Engine/source/platformWin32/winVolume.cpp
@@ -236,6 +236,14 @@ Win32FileSystem::~Win32FileSystem()
 {
 }
 
+void Win32FileSystem::verifyCompatibility(const Path& _path, WIN32_FIND_DATAW _info)
+{
+   if (_path.getFullFileName().isNotEmpty() && _path.getFullFileName().compare(String(_info.cFileName)) != 0)
+   {
+      Con::warnf("Linux Compatibility Warning: %s != %s", String(_info.cFileName).c_str(), _path.getFullFileName().c_str());
+   }
+}
+
 FileNodeRef Win32FileSystem::resolve(const Path& path)
 {
    String file = _BuildFileName(mVolume,path);
@@ -245,6 +253,9 @@ FileNodeRef Win32FileSystem::resolve(const Path& path)
    ::FindClose(handle);
    if (handle != INVALID_HANDLE_VALUE)
    {
+#ifdef TORQUE_DEBUG
+      verifyCompatibility(path, info);
+#endif
       if (S_ISREG(info.dwFileAttributes))
          return new Win32File(path,file);
       if (S_ISDIR(info.dwFileAttributes))

--- a/Engine/source/platformWin32/winVolume.h
+++ b/Engine/source/platformWin32/winVolume.h
@@ -45,6 +45,7 @@ public:
    String   getTypeStr() const { return "Win32"; }
 
    FileNodeRef resolve(const Path& path);
+   void verifyCompatibility(const Path& _path, WIN32_FIND_DATAW _info);
    FileNodeRef create(const Path& path,FileNode::Mode);
    bool remove(const Path& path);
    bool rename(const Path& from,const Path& to);


### PR DESCRIPTION
-triggered during debug only
-still need to expand that to handle bad directories.