### PR TITLE
accutex was left out of the copy constructor for TSRenderState.

### DIFF
--- a/Engine/source/ts/tsRenderState.cpp
+++ b/Engine/source/ts/tsRenderState.cpp
@@ -46,7 +46,8 @@ TSRenderState::TSRenderState( const TSRenderState &state )
       mNoRenderNonTranslucent( state.mNoRenderNonTranslucent ),
       mMaterialHint( state.mMaterialHint ),
       mCuller( state.mCuller ),
+      mUseOriginSort( state.mUseOriginSort ),
       mLightQuery( state.mLightQuery ),
-      mUseOriginSort( state.mUseOriginSort )
+      mAccuTex( state.mAccuTex )
 {
 }


### PR DESCRIPTION
 caused issues with https://github.com/GarageGames/Torque3D/pull/1711