### PR TITLE
explosion cover miscalc

### DIFF
--- a/Templates/Full/game/scripts/server/radiusDamage.cs
+++ b/Templates/Full/game/scripts/server/radiusDamage.cs
@@ -56,7 +56,8 @@ function radiusDamage(%sourceObject, %position, %radius, %damage, %damageType, %
       // Full damage is applied to anything less than half the radius away,
       // linear scale from there.
       %distScale = (%dist < %halfRadius)? 1.0 : 1.0 - ((%dist - %halfRadius) / %halfRadius);
-
+      %distScale = mClamp(%distScale,0.0,1.0);
+      
       // Apply the damage
       %targetObject.damage(%sourceObject, %position, %damage * %coverage * %distScale, %damageType);
 

--- a/Templates/Full/game/scripts/server/radiusDamage.cs
+++ b/Templates/Full/game/scripts/server/radiusDamage.cs
@@ -29,7 +29,7 @@ function radiusDamage(%sourceObject, %position, %radius, %damage, %damageType, %
    // Use the container system to iterate through all the objects
    // within our explosion radius.  We'll apply damage to all ShapeBase
    // objects.
-   InitContainerRadiusSearch(%position, %radius, $TypeMasks::ShapeBaseObjectType);
+   InitContainerRadiusSearch(%position, %radius, $TypeMasks::ShapeBaseObjectType | $TypeMasks::DynamicShapeObjectType);
 
    %halfRadius = %radius / 2;
    while ((%targetObject = containerSearchNext()) != 0)


### PR DESCRIPTION
%distscale can actually end up negative. causes miscalculations for applyimpulse and the like (or even healing if you've hacked in the capacity for negative damage)