### PR TITLE
Confirming argv[0] has a non-zero value

### DIFF
--- a/Engine/source/main/main.cpp
+++ b/Engine/source/main/main.cpp
@@ -240,6 +240,8 @@ int main(int argc, const char **argv)
    
    if(strlen(argv[0]) != 0) {
    int len = strlen(argv[0]);
+   } else {
+      return -1;
    }
    
    char *libName = new char[len+4]; // len + .so + NUL

--- a/Engine/source/main/main.cpp
+++ b/Engine/source/main/main.cpp
@@ -237,7 +237,11 @@ extern "C"
 int main(int argc, const char **argv)
 {
    // assume bin name is in argv[0]
+   
+   if(strlen(argv[0]) != 0) {
    int len = strlen(argv[0]);
+   }
+   
    char *libName = new char[len+4]; // len + .so + NUL
 
    strcpy(libName, argv[0]);


### PR DESCRIPTION
This little if statement just confirms that argv[0] got a non-zero value. Since as is a junk value can be concatenated with .so and dlopen will search for the file, this helps prevents that. It shouldn't slow down execution most the time too much, and should help in cases where something has gone wrong. The printf value could be changed to something others find more appropriate.  