### PR TITLE
fix for loading cached dts from zip archives

### DIFF
--- a/Engine/source/core/volume.cpp
+++ b/Engine/source/core/volume.cpp
@@ -48,6 +48,8 @@ bool FileSystemChangeNotifier::addNotification( const Path &path, ChangeDelegate
    if (dir.isEmpty())
       return false;
 
+   if(!Torque::FS::IsDirectory(dir)) return false;
+
    dir.setFileName( String() );
    dir.setExtension( String () );
    

--- a/Engine/source/platform/platformVolume.cpp
+++ b/Engine/source/platform/platformVolume.cpp
@@ -60,11 +60,15 @@ bool MountZips(const String &root)
 {
    Path basePath;
    basePath.setRoot(root);
-   Vector<String> outList;
+   Vector<String> outList, outListp;
 
    S32 num = FindByPattern(basePath, "*.zip", true, outList);
-   if(num == 0)
-      return true; // not an error
+   S32 nump = FindByPattern(basePath, "*.pak", true, outListp);
+   
+   if(num == 0 && nump == 0)
+      return true; //not an error
+
+   outList.merge(outListp);
 
    S32 mounted = 0;
    for(S32 i = 0;i < outList.size();++i)

--- a/Engine/source/ts/collada/colladaShapeLoader.cpp
+++ b/Engine/source/ts/collada/colladaShapeLoader.cpp
@@ -514,22 +514,22 @@ bool ColladaShapeLoader::canLoadCachedDTS(const Torque::Path& path)
    Torque::Path cachedPath(path);
    cachedPath.setExtension("cached.dts");
 
-   // Check if a cached DTS newer than this file is available
-   FileTime cachedModifyTime;
-   if (Platform::getFileTimes(cachedPath.getFullPath(), NULL, &cachedModifyTime))
-   {
-      bool forceLoadDAE = Con::getBoolVariable("$collada::forceLoadDAE", false);
+   Torque::FS::FileNode::Attributes a1, a2;
 
-      FileTime daeModifyTime;
-      if (!Platform::getFileTimes(path.getFullPath(), NULL, &daeModifyTime) ||
-         (!forceLoadDAE && (Platform::compareFileTimes(cachedModifyTime, daeModifyTime) >= 0) ))
-      {
-         // DAE not found, or cached DTS is newer
-         return true;
-      }
-   }
+   //if there is no cached dts, return false
+   if (!Torque::FS::GetFileAttributes(cachedPath, &a1)) return false;
 
-   return false;
+   //if there is a cached dts but no dae, return true
+   if (!Torque::FS::GetFileAttributes(path, &a2)) return true;
+
+   //if the cached dts was most recently modified, return true
+   if(a1.mtime > a2.mtime) return true;
+
+   //if the cached dts and dae modified times equal, prefer cached dts
+   if(a1.mtime == a2.mtime) return true;
+
+   //otherwise return false
+   return true;
 }
 
 bool ColladaShapeLoader::checkAndMountSketchup(const Torque::Path& path, String& mountPoint, Torque::Path& daePath)

--- a/Engine/source/ts/collada/colladaShapeLoader.cpp
+++ b/Engine/source/ts/collada/colladaShapeLoader.cpp
@@ -514,6 +514,10 @@ bool ColladaShapeLoader::canLoadCachedDTS(const Torque::Path& path)
    Torque::Path cachedPath(path);
    cachedPath.setExtension("cached.dts");
 
+   //if forcing dae loading then return false
+   if( Con::getBoolVariable("$collada::forceLoadDAE", false) )
+   	return false;
+
    Torque::FS::FileNode::Attributes a1, a2;
 
    //if there is no cached dts, return false

--- a/Engine/source/ts/collada/colladaShapeLoader.cpp
+++ b/Engine/source/ts/collada/colladaShapeLoader.cpp
@@ -529,7 +529,7 @@ bool ColladaShapeLoader::canLoadCachedDTS(const Torque::Path& path)
    if(a1.mtime == a2.mtime) return true;
 
    //otherwise return false
-   return true;
+   return false;
 }
 
 bool ColladaShapeLoader::checkAndMountSketchup(const Torque::Path& path, String& mountPoint, Torque::Path& daePath)


### PR DESCRIPTION
This fixes a bug where if you attempted to load cached dts files from a zip archive it would fail. This was because it was attempting to extract the file time information from non-existent files outside of the archive. Thus, canLoadCachedDTS would return false.

I added a line to disable the file change notification errors for directories that don't exist or are in zip archive.

Additionally, I added *.pak to the search pattern for archives.