### PR TITLE
ResourceLeakFix for OpenGL

### DIFF
--- a/Engine/source/gfx/gl/gfxGLCircularVolatileBuffer.h
+++ b/Engine/source/gfx/gl/gfxGLCircularVolatileBuffer.h
@@ -143,6 +143,11 @@ public:
       init();
    }
 
+   ~GLCircularVolatileBuffer()
+   {
+      glDeleteBuffers(1, &mBufferName);
+   }
+
    void init()
    {
       glGenBuffers(1, &mBufferName);

--- a/Engine/source/gfx/gl/gfxGLTextureTarget.cpp
+++ b/Engine/source/gfx/gl/gfxGLTextureTarget.cpp
@@ -163,6 +163,10 @@ void _GFXGLTextureTargetFBOImpl::applyState()
    PRESERVE_FRAMEBUFFER();
    glBindFramebuffer(GL_FRAMEBUFFER, mFramebuffer);
 
+   bool drawbufs[16];
+   int bufsize = 0;
+   for (int i = 0; i < 16; i++)
+           drawbufs[i] = false;
    bool hasColor = false;
    for(int i = 0; i < GFXGL->getNumRenderTargets(); ++i)
    {   
@@ -200,6 +204,20 @@ void _GFXGLTextureTargetFBOImpl::applyState()
       glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
    }
 
+   GLenum *buf = new GLenum[bufsize];
+   int count = 0;
+   for (int i = 0; i < bufsize; i++)
+   {
+           if (drawbufs[i])
+           {
+                   buf[count] = GL_COLOR_ATTACHMENT0 + i;
+                   count++;
+           }
+   }
+ 
+   glDrawBuffers(bufsize, buf);
+ 
+   delete[] buf;
    CHECK_FRAMEBUFFER_STATUS();
 }
 
@@ -260,7 +278,10 @@ GFXGLTextureTarget::GFXGLTextureTarget() : mCopyFboSrc(0), mCopyFboDst(0)
 
 GFXGLTextureTarget::~GFXGLTextureTarget()
 {
-   GFXTextureManager::removeEventDelegate( this, &GFXGLTextureTarget::_onTextureEvent );
+   GFXTextureManager::removeEventDelegate(this, &GFXGLTextureTarget::_onTextureEvent);
+
+   glDeleteFramebuffers(1, &mCopyFboSrc);
+   glDeleteFramebuffers(1, &mCopyFboDst);
 }
 
 const Point2I GFXGLTextureTarget::getSize()

--- a/Engine/source/gfx/gl/gfxGLTextureTarget.cpp
+++ b/Engine/source/gfx/gl/gfxGLTextureTarget.cpp
@@ -163,10 +163,6 @@ void _GFXGLTextureTargetFBOImpl::applyState()
    PRESERVE_FRAMEBUFFER();
    glBindFramebuffer(GL_FRAMEBUFFER, mFramebuffer);
 
-   bool drawbufs[16];
-   int bufsize = 0;
-   for (int i = 0; i < 16; i++)
-           drawbufs[i] = false;
    bool hasColor = false;
    for(int i = 0; i < GFXGL->getNumRenderTargets(); ++i)
    {   
@@ -204,20 +200,6 @@ void _GFXGLTextureTargetFBOImpl::applyState()
       glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
    }
 
-   GLenum *buf = new GLenum[bufsize];
-   int count = 0;
-   for (int i = 0; i < bufsize; i++)
-   {
-           if (drawbufs[i])
-           {
-                   buf[count] = GL_COLOR_ATTACHMENT0 + i;
-                   count++;
-           }
-   }
- 
-   glDrawBuffers(bufsize, buf);
- 
-   delete[] buf;
    CHECK_FRAMEBUFFER_STATUS();
 }
 

--- a/Engine/source/gfx/gl/gfxGLWindowTarget.cpp
+++ b/Engine/source/gfx/gl/gfxGLWindowTarget.cpp
@@ -42,6 +42,14 @@ GFXGLWindowTarget::GFXGLWindowTarget(PlatformWindow *win, GFXDevice *d)
    win->appEvent.notify(this, &GFXGLWindowTarget::_onAppSignal);
 }
 
+GFXGLWindowTarget::~GFXGLWindowTarget()
+{
+   if(glIsFramebuffer(mCopyFBO))
+   {
+      glDeleteFramebuffers(1, &mCopyFBO);
+   }
+}
+
 void GFXGLWindowTarget::resetMode()
 {
    if(mWindow->getVideoMode().fullScreen != mWindow->isFullscreen())
@@ -49,6 +57,7 @@ void GFXGLWindowTarget::resetMode()
       _teardownCurrentMode();
       _setupNewMode();
    }
+   GFX->beginReset();
 }
 
 void GFXGLWindowTarget::_onAppSignal(WindowId wnd, S32 event)

--- a/Engine/source/gfx/gl/gfxGLWindowTarget.cpp
+++ b/Engine/source/gfx/gl/gfxGLWindowTarget.cpp
@@ -57,7 +57,6 @@ void GFXGLWindowTarget::resetMode()
       _teardownCurrentMode();
       _setupNewMode();
    }
-   GFX->beginReset();
 }
 
 void GFXGLWindowTarget::_onAppSignal(WindowId wnd, S32 event)

--- a/Engine/source/gfx/gl/gfxGLWindowTarget.h
+++ b/Engine/source/gfx/gl/gfxGLWindowTarget.h
@@ -30,6 +30,8 @@ class GFXGLWindowTarget : public GFXWindowTarget
 public:
 
    GFXGLWindowTarget(PlatformWindow *win, GFXDevice *d);
+   ~GFXGLWindowTarget();
+
    const Point2I getSize() 
    { 
       return mWindow->getClientExtent();


### PR DESCRIPTION
This resolves some errors related on render targets and other resources which they are never released after creation causing memory leak. It is specific OpenGL fix inside OpenGL render api implementation.
Thank you (: