### PR TITLE
playJournal fix and removed depcrecated command line options

### DIFF
--- a/Templates/Empty/game/core/parseArgs.cs
+++ b/Templates/Empty/game/core/parseArgs.cs
@@ -160,7 +160,7 @@ function defaultParseArgs()
             $argUsed[$i]++;
             if ($hasNextArg)
             {
-               playJournal($nextArg,false);
+               playJournal($nextArg);
                $argUsed[$i+1]++;
                $i++;
             }
@@ -239,18 +239,6 @@ function defaultParseArgs()
             }
             else
                error("Error: Missing Command Line argument. Usage: -vidCapHeight <ouput_video_height>");
-
-         //--------------------
-         case "-jDebug":
-            $argUsed[$i]++;
-            if ($hasNextArg)
-            {
-               playJournal($nextArg,true);
-               $argUsed[$i+1]++;
-               $i++;
-            }
-            else
-               error("Error: Missing Command Line argument. Usage: -jDebug <journal_name>");
 
          //--------------------
          case "-level":

--- a/Templates/Empty/game/main.cs
+++ b/Templates/Empty/game/main.cs
@@ -57,7 +57,7 @@ $displayHelp = false;
 
 // Use these to record and play back crashes
 //saveJournal("editorOnFileQuitCrash.jrn");
-//playJournal("editorOnFileQuitCrash.jrn", false);
+//playJournal("editorOnFileQuitCrash.jrn");
 
 //------------------------------------------------------------------------------
 // Check if a script file exists, compiled or not.

--- a/Templates/Empty/game/main.cs
+++ b/Templates/Empty/game/main.cs
@@ -186,10 +186,8 @@ function displayHelp() {
       "  <game_name>            Works like the -game argument\n"@
       "  -dir <dir_name>        Add <dir_name> to list of directories\n"@
       "  -console               Open a separate console\n"@
-      "  -show <shape>          Deprecated\n"@
       "  -jSave  <file_name>    Record a journal\n"@
       "  -jPlay  <file_name>    Play back a journal\n"@
-      "  -jDebug <file_name>    Play back a journal and issue an int3 at the end\n"@
       "  -help                  Display this help message\n"
    );
 }

--- a/Templates/Empty/game/main.cs.in
+++ b/Templates/Empty/game/main.cs.in
@@ -57,7 +57,7 @@ $displayHelp = false;
 
 // Use these to record and play back crashes
 //saveJournal("editorOnFileQuitCrash.jrn");
-//playJournal("editorOnFileQuitCrash.jrn", false);
+//playJournal("editorOnFileQuitCrash.jrn");
 
 //------------------------------------------------------------------------------
 // Check if a script file exists, compiled or not.

--- a/Templates/Empty/game/main.cs.in
+++ b/Templates/Empty/game/main.cs.in
@@ -186,10 +186,8 @@ function displayHelp() {
       "  <game_name>            Works like the -game argument\n"@
       "  -dir <dir_name>        Add <dir_name> to list of directories\n"@
       "  -console               Open a separate console\n"@
-      "  -show <shape>          Deprecated\n"@
       "  -jSave  <file_name>    Record a journal\n"@
       "  -jPlay  <file_name>    Play back a journal\n"@
-      "  -jDebug <file_name>    Play back a journal and issue an int3 at the end\n"@
       "  -help                  Display this help message\n"
    );
 }

--- a/Templates/Full/game/core/parseArgs.cs
+++ b/Templates/Full/game/core/parseArgs.cs
@@ -160,7 +160,7 @@ function defaultParseArgs()
             $argUsed[$i]++;
             if ($hasNextArg)
             {
-               playJournal($nextArg,false);
+               playJournal($nextArg);
                $argUsed[$i+1]++;
                $i++;
             }
@@ -239,18 +239,6 @@ function defaultParseArgs()
             }
             else
                error("Error: Missing Command Line argument. Usage: -vidCapHeight <ouput_video_height>");
-
-         //--------------------
-         case "-jDebug":
-            $argUsed[$i]++;
-            if ($hasNextArg)
-            {
-               playJournal($nextArg,true);
-               $argUsed[$i+1]++;
-               $i++;
-            }
-            else
-               error("Error: Missing Command Line argument. Usage: -jDebug <journal_name>");
 
          //--------------------
          case "-level":

--- a/Templates/Full/game/main.cs
+++ b/Templates/Full/game/main.cs
@@ -57,7 +57,7 @@ $displayHelp = false;
 
 // Use these to record and play back crashes
 //saveJournal("editorOnFileQuitCrash.jrn");
-//playJournal("editorOnFileQuitCrash.jrn", false);
+//playJournal("editorOnFileQuitCrash.jrn");
 
 //------------------------------------------------------------------------------
 // Check if a script file exists, compiled or not.

--- a/Templates/Full/game/main.cs
+++ b/Templates/Full/game/main.cs
@@ -186,10 +186,8 @@ function displayHelp() {
       "  <game_name>            Works like the -game argument\n"@
       "  -dir <dir_name>        Add <dir_name> to list of directories\n"@
       "  -console               Open a separate console\n"@
-      "  -show <shape>          Deprecated\n"@
       "  -jSave  <file_name>    Record a journal\n"@
       "  -jPlay  <file_name>    Play back a journal\n"@
-      "  -jDebug <file_name>    Play back a journal and issue an int3 at the end\n"@
       "  -help                  Display this help message\n"
    );
 }

--- a/Templates/Full/game/main.cs.in
+++ b/Templates/Full/game/main.cs.in
@@ -57,7 +57,7 @@ $displayHelp = false;
 
 // Use these to record and play back crashes
 //saveJournal("editorOnFileQuitCrash.jrn");
-//playJournal("editorOnFileQuitCrash.jrn", false);
+//playJournal("editorOnFileQuitCrash.jrn");
 
 //------------------------------------------------------------------------------
 // Check if a script file exists, compiled or not.

--- a/Templates/Full/game/main.cs.in
+++ b/Templates/Full/game/main.cs.in
@@ -186,10 +186,8 @@ function displayHelp() {
       "  <game_name>            Works like the -game argument\n"@
       "  -dir <dir_name>        Add <dir_name> to list of directories\n"@
       "  -console               Open a separate console\n"@
-      "  -show <shape>          Deprecated\n"@
       "  -jSave  <file_name>    Record a journal\n"@
       "  -jPlay  <file_name>    Play back a journal\n"@
-      "  -jDebug <file_name>    Play back a journal and issue an int3 at the end\n"@
       "  -help                  Display this help message\n"
    );
 }


### PR DESCRIPTION
playJournal doesn't have two arguments ([reference](https://github.com/GarageGames/Torque3D/blob/2044b2691e1a29fa65d1bdd163f0d834995433ce/Engine/source/app/game.cpp#L179)).