### PR TITLE
Templates sfx autodetect fix

### DIFF
--- a/Templates/Empty/game/core/scripts/client/audio.cs
+++ b/Templates/Empty/game/core/scripts/client/audio.cs
@@ -230,6 +230,8 @@ function sfxShutdown()
 /// Determines which of the two SFX providers is preferable.
 function sfxCompareProvider( %providerA, %providerB )
 {
+   %providerA = getField(%providerA, 0);
+   
    if( %providerA $= %providerB )
       return 0;
       

--- a/Templates/Full/game/core/scripts/client/audio.cs
+++ b/Templates/Full/game/core/scripts/client/audio.cs
@@ -230,6 +230,8 @@ function sfxShutdown()
 /// Determines which of the two SFX providers is preferable.
 function sfxCompareProvider( %providerA, %providerB )
 {
+   %providerA = getField(%providerA, 0);
+   
    if( %providerA $= %providerB )
       return 0;
       


### PR DESCRIPTION
%providerA in sfxCompareProvider function is a vector instead of the first field. This fixes that and prevents defaulting to Null SFX Provider.