### PR TITLE
Precipitation maxVBDrops correction.

### DIFF
--- a/Engine/source/T3D/fx/precipitation.cpp
+++ b/Engine/source/T3D/fx/precipitation.cpp
@@ -298,6 +298,7 @@ Precipitation::Precipitation()
    mSplashShaderCameraPosSC = NULL;
    mSplashShaderAmbientSC = NULL;
 
+   mMaxVBDrops = 5000;
 }
 
 Precipitation::~Precipitation()


### PR DESCRIPTION
Properly initiates the max number of drops per batch to avoid possible corruption issues.

Pertains to #1680