### PR TITLE
Glow buffer graphic corruption fix on OpenGL.

### DIFF
--- a/Engine/source/renderInstance/renderTexTargetBinManager.cpp
+++ b/Engine/source/renderInstance/renderTexTargetBinManager.cpp
@@ -107,8 +107,7 @@ void RenderTexTargetBinManager::initPersistFields()
 
 bool RenderTexTargetBinManager::setTargetSize(const Point2I &newTargetSize)
 {
-   if( GFX->getAdapterType() != OpenGL && // Targets need to match up exactly in size on OpenGL.
-       mTargetSize.x >= newTargetSize.x &&
+   if( mTargetSize.x >= newTargetSize.x &&
        mTargetSize.y >= newTargetSize.y )
       return true;
 


### PR DESCRIPTION
Caused by a wrong target size. (probably it was ok on the very old OpenGL 1.5 version)
Before fix, wrong behaviour:
http://goo.gl/dik7Ia
After fix, all right:
http://goo.gl/IsrckM