### PR TITLE
Removed unused vertex formats from ScatterSky

### DIFF
--- a/Engine/source/environment/scatterSky.cpp
+++ b/Engine/source/environment/scatterSky.cpp
@@ -85,8 +85,6 @@ const F32 ScatterSky::smViewerHeight = 1.0f;
 GFXImplementVertexFormat( ScatterSkyVertex )
 {
    addElement( "POSITION", GFXDeclType_Float3 );
-   addElement( "NORMAL", GFXDeclType_Float3 );
-   addElement( "COLOR", GFXDeclType_Color );
 }
 
 ScatterSky::ScatterSky()

--- a/Engine/source/environment/scatterSky.cpp
+++ b/Engine/source/environment/scatterSky.cpp
@@ -82,11 +82,6 @@ const F32 ScatterSky::smEarthRadius = (6378.0f * 1000.0f);
 const F32 ScatterSky::smAtmosphereRadius = 200000.0f;
 const F32 ScatterSky::smViewerHeight = 1.0f;
 
-GFXImplementVertexFormat( ScatterSkyVertex )
-{
-   addElement( "POSITION", GFXDeclType_Float3 );
-}
-
 ScatterSky::ScatterSky()
 {
    mPrimCount = 0;
@@ -759,7 +754,7 @@ void ScatterSky::_initVBIB()
    F32 zOffset = -( mCos( mSqrt( 1.0f ) ) + 0.01f );
 
    mVB.set( GFX, mVertCount, GFXBufferTypeStatic );
-   ScatterSkyVertex *pVert = mVB.lock();
+   GFXVertexP *pVert = mVB.lock();
    if(!pVert) return;
 
    for ( U32 y = 0; y < vertStride; y++ )

--- a/Engine/source/environment/scatterSky.h
+++ b/Engine/source/environment/scatterSky.h
@@ -57,12 +57,6 @@ class TimeOfDay;
 class CubemapData;
 class MatrixSet;
 
-
-GFXDeclareVertexFormat( ScatterSkyVertex )
-{
-   Point3F point;
-};
-
 class ScatterSky : public SceneObject, public ISceneLight
 {
    typedef SceneObject Parent;
@@ -226,7 +220,7 @@ protected:
 
    // Prim buffer, vertex buffer and shader for rendering.
    GFXPrimitiveBufferHandle mPrimBuffer;
-   GFXVertexBufferHandle<ScatterSkyVertex> mVB;
+   GFXVertexBufferHandle<GFXVertexP> mVB;
    GFXShaderRef mShader;
 
    GFXStateBlockRef mStateBlock;

--- a/Engine/source/environment/scatterSky.h
+++ b/Engine/source/environment/scatterSky.h
@@ -61,8 +61,6 @@ class MatrixSet;
 GFXDeclareVertexFormat( ScatterSkyVertex )
 {
    Point3F point;
-   VectorF normal;
-   GFXVertexColor color;
 };
 
 class ScatterSky : public SceneObject, public ISceneLight

--- a/Templates/Empty/game/shaders/common/gl/scatterSkyV.glsl
+++ b/Templates/Empty/game/shaders/common/gl/scatterSkyV.glsl
@@ -36,14 +36,9 @@ float vernierScale(float fCos)
 }
 
 in vec4 vPosition;
-in vec3 vNormal;
-in vec4 vColor;
-in vec2 vTexCoord0;
 
 // This is the shader input vertex structure.
 #define IN_position vPosition
-#define IN_normal vNormal
-#define IN_color vColor
 
 // This is the shader output data.
 out vec4  rayleighColor;

--- a/Templates/Empty/game/shaders/common/scatterSkyV.hlsl
+++ b/Templates/Empty/game/shaders/common/scatterSkyV.hlsl
@@ -39,10 +39,6 @@ struct Vert
 {
    // .xyz  = point
    float4 position : POSITION;
-   
-   float3 normal   : NORMAL;
-   
-   float4 color : TEXCOORD0;  
 };
 
 // This is the shader output data.

--- a/Templates/Full/game/shaders/common/gl/scatterSkyV.glsl
+++ b/Templates/Full/game/shaders/common/gl/scatterSkyV.glsl
@@ -36,14 +36,9 @@ float vernierScale(float fCos)
 }
 
 in vec4 vPosition;
-in vec3 vNormal;
-in vec4 vColor;
-in vec2 vTexCoord0;
 
 // This is the shader input vertex structure.
 #define IN_position vPosition
-#define IN_normal vNormal
-#define IN_color vColor
 
 // This is the shader output data.
 out vec4  rayleighColor;

--- a/Templates/Full/game/shaders/common/scatterSkyV.hlsl
+++ b/Templates/Full/game/shaders/common/scatterSkyV.hlsl
@@ -39,10 +39,6 @@ struct Vert
 {
    // .xyz  = point
    float4 position : POSITION;
-   
-   float3 normal   : NORMAL;
-   
-   float4 color : TEXCOORD0;  
 };
 
 // This is the shader output data.


### PR DESCRIPTION
I noticed this while working on DX11 stuff, scattersky has unused vertex formats. Thought i would do a separate PR in case it got lost in the DX11 branch 