### PR TITLE
Physx3 cmake

### DIFF
--- a/Tools/CMake/basics.cmake
+++ b/Tools/CMake/basics.cmake
@@ -141,6 +141,8 @@ endmacro()
 ###############################################################################
 ### Linked Library Handling
 ###############################################################################
+
+#addLib will add to both debug and release builds
 macro(addLib libs)
    foreach(lib ${libs})
         # check if we can build it ourselfs
@@ -157,11 +159,52 @@ macro(addLib libs)
    endforeach()
 endmacro()
 
+#addLibRelease will add to only release builds
+macro(addLibRelease libs)
+   foreach(lib ${libs})
+        # check if we can build it ourselfs
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libraries/${lib}.cmake")
+            addLibSrc("${CMAKE_CURRENT_SOURCE_DIR}/libraries/${lib}.cmake")
+        endif()
+        # then link against it
+        # two possibilities: a) target already known, so add it directly, or b) target not yet known, so add it to its cache
+        if(TARGET ${PROJECT_NAME})
+            target_link_libraries(${PROJECT_NAME} optimized "${lib}")
+        else()
+            list(APPEND ${PROJECT_NAME}_libsRelease ${lib})
+        endif()
+   endforeach()
+endmacro()
+
+#addLibDebug will add to only debug builds
+macro(addLibDebug libs)
+   foreach(lib ${libs})
+        # check if we can build it ourselfs
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libraries/${lib}.cmake")
+            addLibSrc("${CMAKE_CURRENT_SOURCE_DIR}/libraries/${lib}.cmake")
+        endif()
+        # then link against it
+        # two possibilities: a) target already known, so add it directly, or b) target not yet known, so add it to its cache
+        if(TARGET ${PROJECT_NAME})
+            target_link_libraries(${PROJECT_NAME} debug "${lib}")
+        else()
+            list(APPEND ${PROJECT_NAME}_libsDebug ${lib})
+        endif()
+   endforeach()
+endmacro()
+
 # this applies cached definitions onto the target
 macro(_process_libs)
     if(DEFINED ${PROJECT_NAME}_libs)
         target_link_libraries(${PROJECT_NAME} "${${PROJECT_NAME}_libs}")
-    endif()
+	endif()
+	if(DEFINED ${PROJECT_NAME}_libsRelease)
+        target_link_libraries(${PROJECT_NAME} optimized "${${PROJECT_NAME}_libsRelease}")
+	endif()
+	if(DEFINED ${PROJECT_NAME}_libsDebug)
+        target_link_libraries(${PROJECT_NAME} debug "${${PROJECT_NAME}_libsDebug}")
+	endif()
+
 endmacro()
 
 ###############################################################################

--- a/Tools/CMake/modules/module_physx3.cmake
+++ b/Tools/CMake/modules/module_physx3.cmake
@@ -1,0 +1,154 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015 GarageGames, LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# -----------------------------------------------------------------------------
+
+# module Physx 3.x
+
+option(TORQUE_PHYSICS_PHYSX3 "Use PhysX 3.x physics" OFF)
+
+if( NOT TORQUE_PHYSICS_PHYSX3 )
+    return()
+endif()
+
+file(TO_CMAKE_PATH $ENV{TORQUE_PHYSX3_PATH} PHYSX3_PATH)
+
+if(PHYSX3_PATH STREQUAL "")
+	set(PHYSX3_PATH "" CACHE PATH "PhysX 3.x path" FORCE)
+endif()
+
+# TODO linux support
+if(MSVC)
+if(TORQUE_CPU_X32)
+	if(MSVC11)
+		set(PHYSX3_LIBPATH_PREFIX vc11win32)
+	elseif(MSVC12)
+		set(PHYSX3_LIBPATH_PREFIX vc12win32)
+	elseif(MSVC14)
+		set(PHYSX3_LIBPATH_PREFIX vc14win32)
+	else()
+		return()
+	endif()	
+set(PHYSX3_LIBNAME_POSTFIX _x86)
+
+elseif(TORQUE_CPU_X64)
+	if(MSVC11)
+		set(PHYSX3_LIBPATH_PREFIX vc11win64)
+	elseif(MSVC12)
+		set(PHYSX3_LIBPATH_PREFIX vc12win64)
+	elseif(MSVC14)
+		set(PHYSX3_LIBPATH_PREFIX vc14win64)
+	else()
+		return()
+	endif()	
+set(PHYSX3_LIBNAME_POSTFIX _x64)
+
+endif()
+
+endif(MSVC)
+
+MACRO(FIND_PHYSX3_LIBRARY VARNAME LIBNAME WITHPOSTFIX)
+
+    set(LIBPOSTFIX "")
+    if(${WITHPOSTFIX})
+        set(LIBPOSTFIX ${PHYSX3_LIBNAME_POSTFIX})
+    endif(${WITHPOSTFIX})
+    find_library(PHYSX3_${VARNAME}_LIBRARY NAMES ${LIBNAME}${LIBPOSTFIX}
+                 PATHS ${PHYSX3_PATH}/Lib/${PHYSX3_LIBPATH_PREFIX})
+    find_library(PHYSX3_${VARNAME}_LIBRARY_DEBUG NAMES ${LIBNAME}DEBUG${LIBPOSTFIX}
+                 PATHS ${PHYSX3_PATH}/Lib/${PHYSX3_LIBPATH_PREFIX})
+
+ENDMACRO(FIND_PHYSX3_LIBRARY VARNAME LIBNAME)
+
+# Find the Libs, we just use the full path to save playing around with link_directories
+FIND_PHYSX3_LIBRARY(CORE PhysX3 1)
+FIND_PHYSX3_LIBRARY(COMMON PhysX3Common 1)
+FIND_PHYSX3_LIBRARY(COOKING PhysX3Cooking 1)
+FIND_PHYSX3_LIBRARY(CHARACTER PhysX3CharacterKinematic 1)
+FIND_PHYSX3_LIBRARY(EXTENSIONS PhysX3Extensions 0)
+FIND_PHYSX3_LIBRARY(TASK PxTask 0)
+FIND_PHYSX3_LIBRARY(DEBUGGER PhysXVisualDebuggerSDK 0)
+FIND_PHYSX3_LIBRARY(PROFILE PhysXProfileSDK 0)
+
+if(NOT PHYSX3_CORE_LIBRARY)
+	return()
+endif()
+
+# Defines
+addDef( "TORQUE_PHYSICS_PHYSX3" )
+addDef( "TORQUE_PHYSICS_ENABLED" )
+
+# Source
+addPath( "${srcDir}/T3D/physics/physx3" )
+
+# Includes
+addInclude( "${PHYSX3_PATH}/Include" )
+addInclude( "${PHYSX3_PATH}/Include/extensions" )
+addInclude( "${PHYSX3_PATH}/Include/foundation" )
+addInclude( "${PHYSX3_PATH}/Include/characterkinematic" )
+addInclude( "${PHYSX3_PATH}/Include/common" )
+
+#Add the libs
+set(PHYSX_LIBRARIES_DEBUG
+	${PHYSX3_CORE_LIBRARY_DEBUG}
+	${PHYSX3_COMMON_LIBRARY_DEBUG}
+	${PHYSX3_COOKING_LIBRARY_DEBUG}
+	${PHYSX3_CHARACTER_LIBRARY_DEBUG}
+	${PHYSX3_EXTENSIONS_LIBRARY_DEBUG}
+	${PHYSX3_TASK_LIBRARY_DEBUG}
+	${PHYSX3_DEBUGGER_LIBRARY_DEBUG}
+	${PHYSX3_PROFILE_LIBRARY_DEBUG}
+)
+
+set(PHYSX_LIBRARIES
+	${PHYSX3_CORE_LIBRARY}
+	${PHYSX3_COMMON_LIBRARY}
+	${PHYSX3_COOKING_LIBRARY}
+	${PHYSX3_CHARACTER_LIBRARY}
+	${PHYSX3_EXTENSIONS_LIBRARY}
+	${PHYSX3_TASK_LIBRARY}
+	${PHYSX3_DEBUGGER_LIBRARY}
+	${PHYSX3_PROFILE_LIBRARY}
+)
+
+addLibRelease("${PHYSX_LIBRARIES}")
+addLibDebug("${PHYSX_LIBRARIES_DEBUG}")
+
+#Install dll files
+if( WIN32 )
+	# File Copy for Release   
+	INSTALL(FILES "${PHYSX3_PATH}/Bin/${PHYSX3_LIBPATH_PREFIX}/PhysX3${PHYSX3_LIBNAME_POSTFIX}.dll"             DESTINATION "${projectOutDir}" CONFIGURATIONS "Optimized")
+	INSTALL(FILES "${PHYSX3_PATH}/Bin/${PHYSX3_LIBPATH_PREFIX}/PhysX3CharacterKinematic${PHYSX3_LIBNAME_POSTFIX}.dll"             DESTINATION "${projectOutDir}" CONFIGURATIONS "Optimized")
+	INSTALL(FILES "${PHYSX3_PATH}/Bin/${PHYSX3_LIBPATH_PREFIX}/PhysX3Common${PHYSX3_LIBNAME_POSTFIX}.dll"             DESTINATION "${projectOutDir}" CONFIGURATIONS "Optimized")
+	INSTALL(FILES "${PHYSX3_PATH}/Bin/${PHYSX3_LIBPATH_PREFIX}/PhysX3Cooking${PHYSX3_LIBNAME_POSTFIX}.dll"             DESTINATION "${projectOutDir}" CONFIGURATIONS "Optimized")
+
+	# File Copy for Debug
+	if(TORQUE_CPU_X32)
+		INSTALL(FILES "${PHYSX3_PATH}/Bin/${PHYSX3_LIBPATH_PREFIX}/nvToolsExt32_1.dll"             DESTINATION "${projectOutDir}" CONFIGURATIONS "Debug")
+	elseif(TORQUE_CPU_X64)
+		INSTALL(FILES "${PHYSX3_PATH}/Bin/${PHYSX3_LIBPATH_PREFIX}/nvToolsExt64_1.dll"             DESTINATION "${projectOutDir}" CONFIGURATIONS "Debug")
+	endif()
+	
+	INSTALL(FILES "${PHYSX3_PATH}/Bin/${PHYSX3_LIBPATH_PREFIX}/PhysX3DEBUG${PHYSX3_LIBNAME_POSTFIX}.dll"             DESTINATION "${projectOutDir}" CONFIGURATIONS "Debug")
+	INSTALL(FILES "${PHYSX3_PATH}/Bin/${PHYSX3_LIBPATH_PREFIX}/PhysX3CharacterKinematicDEBUG${PHYSX3_LIBNAME_POSTFIX}.dll"             DESTINATION "${projectOutDir}" CONFIGURATIONS "Debug")
+	INSTALL(FILES "${PHYSX3_PATH}/Bin/${PHYSX3_LIBPATH_PREFIX}/PhysX3CommonDEBUG${PHYSX3_LIBNAME_POSTFIX}.dll"             DESTINATION "${projectOutDir}" CONFIGURATIONS "Debug")
+	INSTALL(FILES "${PHYSX3_PATH}/Bin/${PHYSX3_LIBPATH_PREFIX}/PhysX3CookingDEBUG${PHYSX3_LIBNAME_POSTFIX}.dll"             DESTINATION "${projectOutDir}" CONFIGURATIONS "Debug")
+	
+endif(WIN32)


### PR DESCRIPTION
Support for PhysX 3.x with CMake. I will make a thread very soon about this, basically NVidia doesn't supply binaries any more for PhysX and only source code access so you have to compile yourself. I will outline the steps in the forum post.

Also had to add two new macros for adding libs with CMake, addLibRelease and addLibDebug. The original addLib macro will work just as before but these two new macros allow the use of different libs for debug/release modes. The original addLib obviously still adds the lib to both builds so this will not change any other current CMake modules. Perhaps I should have split this into two separate PR's??

Tested with latest PhysX 3.3.4