### PR TITLE
cuts the shadergen hashkey generator down from a 64 bit to a 32 bit key.

### DIFF
--- a/Engine/source/shaderGen/shaderGen.cpp
+++ b/Engine/source/shaderGen/shaderGen.cpp
@@ -465,12 +465,12 @@ GFXShader* ShaderGen::getShader( const MaterialFeatureData &featureData, const G
    // Don't get paranoid!  This has 1 in 18446744073709551616
    // chance for collision... it won't happen in this lifetime.
    //
-   U64 hash = Torque::hash64( (const U8*)shaderDescription.c_str(), shaderDescription.length(), 0 );
+   U32 hash = Torque::hash( (const U8*)shaderDescription.c_str(), shaderDescription.length(), 0 );
    hash = convertHostToLEndian(hash);
-   U32 high = (U32)( hash >> 32 );
-   U32 low = (U32)( hash & 0x00000000FFFFFFFF );
-   String cacheKey = String::ToString( "%x%x", high, low );
-
+   //U32 high = (U32)( hash >> 32 );
+   //U32 low = (U32)( hash & 0x00000000FFFFFFFF );
+   //String cacheKey = String::ToString( "%x%x", high, low );
+   String cacheKey = String::ToString("%x", hash);
    // return shader if exists
    GFXShader *match = mProcShaders[cacheKey];
    if ( match )


### PR DESCRIPTION
(MacOSX 32 bit compatibilty errors. was generating 2k+ shader files. may also address  https://github.com/GarageGames/Torque3D/issues/1219)