### PR TITLE
Linux vix shader fixes

### DIFF
--- a/Templates/Empty/game/shaders/common/lighting/advanced/gl/dbgColorBufferP.glsl
+++ b/Templates/Empty/game/shaders/common/lighting/advanced/gl/dbgColorBufferP.glsl
@@ -22,7 +22,6 @@
 
 #include "../../../gl/hlslCompat.glsl"
 #include "shadergen:/autogenConditioners.h"
-#include "../../../postfx/gl/postFx.glsl"
 
 uniform sampler2D colorBufferTex;
 

--- a/Templates/Empty/game/shaders/common/lighting/advanced/gl/dbgSpecMapVisualizeP.glsl
+++ b/Templates/Empty/game/shaders/common/lighting/advanced/gl/dbgSpecMapVisualizeP.glsl
@@ -21,7 +21,6 @@
 //-----------------------------------------------------------------------------
 #include "../../../gl/hlslCompat.glsl"
 #include "shadergen:/autogenConditioners.h"
-#include "../../../postfx/gl/postFx.glsl"
 
 uniform sampler2D matinfoTex;
 

--- a/Templates/Full/game/shaders/common/lighting/advanced/gl/dbgColorBufferP.glsl
+++ b/Templates/Full/game/shaders/common/lighting/advanced/gl/dbgColorBufferP.glsl
@@ -22,7 +22,6 @@
 
 #include "../../../gl/hlslCompat.glsl"
 #include "shadergen:/autogenConditioners.h"
-#include "../../../postfx/gl/postFx.glsl"
 
 uniform sampler2D colorBufferTex;
 

--- a/Templates/Full/game/shaders/common/lighting/advanced/gl/dbgSpecMapVisualizeP.glsl
+++ b/Templates/Full/game/shaders/common/lighting/advanced/gl/dbgSpecMapVisualizeP.glsl
@@ -21,7 +21,6 @@
 //-----------------------------------------------------------------------------
 #include "../../../gl/hlslCompat.glsl"
 #include "shadergen:/autogenConditioners.h"
-#include "../../../postfx/gl/postFx.glsl"
 
 uniform sampler2D matinfoTex;
 


### PR DESCRIPTION
These debug viz shaders don't compile linux side. Should be postFX.glsl and not postFx.glsl but that include is not even needed for these anyway ;)