### PR TITLE
Static SDL and File Dialog Flag control

### DIFF
--- a/Engine/source/platform/nativeDialogs/fileDialog.cpp
+++ b/Engine/source/platform/nativeDialogs/fileDialog.cpp
@@ -29,7 +29,9 @@
 #include "console/consoleTypes.h"
 #include "platform/profiler.h"
 #include "console/engineAPI.h"
+#ifndef TORQUE_PLAYER
 #include <nfd.h>
+#endif
 #include "core/strings/stringUnit.h"
 #include "core/frameAllocator.h"
 
@@ -184,6 +186,11 @@ static const U32 convertUTF16toUTF8DoubleNULL(const UTF16 *unistring, UTF8  *out
 //
 bool FileDialog::Execute()
 {
+   //If we've flagged as TORQUE_PLAYER, we're going to be utlizing tools, so the file dialogs are not needed.
+   //As such, we'll just return out immediately skipping any file dialog functionality
+#ifdef TORQUE_PLAYER
+   return false;
+#else
    String strippedFilters;
 
    U32 filtersCount = StringUnit::getUnitCount(mData.mFilters, "|");
@@ -305,6 +312,7 @@ bool FileDialog::Execute()
 
    // Return success.
    return true;
+#endif
 }
 
 DefineEngineMethod(FileDialog, Execute, bool, (), ,

--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -358,48 +358,55 @@ endif()
 
 if(TORQUE_SDL)
     addPathRec("${srcDir}/windowManager/sdl")
-    addPathRec("${srcDir}/platformSDL")
     
     if(TORQUE_OPENGL)
       addPathRec("${srcDir}/gfx/gl/sdl")
+      addPathRec("${srcDir}/platformSDL")
+    else()
+      set(BLACKLIST "sdlPlatformGL.cpp")
+      addPathRec("${srcDir}/platformSDL")
+      set(BLACKLIST "")
     endif()
     
-    if(UNIX)
-       #set(CMAKE_SIZEOF_VOID_P 4) #force 32 bit
-       set(ENV{CFLAGS} "${CXX_FLAG32} -g -O3")
-       if("${TORQUE_ADDITIONAL_LINKER_FLAGS}" STREQUAL "")
-         set(ENV{LDFLAGS} "${CXX_FLAG32}")
-       else()
-         set(ENV{LDFLAGS} "${CXX_FLAG32} ${TORQUE_ADDITIONAL_LINKER_FLAGS}")
-       endif()
+    if(NOT TORQUE_PLAYER)
+        if(UNIX)
+            #set(CMAKE_SIZEOF_VOID_P 4) #force 32 bit
+            set(ENV{CFLAGS} "${CXX_FLAG32} -g -O3")
+            if("${TORQUE_ADDITIONAL_LINKER_FLAGS}" STREQUAL "")
+                set(ENV{LDFLAGS} "${CXX_FLAG32}")
+            else()
+                set(ENV{LDFLAGS} "${CXX_FLAG32} ${TORQUE_ADDITIONAL_LINKER_FLAGS}")
+            endif()
 
-       find_package(PkgConfig REQUIRED)
-       pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
+            find_package(PkgConfig REQUIRED)
+            pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
 
-       # Setup CMake to use GTK+, tell the compiler where to look for headers
-       # and to the linker where to look for libraries
-       include_directories(${GTK3_INCLUDE_DIRS})
-       link_directories(${GTK3_LIBRARY_DIRS})
+            # Setup CMake to use GTK+, tell the compiler where to look for headers
+            # and to the linker where to look for libraries
+            include_directories(${GTK3_INCLUDE_DIRS})
+            link_directories(${GTK3_LIBRARY_DIRS})
 
-       # Add other flags to the compiler
-       add_definitions(${GTK3_CFLAGS_OTHER})
+            # Add other flags to the compiler
+            add_definitions(${GTK3_CFLAGS_OTHER})
 
-       set(BLACKLIST "nfd_win.cpp"  )
-       addLib(nativeFileDialogs)
+            set(BLACKLIST "nfd_win.cpp"  )
+            addLib(nativeFileDialogs)
 
-       set(BLACKLIST ""  )
-       target_link_libraries(nativeFileDialogs ${GTK3_LIBRARIES})
- 	else()
- 	   set(BLACKLIST "nfd_gtk.c" )
- 	   addLib(nativeFileDialogs)
-       set(BLACKLIST ""  )
- 	   addLib(comctl32)	   
+            set(BLACKLIST ""  )
+            target_link_libraries(nativeFileDialogs ${GTK3_LIBRARIES})
+        else()
+            set(BLACKLIST "nfd_gtk.c" )
+            addLib(nativeFileDialogs)
+            set(BLACKLIST ""  )
+            addLib(comctl32)	   
+        endif()
     endif()
     
     #override and hide SDL2 cache variables
-    set(SDL_SHARED ON CACHE INTERNAL "" FORCE)
-    set(SDL_STATIC OFF CACHE INTERNAL "" FORCE)
+    set(SDL_SHARED OFF CACHE INTERNAL "" FORCE)
+    set(SDL_STATIC ON CACHE INTERNAL "" FORCE)
     add_subdirectory( ${libDir}/sdl ${CMAKE_CURRENT_BINARY_DIR}/sdl2)
+    link_directories( ${libDir}/sdl ${CMAKE_CURRENT_BINARY_DIR}/sdl2)
 endif()
 
 if(TORQUE_DEDICATED)
@@ -664,7 +671,7 @@ addInclude("${libDir}/libogg/include")
 addInclude("${libDir}/opcode")
 addInclude("${libDir}/collada/include")
 addInclude("${libDir}/collada/include/1.4")
-if(TORQUE_SDL)
+if(TORQUE_SDL AND NOT TORQUE_PLAYER)
    addInclude("${libDir}/nativeFileDialogs/include")
 endif()
 if(TORQUE_OPENGL)


### PR DESCRIPTION
Switches SDL to be statically linked, as well as having TORQUE_PLAYER a flag to control if the file dialogs are utilized.

The understanding being that if the build is set as intended to just be for playing, the toolchain won't be utilized, and thus the file dialogs are unneeded.
