### PR TITLE
CMake support for VS_STARTUP_PROJECT

### DIFF
--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -554,6 +554,11 @@ finishExecutable()
 ###############################################################################
 ###############################################################################
 
+# Set Visual Studio startup project
+if((${CMAKE_VERSION} VERSION_EQUAL 3.6.0) OR (${CMAKE_VERSION} VERSION_GREATER 3.6.0) AND MSVC)
+set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${TORQUE_APP_NAME})
+endif()
+
 message(STATUS "writing ${projectSrcDir}/torqueConfig.h")
 CONFIGURE_FILE("${cmakeDir}/torqueConfig.h.in" "${projectSrcDir}/torqueConfig.h")
 


### PR DESCRIPTION
Support for the new VS_STARTUP_PROJECT directory property. This was added in CMake 3.6