### PR TITLE
Added a test physicsShape datablock

### DIFF
--- a/Templates/Full/game/art/datablocks/physicsShape.cs
+++ b/Templates/Full/game/art/datablocks/physicsShape.cs
@@ -20,48 +20,22 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-// Load up all datablocks.  This function is called when
-// a server is constructed.
-
-// Do the sounds first -- later scripts/datablocks may need them
-exec("./audioProfiles.cs");
-
-// LightFlareData and LightAnimData(s)
-exec("./lights.cs");
-
-// Do the various effects next -- later scripts/datablocks may need them
-exec("./particles.cs");
-exec("./environment.cs");
-
-exec("./triggers.cs");
-
-// Add a rigid example
-exec("./rigidShape.cs");
-
-// Add a physics example
-//exec("./physicsShape.cs");
-
-exec("./health.cs");
-
-// Load our supporting weapon datablocks, effects and such.  They must be
-// loaded before any weapon that uses them.
-exec("./weapon.cs");
-exec("./weapons/grenadefx.cs");
-exec("./weapons/rocketfx.cs");
-
-// Load the weapon datablocks
-exec("./weapons/Lurker.cs");
-exec("./weapons/Ryder.cs");
-exec("./weapons/ProxMine.cs");
-exec("./weapons/Turret.cs");
-
-exec("./teleporter.cs");
-
-// Load the default player datablocks
-exec("./player.cs");
-
-// Load our other player datablocks
-exec("./aiPlayer.cs");
-
-// Load the vehicle datablocks
-exec("./vehicles/cheetahCar.cs");
+// Physics shape need collision mesh or it won't loaded.
+// You need to have enabled a physics library to work. (Bullet or PhysX)
+datablock PhysicsShapeData( PSBouncingBoulder )
+{
+   category = "PhysicsShape";
+	
+   shapeName = "art/shapes/rocks/boulder.dts";
+   
+   mass = "1";
+   friction = "0";
+   staticFriction = "0";
+   restitution = "0";
+   linearDamping = "0";
+   angularDamping = "0";
+   linearSleepThreshold = "1";
+   angularSleepThreshold = "1";
+   waterDampingScale = "1";
+   buoyancyDensity = "0";
+};


### PR DESCRIPTION
Added a physicsShapeData datablock to use as template and shape test.

This will enable an easy way to add a physicsShape from datablock editor. 

If this test object don't exist, you can't add a new PhysicsShapeData, the new datablock need an object to copy values from. Unless you made the script by hand and then load to your level, but again you need to copies values from somewhere.. new peoples not known this values. This wil help to take down this boundaries.

1) Before you need to compile with bullet or physX
2) Uncomment from art/datablocks/datablockExec.cs
`//exec("./physicsShape.cs");`

Now you can add with a few clicks a physcisShape

1) Create
<img src="http://i.imgur.com/A2WRgQt.png"/>

2) Edit
<img src="http://i.imgur.com/Ka6Tg0L.png"/>

3) Add
<img src="http://i.imgur.com/7dbILS4.png"/>