### PR TITLE
U32 MRandomLCG::randI() was using longs

### DIFF
--- a/Engine/source/math/mRandom.cpp
+++ b/Engine/source/math/mRandom.cpp
@@ -88,13 +88,13 @@ void MRandomLCG::setSeed(S32 s)
 U32 MRandomLCG::randI()
 {
    if ( mSeed <= msQuotient )
-      mSeed = (mSeed * 16807L) % S32_MAX;
+      mSeed = (mSeed * 16807) % S32_MAX;
    else
    {
       S32 high_part = mSeed / msQuotient;
       S32 low_part  = mSeed % msQuotient;
 
-      S32 test = (16807L * low_part) - (msRemainder * high_part);
+      S32 test = (16807 * low_part) - (msRemainder * high_part);
 
       if ( test > 0 )
          mSeed = test;

--- a/Engine/source/math/mRandom.h
+++ b/Engine/source/math/mRandom.h
@@ -54,7 +54,7 @@ public:
 inline F32 MRandomGenerator::randF()
 {
    // default: multiply by 1/(2^31)
-   return  F32(randI()) * (1.0f/2147483647.0f);
+   return F32(randI()) * (1.0f / S32_MAX);
 }
 
 inline S32 MRandomGenerator::randI(S32 i, S32 n)


### PR DESCRIPTION
32 and 64 bit windows can handle that. 64 bit linux no likey mixing longs and ints.