### PR TITLE
Fixes the drawUtil rendering of polyhedrons

### DIFF
--- a/Engine/source/gfx/gfxDrawUtil.cpp
+++ b/Engine/source/gfx/gfxDrawUtil.cpp
@@ -1015,7 +1015,7 @@ void GFXDrawUtil::_drawSolidPolyhedron( const GFXStateBlockDesc &desc, const Any
 
    // Allocate a temp buffer for the face indices.
 
-   const U32 numIndices = poly.getNumEdges() * 2;
+   const U32 numIndices = poly.getNumEdges() * 3;
    const U32 numPlanes = poly.getNumPlanes();
 
    GFXPrimitiveBufferHandle prims( mDevice, numIndices, 0, GFXBufferTypeVolatile );

--- a/Engine/source/math/mPolyhedron.impl.h
+++ b/Engine/source/math/mPolyhedron.impl.h
@@ -385,6 +385,8 @@ U32 PolyhedronImpl< Base >::extractFace( U32 plane, IndexType* outIndices, U32 m
    // so it should be sufficiently fast to just loop over the original
    // set.
 
+   U32 indexItr = 0;
+
    do 
    {
       // Add the vertex for the current edge.
@@ -392,7 +394,15 @@ U32 PolyhedronImpl< Base >::extractFace( U32 plane, IndexType* outIndices, U32 m
       if( idx >= maxOutIndices )
          return 0;
 
-      outIndices[ idx ++ ] = currentVertex;
+      ++indexItr;
+
+      if (indexItr >= 3)
+      {
+         outIndices[idx++] = firstEdge->vertex[0];
+         indexItr = 0;
+      }
+
+      outIndices[idx++] = currentVertex;
 
       // Look for next edge.
 


### PR DESCRIPTION
Fixes the drawUtil rendering of polyhedrons by correcting the index ordering to work with triangleStrip as opposed to Fan.