### PR TITLE
GFXDynamicTextureProfile

### DIFF
--- a/Engine/source/gfx/gfxTextureProfile.cpp
+++ b/Engine/source/gfx/gfxTextureProfile.cpp
@@ -59,6 +59,10 @@ GFX_ImplementTextureProfile(GFXDefaultZTargetProfile,
                             GFXTextureProfile::DiffuseMap, 
                             GFXTextureProfile::PreserveSize | GFXTextureProfile::NoMipmap | GFXTextureProfile::ZTarget | GFXTextureProfile::NoDiscard, 
                             GFXTextureProfile::NONE);
+GFX_ImplementTextureProfile(GFXDynamicTextureProfile,
+                            GFXTextureProfile::DiffuseMap,
+                            GFXTextureProfile::Dynamic,
+                            GFXTextureProfile::NONE);
 
 //-----------------------------------------------------------------------------
 

--- a/Engine/source/gfx/gfxTextureProfile.h
+++ b/Engine/source/gfx/gfxTextureProfile.h
@@ -215,5 +215,7 @@ GFX_DeclareTextureProfile(GFXDefaultStaticDXT5nmProfile);
 GFX_DeclareTextureProfile(GFXSystemMemProfile);
 // Depth buffer texture
 GFX_DeclareTextureProfile(GFXDefaultZTargetProfile);
+// Dynamic Texure
+GFX_DeclareTextureProfile(GFXDynamicTextureProfile);
 
 #endif


### PR DESCRIPTION
Certain plugins were not playing nice on the directx end with updating rendertargets. Provides a profile for targets intended to be continuously updated.