### PR TITLE
Select camera when in material editor crashfix.

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -4889,7 +4889,7 @@ DefineEngineMethod( ShapeBase, getTargetCount, S32, (),,
 			obj = (ShapeBase*)obj->getClientObject();
 
       if (obj->getShapeInstance() != NULL)
-		   return obj->getShapeInstance()->getTargetCount();
+         return obj->getShapeInstance()->getTargetCount();
 	}
 
 	return -1;

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -4888,7 +4888,8 @@ DefineEngineMethod( ShapeBase, getTargetCount, S32, (),,
 		if ((ShapeBase*)obj->getClientObject())
 			obj = (ShapeBase*)obj->getClientObject();
 
-		return obj->getShapeInstance()->getTargetCount();
+      if (obj->getShapeInstance() != NULL)
+		   return obj->getShapeInstance()->getTargetCount();
 	}
 
 	return -1;

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -4881,18 +4881,18 @@ DefineEngineMethod( ShapeBase, getTargetCount, S32, (),,
    
    "@see getTargetName()\n")
 {
-	ShapeBase *obj = dynamic_cast< ShapeBase* > ( object );
-	if(obj)
-	{
-		// Try to use the client object (so we get the reskinned targets in the Material Editor)
-		if ((ShapeBase*)obj->getClientObject())
-			obj = (ShapeBase*)obj->getClientObject();
+   ShapeBase *obj = dynamic_cast< ShapeBase* > ( object );
+   if(obj)
+   {
+      // Try to use the client object (so we get the reskinned targets in the Material Editor)
+      if ((ShapeBase*)obj->getClientObject())
+         obj = (ShapeBase*)obj->getClientObject();
 
       if (obj->getShapeInstance() != NULL)
          return obj->getShapeInstance()->getTargetCount();
 	}
-
-	return -1;
+   
+   return -1;
 }
 
 DefineEngineMethod( ShapeBase, changeMaterial, void, ( const char* mapTo, Material* oldMat, Material* newMat ),,


### PR DESCRIPTION
When attempting to select a camera Object(so going into the editor, going into the freefloating camera and then back to the player camera and selecting the freefloating one) while the material editor was open, it would crash because it attempts to access the shapebase object's shapeInstance - but cameras don't have a shape.

This fixes it so it makes sure there's a shapeinstance before trying to get the material data.

Pertains to #1486