### PR TITLE
new method: ResetGFX();

### DIFF
--- a/Engine/source/gfx/gfxDevice.h
+++ b/Engine/source/gfx/gfxDevice.h
@@ -1192,4 +1192,9 @@ inline void GFXDevice::setVertexFormat( const GFXVertexFormat *vertexFormat )
 #define GFXAssertFatal(x, error)
 #endif
 
+DefineConsoleFunction(ResetGFX, void, (), , "")
+{
+   GFX->beginReset();
+}
+
 #endif // _GFXDEVICE_H_


### PR DESCRIPTION
exposes the GFX->beginReset(); method to script to allow folks to force the gbuffer to reinitialize (if, say a custom element is holding on to data in a buffer and it needs a cleaning, to name one example)