### PR TITLE
Fixed compile errors on linux (obvious programming faults).

### DIFF
--- a/Engine/lib/collada/src/dae/daeMetaGroup.cpp
+++ b/Engine/lib/collada/src/dae/daeMetaGroup.cpp
@@ -31,7 +31,7 @@ daeElement *daeMetaGroup::placeElement( daeElement *parent, daeElement *child, d
 	(void)offset;
 	daeString nm = child->getElementName();
 	if ( findChild( nm ) == NULL ) {
-		return false;
+		return NULL;
 	}
 	daeElementRef el;
 

--- a/Engine/lib/convexDecomp/NvHashMap.h
+++ b/Engine/lib/convexDecomp/NvHashMap.h
@@ -692,9 +692,6 @@ namespace CONVEX_DECOMPOSITION
 				mCapacity = t.mCapacity;
 
 				copy(mData,t.mData,t.mSize);
-				mSize = t.mSize;
-
-				return;
 			}
 			else
 			{
@@ -1521,7 +1518,7 @@ namespace CONVEX_DECOMPOSITION
 			NX_INLINE const Entry *find(const Key &k) const
 			{
 				if(!mHash.size())
-					return false;
+					return NULL;
 
 				NxU32 h = hash(k);
 				NxU32 index = mHash[h];


### PR DESCRIPTION
A bool is not a pointer and a reference has to be returned.