### PR TITLE
New object pointer cleanup

### DIFF
--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -871,6 +871,7 @@ breakContinue:
                {
                   Con::errorf(ConsoleLogEntry::General, "%s: Unable to instantiate non-SimObject class %s.", getFileLine(ip), (const char*)callArgv[1]);
                   delete object;
+                  currentNewObject = NULL;
                   ip = failJump;
                   break;
                }

--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -902,6 +902,7 @@ breakContinue:
 
                      // Fail to create the object.
                      delete object;
+                     currentNewObject = NULL;
                      ip = failJump;
                      break;
                   }
@@ -1016,6 +1017,7 @@ breakContinue:
                Con::errorf(ConsoleLogEntry::General, "%s: preload failed for %s: %s.", getFileLine(ip),
                            currentNewObject->getName(), errorStr.c_str());
                dataBlock->deleteObject();
+               currentNewObject = NULL;
                ip = failJump;
 			   
                // Prevent stack value corruption

--- a/Engine/source/core/stream/stream.cpp
+++ b/Engine/source/core/stream/stream.cpp
@@ -155,7 +155,7 @@ void Stream::readLongString(U32 maxStringLen, char *stringBuf)
 {
    U32 len;
    read(&len);
-   if(len > maxStringLen)
+   if(len >= maxStringLen)
    {
       m_streamStatus = IOError;
       return;


### PR DESCRIPTION
Adds some pointer cleanup if we bail out of creating a new object for whatever reason, mostly pertainig to datablocks.

If we exit out and delete our object, we were had the possibility of currentNewObject pointing to a bad memory address, potentially causing a crash. The cleanup of the pointer on the delete by setting it to NULL prevents that.