### PR TITLE
CMake SDL Option

### DIFF
--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -64,7 +64,6 @@ option(TORQUE_EXTENDED_MOVE "Extended move support" OFF)
 mark_as_advanced(TORQUE_EXTENDED_MOVE)
 if(WIN32)
 	option(TORQUE_SDL "Use SDL for window and input" OFF)
-	mark_as_advanced(TORQUE_SDL)
 else()
 	set(TORQUE_SDL ON) # we need sdl to work on Linux/Mac
 endif()


### PR DESCRIPTION
Makes the cmake SDL flag a regular, non-advanced option so that it's not hidden from the base setup on Windows.