### PR TITLE
Fix NULL pointer Crashes in WorldEditor::selectObject & unselectObject

### DIFF
--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -2810,7 +2810,7 @@ void WorldEditor::clearSelection()
 
 void WorldEditor::selectObject( SimObject *obj )
 {
-   if ( mSelectionLocked || !mSelected )
+   if ( mSelectionLocked || !mSelected || !obj )
       return;
 
    // Don't check isSelectionEnabled of SceneObjects here as we
@@ -2833,7 +2833,7 @@ void WorldEditor::selectObject( const char* obj )
 
 void WorldEditor::unselectObject( SimObject *obj )
 {
-   if ( mSelectionLocked || !mSelected )
+   if ( mSelectionLocked || !mSelected || !obj )
       return;
 
    if ( !objClassIgnored( obj ) && mSelected->objInSet( obj ) )


### PR DESCRIPTION
Relatively simple fix, the engine will crash because this code fails to return if the input obj is NULL:

https://github.com/GarageGames/Torque3D/blob/development/Engine/source/gui/worldEditor/worldEditor.cpp#L2834

Same for selectObject.
This stack is generated in unselectObject's case: http://pastebin.com/nUzFJN5u

So it pretty much just attempts to make a call against a NULL pointer if you don't give them a valid ID :) (Try EWorldEditor.unselectObject(0))

As an aside, I fixed my line endings so we don't have spastic messes for commits anymore.