### PR TITLE
Removed unused vertex colors from GFXWaterVertex

### DIFF
--- a/Engine/source/environment/waterBlock.cpp
+++ b/Engine/source/environment/waterBlock.cpp
@@ -205,8 +205,6 @@ void WaterBlock::setupVertexBlock( U32 width, U32 height, U32 rowOffset )
    U32 numVerts = width * height;
 
    GFXWaterVertex *verts = new GFXWaterVertex[ numVerts ];
-   ColorI waterColor(31, 56, 64, 127);
-   GFXVertexColor vertCol(waterColor);
 
    U32 index = 0;
    for( U32 i=0; i<height; i++ )
@@ -219,7 +217,6 @@ void WaterBlock::setupVertexBlock( U32 width, U32 height, U32 rowOffset )
          vert->point.x = vertX;
          vert->point.y = vertY;
          vert->point.z = 0.0;
-         vert->color = vertCol;
          vert->normal.set(0,0,1);
          vert->undulateData.set( vertX, vertY );
          vert->horizonFactor.set( 0, 0, 0, 0 );

--- a/Engine/source/environment/waterObject.cpp
+++ b/Engine/source/environment/waterObject.cpp
@@ -50,7 +50,6 @@ GFXImplementVertexFormat( GFXWaterVertex )
 {
    addElement( "POSITION", GFXDeclType_Float3 );
    addElement( "NORMAL", GFXDeclType_Float3 );
-   addElement( "COLOR", GFXDeclType_Color );   
    addElement( "TEXCOORD", GFXDeclType_Float2, 0 );
    addElement( "TEXCOORD", GFXDeclType_Float4, 1 );   
 }

--- a/Engine/source/environment/waterObject.h
+++ b/Engine/source/environment/waterObject.h
@@ -49,7 +49,6 @@ GFXDeclareVertexFormat( GFXWaterVertex )
 {
    Point3F point;
    Point3F normal;
-   GFXVertexColor color;
    Point2F undulateData;
    Point4F horizonFactor;
 };

--- a/Engine/source/environment/waterPlane.cpp
+++ b/Engine/source/environment/waterPlane.cpp
@@ -175,9 +175,6 @@ void WaterPlane::setupVBIB( SceneRenderState *state )
 {
    const Frustum &frustum = state->getCullingFrustum();
    
-   // Water base-color, assigned as color for all verts.
-   const GFXVertexColor vertCol(mWaterFogData.color);
-
    // World-Up vector, assigned as normal for all verts.
    const Point3F worldUp( 0.0f, 0.0f, 1.0f );
 
@@ -250,7 +247,6 @@ void WaterPlane::setupVBIB( SceneRenderState *state )
          xVal = cornerPosition.x + (F32)( j * squareSize );
 
          vertPtr->point.set( xVal, yVal, 0.0f );
-         vertPtr->color = vertCol;
          vertPtr->normal = worldUp;
          vertPtr->undulateData.set( xVal, yVal );
          vertPtr->horizonFactor.set( 0, 0, 0, 0 );
@@ -404,7 +400,6 @@ void WaterPlane::setupVBIB( SceneRenderState *state )
          vertPtr->point.set( pos.x, pos.y, 0.0f );
          vertPtr->undulateData.set( pos.x, pos.y );
          vertPtr->horizonFactor.set( 0, 0, 0, 0 );
-         vertPtr->color = vertCol;
          vertPtr->normal = worldUp;         
          vertPtr++;
       }
@@ -427,7 +422,6 @@ void WaterPlane::setupVBIB( SceneRenderState *state )
       vertPtr->point.set( pos.x, pos.y, 50.0f );
       vertPtr->undulateData.set( pos.x, pos.y );
       vertPtr->horizonFactor.set( 1, 0, 0, 0 );
-      vertPtr->color = vertCol;
       vertPtr->normal = worldUp;
       vertPtr++;
    }

--- a/Templates/Empty/game/shaders/common/water/gl/waterBasicV.glsl
+++ b/Templates/Empty/game/shaders/common/water/gl/waterBasicV.glsl
@@ -72,7 +72,6 @@ uniform float    undulateMaxDist;
 
 in vec4 vPosition;
 in vec3 vNormal;
-in vec4 vColor;
 in vec2 vTexCoord0;
 in vec4 vTexCoord1;
 

--- a/Templates/Full/game/shaders/common/water/gl/waterBasicV.glsl
+++ b/Templates/Full/game/shaders/common/water/gl/waterBasicV.glsl
@@ -72,7 +72,6 @@ uniform float    undulateMaxDist;
 
 in vec4 vPosition;
 in vec3 vNormal;
-in vec4 vColor;
 in vec2 vTexCoord0;
 in vec4 vTexCoord1;
 


### PR DESCRIPTION
Colour is sent via a uniform in the pixel shader, this must be old code leftover from a previous water system or something like that. No point sending data that is never used.