### PR TITLE
mQuat.h change to fix QuatF::angleBetween

### DIFF
--- a/Engine/source/math/mQuat.h
+++ b/Engine/source/math/mQuat.h
@@ -227,7 +227,7 @@ inline F32 QuatF::dot( const QuatF &q ) const
 
 inline F32 QuatF::angleBetween( const QuatF & q )
 {
-   // angle between two quaternions.
+   // angle between two normalized quaternions.
    return mAcos(q.dot(*this)) * 2.0f;
 }
 

--- a/Engine/source/math/mQuat.h
+++ b/Engine/source/math/mQuat.h
@@ -227,8 +227,13 @@ inline F32 QuatF::dot( const QuatF &q ) const
 
 inline F32 QuatF::angleBetween( const QuatF & q )
 {
-   // angle between to quaternions
-   return mAcos(x * q.x + y * q.y + z * q.z + w * q.w);
+   // angle between two quaternions
+   QuatF base(x,y,z,w);
+   base=base.normalize();
+   QuatF q_norm=q;
+   q_norm=q_norm.normalize();
+   return 2.0f*mAcos(base.dot(q_norm));
 }
+
 
 #endif // _MQUAT_H_

--- a/Engine/source/math/mQuat.h
+++ b/Engine/source/math/mQuat.h
@@ -229,11 +229,10 @@ inline F32 QuatF::angleBetween( const QuatF & q )
 {
    // angle between two quaternions
    QuatF base(x,y,z,w);
-   base=base.normalize();
+   base.normalize();
    QuatF q_norm=q;
-   q_norm=q_norm.normalize();
+   q_norm.normalize();
    return 2.0f*mAcos(base.dot(q_norm));
 }
-
 
 #endif // _MQUAT_H_

--- a/Engine/source/math/mQuat.h
+++ b/Engine/source/math/mQuat.h
@@ -227,12 +227,8 @@ inline F32 QuatF::dot( const QuatF &q ) const
 
 inline F32 QuatF::angleBetween( const QuatF & q )
 {
-   // angle between two quaternions
-   QuatF base(x,y,z,w);
-   base.normalize();
-   QuatF q_norm=q;
-   q_norm.normalize();
-   return 2.0f*mAcos(base.dot(q_norm));
+   // angle between two quaternions.
+   return mAcos(q.dot(*this)) * 2.0f;
 }
 
 #endif // _MQUAT_H_


### PR DESCRIPTION
The old version doesn't have that 2.0f in the return that seems to be needed.
Also added normalizing inside so it can be used directly for not-normalized quaternions too.