### PR TITLE
short term LOD correction

### DIFF
--- a/Engine/source/ts/tsShapeInstance.cpp
+++ b/Engine/source/ts/tsShapeInstance.cpp
@@ -642,7 +642,7 @@ S32 TSShapeInstance::setDetailFromDistance( const SceneRenderState *state, F32 s
    // 4:3 aspect ratio, we've changed the reference value
    // to 300 to be more compatible with legacy shapes.
    //
-   const F32 pixelScale = (state->getViewport().extent.x / state->getViewport().extent.y);
+   const F32 pixelScale = (state->getViewport().extent.x / state->getViewport().extent.y)*2;
 
    // This is legacy DTS support for older "multires" based
    // meshes.  The original crossbow weapon uses this.


### PR DESCRIPTION
 to preserve current widescreen vs 4:3 windows while closer matching prior release results

Long Term we'll likely want to circle back around to https://github.com/Azaezel/Torque3D/commit/10f528280e205b273457b6ae40d35ba3fc95ea39