### PR TITLE
Fix release build compile with MSVC 2015 (finally)

### DIFF
--- a/Tools/CMake/CMakeLists.txt
+++ b/Tools/CMake/CMakeLists.txt
@@ -20,6 +20,9 @@
 # IN THE SOFTWARE.
 # -----------------------------------------------------------------------------
 
+# JTH: We require CMake 3.1.4 for MSVC14 compatibility check
+cmake_minimum_required(VERSION 3.1.4)
+
 include(basics.cmake)
 
 setupVersionNumbers()

--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -541,6 +541,13 @@ if(WIN32)
    if(TORQUE_OPENGL)
       addLib(OpenGL32.lib)
    endif()
+		
+   # JTH: DXSDK is compiled with older runtime, and MSVC 2015+ is when __vsnprintf is undefined.
+   # This is a workaround by linking with the older legacy library functions.
+   # See this for more info: http://stackoverflow.com/a/34230122
+   if (MSVC14)
+      addLib(legacy_stdio_definitions.lib)
+   endif()
 endif()
 
 if(UNIX)


### PR DESCRIPTION
This fixes compiling a release build with MSVC 2015. The issue was that the DirectX runtime requires a function that is no longer present in MSVC 2015. However, Microsoft was nice enough to add a legacy compatibility library to continue using it, so linking against that fixes the linker errors and it works again.

However, we have to check for MSVC 2015, and to do that requires CMake 3.1.4 as that is when they added MSVC14 macro. If that is not okay, I can come up with a solution to keep backwards compatibility, but c'mon its 2016. They are at CMake 3.5.0 now :/