### PR TITLE
SfxCompareProvider fix

### DIFF
--- a/Templates/Empty/game/core/scripts/client/audio.cs
+++ b/Templates/Empty/game/core/scripts/client/audio.cs
@@ -239,26 +239,26 @@ function sfxCompareProvider( %providerA, %providerB )
       case "FMOD":
          return 1;
          
-      case "XAudio":
-         if( %providerB !$= "FMOD" )
-            return 1;
-         else
-            return -1;
-            
       // Prefer OpenAL over anything but FMOD.
       case "OpenAL":
-         if( %providerB $= "FMOD" && %providerB !$= "XAudio")
+         if( %providerB $= "FMOD" )
             return -1;
          else
             return 1;
-            
-      // DSound is just about deprecated, so make that one the last fallback
-      case "DirectSound":
-         if( %providerB $= "FMOD" || %providerB $= "OpenAL" && %providerB !$= "XAudio")
+      
+      // choose XAudio over DirectSound
+      case "XAudio":
+         if( %providerB $= "FMOD" || %providerB $= "OpenAL" )
             return -1;
          else
             return 0;
             
+      case "DirectSound":
+         if( %providerB !$= "FMOD" && %providerB !$= "OpenAL" && %providerB !$= "XAudio" )
+            return 1;
+         else
+            return -1;
+         
       default:
          return -1;
    }

--- a/Templates/Full/game/core/scripts/client/audio.cs
+++ b/Templates/Full/game/core/scripts/client/audio.cs
@@ -239,26 +239,26 @@ function sfxCompareProvider( %providerA, %providerB )
       case "FMOD":
          return 1;
          
-      case "XAudio":
-         if( %providerB !$= "FMOD" )
-            return 1;
-         else
-            return -1;
-            
       // Prefer OpenAL over anything but FMOD.
       case "OpenAL":
-         if( %providerB $= "FMOD" && %providerB !$= "XAudio")
+         if( %providerB $= "FMOD" )
             return -1;
          else
             return 1;
-            
-      // DSound is just about deprecated, so make that one the last fallback
-      case "DirectSound":
-         if( %providerB $= "FMOD" || %providerB $= "OpenAL" && %providerB !$= "XAudio")
+      
+      // choose XAudio over DirectSound
+      case "XAudio":
+         if( %providerB $= "FMOD" || %providerB $= "OpenAL" )
             return -1;
          else
             return 0;
             
+      case "DirectSound":
+         if( %providerB !$= "FMOD" && %providerB !$= "OpenAL" && %providerB !$= "XAudio" )
+            return 1;
+         else
+            return -1;
+         
       default:
          return -1;
    }


### PR DESCRIPTION
This fixes the sfxCompareProvider function in Full and Empty templates to prefer in the following order: FMOD > OpenAL > XAudio > DirectSound