### PR TITLE
new method: ResetGFX();

### DIFF
--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -1329,3 +1329,8 @@ DefineEngineFunction( getBestHDRFormat, GFXFormat, (),,
 
    return format;
 }
+
+DefineConsoleFunction(ResetGFX, void, (), , "")
+{
+   GFX->beginReset();
+}

--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -1330,7 +1330,7 @@ DefineEngineFunction( getBestHDRFormat, GFXFormat, (),,
    return format;
 }
 
-DefineConsoleFunction(ResetGFX, void, (), , "")
+DefineConsoleFunction(ResetGFX, void, (), , "forces the gbuffer to be reinitialized in cases of improper/lack of buffer clears.")
 {
    GFX->beginReset();
 }


### PR DESCRIPTION
exposes the GFX->beginReset(); method to script to allow folks to force the gbuffer to reinitialize (if, say a custom element is holding on to data in a buffer and it needs a cleaning, to name one example)