### PR TITLE
SDL Menubar accelerator fix

### DIFF
--- a/Templates/Empty/game/tools/base/menuBar/menuBuilder.ed.cs
+++ b/Templates/Empty/game/tools/base/menuBar/menuBuilder.ed.cs
@@ -132,7 +132,7 @@ function MenuBuilder::addItem(%this, %pos, %item)
    }
    else
    {
-      %this.insertItem(%pos, %name !$= "-" ? %name : "", %accel);
+      %this.insertItem(%pos, %name !$= "-" ? %name : "", %accel, %cmd);
    }
 }
 

--- a/Templates/Full/game/tools/base/menuBar/menuBuilder.ed.cs
+++ b/Templates/Full/game/tools/base/menuBar/menuBuilder.ed.cs
@@ -132,7 +132,7 @@ function MenuBuilder::addItem(%this, %pos, %item)
    }
    else
    {
-      %this.insertItem(%pos, %name !$= "-" ? %name : "", %accel);
+      %this.insertItem(%pos, %name !$= "-" ? %name : "", %accel, %cmd);
    }
 }
 


### PR DESCRIPTION
Fixes it so when using SDL, the editor menubar will correctly react to accelerator commands.