### PR TITLE
addresses https://github.com/GarageGames/Torque3D/issues/1537 via the…

### DIFF
--- a/Engine/source/lighting/advanced/glsl/deferredShadingFeaturesGLSL.cpp
+++ b/Engine/source/lighting/advanced/glsl/deferredShadingFeaturesGLSL.cpp
@@ -163,8 +163,8 @@ void DeferredSpecVarsGLSL::processPix( Vector<ShaderComponent*> &componentList, 
    MultiLine *meta = new MultiLine;
    //matinfo.g slot reserved for AO later
    meta->addStatement(new GenOp("   @.g = 1.0;\r\n", material));
-   meta->addStatement(new GenOp("   @.b = @/128;\r\n", material, specStrength));
-   meta->addStatement(new GenOp("   @.a = @/5;\r\n", material, specPower));
+   meta->addStatement(new GenOp("   @.a = @/128;\r\n", material, specPower));
+   meta->addStatement(new GenOp("   @.b = @/5;\r\n", material, specStrength));
    output = meta;
 }
 

--- a/Engine/source/lighting/advanced/hlsl/deferredShadingFeaturesHLSL.cpp
+++ b/Engine/source/lighting/advanced/hlsl/deferredShadingFeaturesHLSL.cpp
@@ -160,8 +160,8 @@ void DeferredSpecVarsHLSL::processPix( Vector<ShaderComponent*> &componentList, 
    MultiLine * meta = new MultiLine;
    //matinfo.g slot reserved for AO later
    meta->addStatement(new GenOp("   @.g = 1.0;\r\n", material));
-   meta->addStatement(new GenOp("   @.b = @/128;\r\n", material, specStrength));
-   meta->addStatement(new GenOp("   @.a = @/5;\r\n", material, specPower));
+   meta->addStatement(new GenOp("   @.a = @/128;\r\n", material, specPower));
+   meta->addStatement(new GenOp("   @.b = @/5;\r\n", material, specStrength));
    output = meta;
 }
 

--- a/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
@@ -1856,7 +1856,7 @@ void ReflectCubeFeatGLSL::processPix(  Vector<ShaderComponent*> &componentList,
       if (fd.features[MFT_DeferredSpecMap])
          texCube = new GenOp("textureLod(  @, @, (@.a*5) )", cubeMap, reflectVec, matinfo);
       else
-         texCube = new GenOp("textureLod(  @, @, (@.a/4) )", cubeMap, reflectVec, matinfo);
+         texCube = new GenOp("textureLod(  @, @, ((1.0-@.a)*6) )", cubeMap, reflectVec, matinfo);
    }
    else if(glossColor) //failing that, rtry and find color data
       texCube = new GenOp("textureLod( @, @, @.a*5)", cubeMap, reflectVec, glossColor);
@@ -1896,7 +1896,7 @@ void ReflectCubeFeatGLSL::processPix(  Vector<ShaderComponent*> &componentList,
       if (fd.features[MFT_DeferredSpecMap])
          meta->addStatement(new GenOp("   @.rgb = lerp( @.rgb, (@).rgb, (@.b));\r\n", targ, targ, texCube, lerpVal));
       else
-         meta->addStatement(new GenOp("   @.rgb = lerp( @.rgb, (@).rgb, (@.b*128/5));\r\n", targ, targ, texCube, lerpVal));
+         meta->addStatement(new GenOp("   @.rgb = lerp( @.rgb, (@).rgb, (@.b));\r\n", targ, targ, texCube, lerpVal));
    }
    else
         meta->addStatement( new GenOp( "   @;\r\n", assignColor( texCube, blendOp, lerpVal ) ) );         

--- a/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
@@ -1857,7 +1857,7 @@ void ReflectCubeFeatHLSL::processPix(  Vector<ShaderComponent*> &componentList,
       if (fd.features[MFT_DeferredSpecMap])
          texCube = new GenOp("texCUBElod( @, float4(@, (@.a*5)) )", cubeMap, reflectVec, matinfo);
       else
-         texCube = new GenOp("texCUBElod( @, float4(@, (@.a/4)) )", cubeMap, reflectVec, matinfo);
+         texCube = new GenOp("texCUBElod( @, float4(@, ((1.0-@.a)*6)) )", cubeMap, reflectVec, matinfo);
    }
    else
       if (glossColor) //failing that, rtry and find color data
@@ -1898,7 +1898,7 @@ void ReflectCubeFeatHLSL::processPix(  Vector<ShaderComponent*> &componentList,
       if (fd.features[MFT_DeferredSpecMap])
          meta->addStatement(new GenOp("   @.rgb = lerp( @.rgb, (@).rgb, (@.b));\r\n", targ, targ, texCube, lerpVal));
       else
-         meta->addStatement(new GenOp("   @.rgb = lerp( @.rgb, (@).rgb, (@.b*128/5));\r\n", targ, targ, texCube, lerpVal));
+         meta->addStatement(new GenOp("   @.rgb = lerp( @.rgb, (@).rgb, (@.b));\r\n", targ, targ, texCube, lerpVal));
    }
    else
        meta->addStatement( new GenOp( "   @;\r\n", assignColor( texCube, blendOp, lerpVal ) ) );         


### PR DESCRIPTION
… following:

https://github.com/GarageGames/Torque3D/blob/908be4818f7e5de23f2070d18ed4df0f4dfc5ddf/Engine/source/materials/materialDefinition.cpp#L261 denotes power as sharpness, reflected in the size/falloff of a highlight halo *

https://github.com/GarageGames/Torque3D/blob/908be4818f7e5de23f2070d18ed4df0f4dfc5ddf/Engine/source/materials/materialDefinition.cpp#L264 denotes strength as overall brightness of highlights. **

*and sharpness of reflection if using a cubemap.
**  reflected in cubemapped objects as also degree of 'reflection' vs diffuse/albedo coloration.