### PR TITLE
fallback - dynamic shadow cache nuking (static refresh delay preserved)

### DIFF
--- a/Engine/source/lighting/shadowMap/lightShadowMap.cpp
+++ b/Engine/source/lighting/shadowMap/lightShadowMap.cpp
@@ -313,9 +313,11 @@ void LightShadowMap::render(  RenderPassManager* renderPass,
         return;
     mStaticRefreshTimer->reset();
 
+    /* TODO: find out why this is causing issue with translucent objects
     if (_dynamic && (mDynamicRefreshTimer->getElapsedMs() < getLightInfo()->getDynamicRefreshFreq()))
         return;
     mDynamicRefreshTimer->reset();
+    */
 
    mDebugTarget.setTexture( NULL );
    _render( renderPass, diffuseState );


### PR DESCRIPTION
worst case scenario fallback for if we can't track down why vector lighting seems determined to shift positions periodically based upon some influence by the dynamicrefreshfrequency rate