### PR TITLE
Changed order of fmodex library unload.

### DIFF
--- a/Engine/source/sfx/fmod/sfxFMODDevice.h
+++ b/Engine/source/sfx/fmod/sfxFMODDevice.h
@@ -105,8 +105,8 @@ struct FModFNTable
    }
    ~FModFNTable()
    {
-      eventDllRef = NULL;
       dllRef = NULL;
+      eventDllRef = NULL;      
       delete mutex;
    }
 


### PR DESCRIPTION
This solves a crash i have personally had under multiple reinstalls of my OS, happened with windows 7, 8.1 and 10. When unloading the fmodex.dll it crashes on Win32DLibrary::close(). I have never been able to reproduce this bug on another computer though :/ . I have even tried a clean re-install disabling my on-board sound in the bios and using a pcie creative card and same thing happens so it's not a sound card driver.

Only thing that solved it was swapping the order that fmod_event and fmodex was dereferenced thus causing the dll to be unloaded.