### PR TITLE
New script function to edit script-created decals

### DIFF
--- a/Engine/source/T3D/decal/decalManager.cpp
+++ b/Engine/source/T3D/decal/decalManager.cpp
@@ -1773,7 +1773,11 @@ DefineEngineFunction( decalManagerEditDecal, bool, ( S32 decalID, Point3F pos, P
    mat.getColumn( 1, &tangent );
    
    //if everything is unchanged just do nothing and  return "everything is ok"
-   if ( pos.equal(decalInstance->mPosition) && normal.equal(decalInstance->mNormal) && tangent.equal(decalInstance->mTangent) && mFabs( decalInstance->mSize - (decalInstance->mDataBlock->size * decalScale) ) < POINT_EPSILON ) return true;
+   if ( pos.equal(decalInstance->mPosition) &&
+        normal.equal(decalInstance->mNormal) &&
+        tangent.equal(decalInstance->mTangent) &&
+        mFabs( decalInstance->mSize - (decalInstance->mDataBlock->size * decalScale) ) < POINT_EPSILON )
+           return true;
 
    decalInstance->mPosition = pos;
    decalInstance->mNormal = normal;

--- a/Engine/source/T3D/decal/decalManager.cpp
+++ b/Engine/source/T3D/decal/decalManager.cpp
@@ -1744,3 +1744,44 @@ DefineEngineFunction( decalManagerRemoveDecal, bool, ( S32 decalID ),,
    gDecalManager->removeDecal(inst);
    return true;
 }
+
+DefineEngineFunction( decalManagerEditDecal, bool, ( S32 decalID, Point3F pos, Point3F normal, F32 rotAroundNormal, F32 decalScale ),,
+   "Edit specified decal of the decal manager.\n"
+   "@param decalID ID of the decal to edit.\n"
+   "@param pos World position for the decal.\n"
+   "@param normal Decal normal vector (if the decal was a tire lying flat on a "
+   "surface, this is the vector pointing in the direction of the axle).\n"
+   "@param rotAroundNormal Angle (in radians) to rotate this decal around its normal vector.\n"
+   "@param decalScale Scale factor applied to the decal.\n"
+   "@return Returns true if successful, false if decalID not found.\n"
+   "" )
+{
+   DecalInstance *decalInstance = gDecalManager->getDecal( decalID );
+   if( !decalInstance )
+		return false;
+
+   //Internally we need Point3F tangent instead of the user friendly F32 rotAroundNormal
+   MatrixF mat( true );
+   MathUtils::getMatrixFromUpVector( normal, &mat );
+
+   AngAxisF rot( normal, rotAroundNormal );
+   MatrixF rotmat;
+   rot.setMatrix( &rotmat );
+   mat.mul( rotmat );
+
+   Point3F tangent;
+   mat.getColumn( 1, &tangent );
+   
+   //if everything is unchanged just do nothing and  return "everything is ok"
+   if ( pos.equal(decalInstance->mPosition) && normal.equal(decalInstance->mNormal) && tangent.equal(decalInstance->mTangent) && mFabs( decalInstance->mSize - (decalInstance->mDataBlock->size * decalScale) ) < POINT_EPSILON ) return true;
+
+   decalInstance->mPosition = pos;
+   decalInstance->mNormal = normal;
+   decalInstance->mTangent = tangent;
+   decalInstance->mSize = decalInstance->mDataBlock->size * decalScale;
+
+   gDecalManager->clipDecal( decalInstance, NULL, NULL);
+   
+   gDecalManager->notifyDecalModified( decalInstance );
+   return true;
+}


### PR DESCRIPTION
TorqueScript function to edit the position of decals created with decalManagerAddDecal.

---

Playing with the idea of creating a shadow from script using decals I found:
-Creating and deleting decals with TorqueScript is quite simple with the functions decalManagerAddDecal and decalManagerRemoveDecal.
-But once you create a decal there isn't any scripted way to modify it.

A solution I was thinking on use is to just keep deleting old decals and create a new one in the new position but a problem appeared as the ID of the decal keeps increasing making the c++ internal array of decals bigger.
I fear that may end as a memory leak so I decided to add an edit function.

This function imitates how proyectedshadow works so it's quite standard.
The math at the start is copied from the one used when you create a decal (DecalDataFile::addDecal) to change from the user friendly F32 rotAroundNormal to the internal Point3F tangent.
The variables of a decal are defined as public so the change is quite direct.

I decided for position, normal, rotation and size to be at the same function so it's kind of a long list of variables but it's quite similar to decalManagerAddDecal so it shouldn't be very confusing.

-How to test-
Play the desert mission of a full template and while the player is standing in the sand (this way raycast isn't needed) type in the console:
$decaltest=decalManagerAddDecal(LocalClientConnection.player.position,"0.0 0.0 1.0","0.0","1.0","ScorchRXDecal",true);

Now move the player away from the mark and type to test:
decalManagerEditDecal( $decaltest , LocalClientConnection.player.position , "0.0 0.0 1.0" , "0.0" , "1.0");

The ScorchRXDecal will move without increasing the decal ID. It returns true as there is a decal with that ID.

You can still use to remove the decal:
decalManagerRemoveDecal($decaltest);

And the decal will just be removed. Trying to edit the removed decal will do nothing and return false.