### PR TITLE
Flips the i386 flag to __i386__

### DIFF
--- a/Engine/source/platform/types.gcc.h
+++ b/Engine/source/platform/types.gcc.h
@@ -103,7 +103,7 @@ typedef unsigned long  U64;
 #  define TORQUE_OS_STRING "MacOS X"
 #  define TORQUE_OS_MAC
 #  include "platform/types.mac.h"
-#  if defined(i386)
+#  if defined(__i386__)
 // Disabling ASM on XCode for shared library build code relocation issues
 // This could be reconfigured for static builds, though minimal impact
 //#     define TORQUE_SUPPORTS_NASM
@@ -115,7 +115,7 @@ typedef unsigned long  U64;
 
 //--------------------------------------
 // Identify the CPU
-#if defined(i386)
+#if defined(__i386__)
 #  define TORQUE_CPU_STRING "Intel x86"
 #  define TORQUE_CPU_X86
 #  define TORQUE_LITTLE_ENDIAN

--- a/Engine/source/platform/types.gcc.h
+++ b/Engine/source/platform/types.gcc.h
@@ -103,7 +103,7 @@ typedef unsigned long  U64;
 #  define TORQUE_OS_STRING "MacOS X"
 #  define TORQUE_OS_MAC
 #  include "platform/types.mac.h"
-#  if defined(__i386__)
+#  if defined(i386)
 // Disabling ASM on XCode for shared library build code relocation issues
 // This could be reconfigured for static builds, though minimal impact
 //#     define TORQUE_SUPPORTS_NASM
@@ -115,7 +115,7 @@ typedef unsigned long  U64;
 
 //--------------------------------------
 // Identify the CPU
-#if defined(__i386__)
+#if defined(i386) || defined(__i386) || defined(__i386__)
 #  define TORQUE_CPU_STRING "Intel x86"
 #  define TORQUE_CPU_X86
 #  define TORQUE_LITTLE_ENDIAN

--- a/Engine/source/platformX86UNIX/x86UNIXMath.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXMath.cpp
@@ -131,7 +131,7 @@ F32 Platform::getRandom()
 }
 
 
-#if defined(i386) || defined(__x86_64__)
+#if defined(__i386__) || defined(__x86_64__)
 
 U32 Platform::getMathControlState()
 {

--- a/Engine/source/platformX86UNIX/x86UNIXMath.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXMath.cpp
@@ -131,7 +131,7 @@ F32 Platform::getRandom()
 }
 
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(TORQUE_CPU_X86) || defined(__x86_64__)
 
 U32 Platform::getMathControlState()
 {


### PR DESCRIPTION
Flips the i386 preprocessor flag to use __i386__, which is apparently more standard.