### PR TITLE
Fixes some bullet physics issues with the player class

### DIFF
--- a/Engine/source/T3D/physics/bullet/btPlayer.h
+++ b/Engine/source/T3D/physics/bullet/btPlayer.h
@@ -58,6 +58,10 @@ protected:
    F32 mOriginOffset;
 
    ///
+   F32 mSlopeAngle;
+   ///
+
+   ///
    F32 mStepHeight;
    ///
    void _releaseController();


### PR DESCRIPTION
When using bullet physics, it ensures the player does not move when the world sim is paused, as well as correcting the surface check when walking to test against the max run angle.