### PR TITLE
 mDirtyTiles changed from std::queue to a vector

### DIFF
--- a/Engine/source/navigation/navMesh.cpp
+++ b/Engine/source/navigation/navMesh.cpp
@@ -637,7 +637,7 @@ DefineEngineMethod(NavMesh, build, bool, (bool background, bool save), (true, fa
 
 void NavMesh::cancelBuild()
 {
-   while(!mDirtyTiles.empty()) mDirtyTiles.pop();
+   mDirtyTiles.clear();
    ctx->stopTimer(RC_TIMER_TOTAL);
    mBuilding = false;
 }
@@ -707,7 +707,7 @@ void NavMesh::updateTiles(bool dirty)
 
    mTiles.clear();
    mTileData.clear();
-   while(!mDirtyTiles.empty()) mDirtyTiles.pop();
+   mDirtyTiles.clear();
 
    const Box3F &box = DTStoRC(getWorldBox());
    if(box.isEmpty())
@@ -741,7 +741,7 @@ void NavMesh::updateTiles(bool dirty)
                   tileBmin, tileBmax));
 
          if(dirty)
-            mDirtyTiles.push(mTiles.size() - 1);
+            mDirtyTiles.push_back_unique(mTiles.size() - 1);
 
          if(mSaveIntermediates)
             mTileData.increment();
@@ -760,7 +760,7 @@ void NavMesh::buildNextTile()
    {
       // Pop a single dirty tile and process it.
       U32 i = mDirtyTiles.front();
-      mDirtyTiles.pop();
+      mDirtyTiles.pop_front();
       const Tile &tile = mTiles[i];
       // Intermediate data for tile build.
       TileData tempdata;
@@ -844,7 +844,7 @@ unsigned char *NavMesh::buildTileData(const Tile &tile, TileData &data, U32 &dat
 
    // Check for no geometry.
    if(!data.geom.getVertCount())
-      return false;
+      return NULL;
 
    // Figure out voxel dimensions of this tile.
    U32 width = 0, height = 0;
@@ -1066,7 +1066,7 @@ void NavMesh::buildTiles(const Box3F &box)
       if(!tile.box.isOverlapped(box))
          continue;
       // Mark as dirty.
-      mDirtyTiles.push(i);
+      mDirtyTiles.push_back_unique(i);
    }
    if(mDirtyTiles.size())
       ctx->startTimer(RC_TIMER_TOTAL);
@@ -1082,7 +1082,7 @@ void NavMesh::buildTile(const U32 &tile)
 {
    if(tile < mTiles.size())
    {
-      mDirtyTiles.push(tile);
+      mDirtyTiles.push_back_unique(tile);
       ctx->startTimer(RC_TIMER_TOTAL);
    }
 }
@@ -1104,7 +1104,7 @@ void NavMesh::buildLinks()
             mLinksUnsynced[j])
          {
             // Mark tile for build.
-            mDirtyTiles.push(i);
+            mDirtyTiles.push_back_unique(i);
             // Delete link if necessary
             if(mDeleteLinks[j])
             {

--- a/Engine/source/navigation/navMesh.h
+++ b/Engine/source/navigation/navMesh.h
@@ -325,7 +325,7 @@ private:
    Vector<TileData> mTileData;
 
    /// List of indices to the tile array which are dirty.
-   std::queue<U32> mDirtyTiles;
+   Vector<U32> mDirtyTiles;
 
    /// Update tile dimensions.
    void updateTiles(bool dirty = false);


### PR DESCRIPTION
allows us to leverage  .push_back_unique(&foo); and .clear();
(part 1 in a series)