### PR TITLE
Update coverPoint.cpp

### DIFF
--- a/Engine/source/navigation/coverPoint.cpp
+++ b/Engine/source/navigation/coverPoint.cpp
@@ -337,8 +337,8 @@ void CoverPoint::render(ObjectRenderInst *ri, SceneRenderState *state, BaseMatIn
    // Draw arrows to represent peek directions.
    if(peekLeft())
       GFX->getDrawUtil()->drawArrow(desc, Point3F(0, 0, height * 0.5), Point3F(-0.5, 0, height * 0.5), ColorI::GREEN);
-   if(peekRight())
+   else if(peekRight())
       GFX->getDrawUtil()->drawArrow(desc, Point3F(0, 0, height * 0.5), Point3F(0.5, 0, height * 0.5), ColorI::GREEN);
-   if(peekOver())
+   else if(peekOver())
       GFX->getDrawUtil()->drawArrow(desc, Point3F(0, 0, height * 0.5), Point3F(0, 0, height), ColorI::GREEN);
 }


### PR DESCRIPTION
Assuming you can't peek in more than one direction at a time, in cases where the peek direction isn't "over", this'll decrease the amount of checks performed. There were previously three if statements, the program would have to run through the other ones even if the first one was satisfied.