### PR TITLE
Fix axis check in Box3F::extend method

### DIFF
--- a/Engine/source/math/mBox.h
+++ b/Engine/source/math/mBox.h
@@ -415,7 +415,7 @@ inline void Box3F::extend(const Point3F & p)
 #define EXTEND_AXIS(AXIS)    \
 if (p.AXIS < minExtents.AXIS)       \
    minExtents.AXIS = p.AXIS;        \
-else if (p.AXIS > maxExtents.AXIS)  \
+if (p.AXIS > maxExtents.AXIS)  \
    maxExtents.AXIS = p.AXIS;
 
    EXTEND_AXIS(x)


### PR DESCRIPTION
Box3F::extend only checks the axis once. This is incorrect behaviour for an extend method as for example if we have a point which satisfies both `p.AXIS < minExtents.AXIS` and `p.AXIS > maxExtents.AXIS` only minExtent.AXIS will get set.

This pull request fixes the aforementioned issue.