### PR TITLE
CMake NMake fix to place exe in game directory

### DIFF
--- a/Tools/CMake/basics.cmake
+++ b/Tools/CMake/basics.cmake
@@ -393,6 +393,7 @@ endif()
 
 # fix the debug/release subfolders on windows
 if(MSVC)
+    SET("CMAKE_RUNTIME_OUTPUT_DIRECTORY" "${projectOutDir}")
     FOREACH(CONF ${CMAKE_CONFIGURATION_TYPES})
         # Go uppercase (DEBUG, RELEASE...)
         STRING(TOUPPER "${CONF}" CONF)


### PR DESCRIPTION
This fixes CMake NMake build generation to place the exe in the game directory