### PR TITLE
Fixes the cmake blacklist filter it not using SDL

### DIFF
--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -196,14 +196,15 @@ addPath("${srcDir}/math")
 addPath("${srcDir}/math/util")
 addPath("${srcDir}/math/test")
 
+addPath("${srcDir}/platform")
 if(NOT TORQUE_SDL) 
    set(BLACKLIST "fileDialog.cpp" )
 endif()
-addPath("${srcDir}/platform")
+addPath("${srcDir}/platform/nativeDialogs")
 set(BLACKLIST "" )
 
 addPath("${srcDir}/cinterface")
-addPath("${srcDir}/platform/nativeDialogs")
+
 if( NOT TORQUE_DEDICATED )
     addPath("${srcDir}/platform/menus")
 endif()


### PR DESCRIPTION
Fixes the blacklist filter in the event we aren't using SDL to avoid including an unwanted file dialog codefile.