### PR TITLE
Rolls back OGL Projection correction.

### DIFF
--- a/Engine/source/math/mathUtils.cpp
+++ b/Engine/source/math/mathUtils.cpp
@@ -30,7 +30,6 @@
 #include "platform/profiler.h"
 #include "core/tAlgorithm.h"
 
-#include "gfx/gfxDevice.h"
 namespace MathUtils
 {
 
@@ -1450,8 +1449,6 @@ void makeProjection( MatrixF *outMatrix,
                      F32 farPlane,
                      bool gfxRotate )
 {
-   bool isGL = GFX->getAdapterType() == OpenGL;
-
    Point4F row;
    row.x = 2.0*nearPlane / (right-left);
    row.y = 0.0;
@@ -1467,13 +1464,13 @@ void makeProjection( MatrixF *outMatrix,
 
    row.x = (left+right) / (right-left);
    row.y = (top+bottom) / (top-bottom);
-   row.z = isGL ? -(farPlane + nearPlane) / (farPlane - nearPlane) : farPlane / (nearPlane - farPlane);
+   row.z = farPlane / (nearPlane - farPlane);
    row.w = -1.0;
    outMatrix->setRow( 2, row );
 
    row.x = 0.0;
    row.y = 0.0;
-   row.z = isGL ? 2 * nearPlane * farPlane / (nearPlane - farPlane)  : nearPlane * farPlane / (nearPlane - farPlane);
+   row.z = nearPlane * farPlane / (nearPlane - farPlane);
    row.w = 0.0;
    outMatrix->setRow( 3, row );
 
@@ -1494,8 +1491,6 @@ void makeOrthoProjection(  MatrixF *outMatrix,
                            F32 farPlane,
                            bool gfxRotate )
 {
-   bool isGL = GFX->getAdapterType() == OpenGL;
-
    Point4F row;
    row.x = 2.0f / (right - left);
    row.y = 0.0f;
@@ -1513,15 +1508,15 @@ void makeOrthoProjection(  MatrixF *outMatrix,
    row.y = 0.0f;
    row.w = 0.0f;
 
-   // This needs to be modified to work with OpenGL (d3d has 0..1 
-   // projection for z, vs -1..1 in OpenGL)
-   row.z = isGL ? 2.0f / (nearPlane - farPlane) : 1.0f / (nearPlane - farPlane);
+   //Unlike D3D, which has a 0-1 range, OpenGL uses a -1-1 range. 
+   //However, epoxy internally handles the swap, so the math here is the same for both APIs
+   row.z = 1.0f / (nearPlane - farPlane);
 
    outMatrix->setRow( 2, row );
 
    row.x = (left + right) / (left - right);
    row.y = (top + bottom) / (bottom - top);
-   row.z = isGL ? (nearPlane + farPlane) / (nearPlane - farPlane) : nearPlane / (nearPlane - farPlane);
+   row.z = nearPlane / (nearPlane - farPlane);
    row.w = 1.0f;
    outMatrix->setRow( 3, row );
 


### PR DESCRIPTION
Epoxy looks to handle the projection depth range so it behaves more like D3D, so this change was doubling up and causing problems.