### PR TITLE
ensures opengl texSpaceMat is initialized from the get-go 

### DIFF
--- a/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
@@ -49,7 +49,7 @@ LangElement * ShaderFeatureGLSL::setupTexSpaceMat( Vector<ShaderComponent*> &, /
    (*texSpaceMat)->setName( "objToTangentSpace" );
 
    MultiLine * meta = new MultiLine;
-   meta->addStatement( new GenOp( "   @;\r\n", new DecOp( *texSpaceMat ) ) );
+   meta->addStatement( new GenOp( "   @ = float3x3(1,0,0, 0,1,0, 0,0,1);\r\n", new DecOp( *texSpaceMat ) ) );
    
    // Protect against missing normal and tangent.
    if ( !N || !T )


### PR DESCRIPTION
cleans up those
0(473) : warning C7050: "objToTangentSpace[0]" might be used before being initialized
0(473) : warning C7050: "objToTangentSpace[1]" might be used before being initialized
0(473) : warning C7050: "objToTangentSpace[2]" might be used before being initialized
warnings.