### PR TITLE
address banding

### DIFF
--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -1320,7 +1320,7 @@ DefineEngineFunction( getBestHDRFormat, GFXFormat, (),,
    // Figure out the best HDR format.  This is the smallest
    // format which supports blending and filtering.
    Vector<GFXFormat> formats;
-   formats.push_back( GFXFormatR10G10B10A2 );
+   //formats.push_back( GFXFormatR10G10B10A2 );
    formats.push_back( GFXFormatR16G16B16A16F );
    formats.push_back( GFXFormatR16G16B16A16 );    
    GFXFormat format = GFX->selectSupportedFormat(  &GFXDefaultRenderTargetProfile,

--- a/Templates/Empty/game/core/scripts/client/postFx/GammaPostFX.cs
+++ b/Templates/Empty/game/core/scripts/client/postFx/GammaPostFX.cs
@@ -55,6 +55,7 @@ singleton PostEffect( GammaPostFX )
    
    texture[0] = "$backBuffer";  
    texture[1] = $HDRPostFX::colorCorrectionRamp;  
+   targetFormat = "GFXFormatR16G16B16A16F";
 };
 
 function GammaPostFX::preProcess( %this )

--- a/Templates/Empty/game/core/scripts/client/renderManager.cs
+++ b/Templates/Empty/game/core/scripts/client/renderManager.cs
@@ -33,7 +33,7 @@ function initRenderManager()
    {
       enabled = "false";
       
-      format = "GFXFormatR16G16B16A16F";
+      format = "GFXFormatR8G8B8A8";
       depthFormat = "GFXFormatD24S8";
       aaLevel = 0; // -1 = match backbuffer
       
@@ -59,7 +59,7 @@ function initRenderManager()
    DiffuseRenderPassManager.addManager( new RenderMeshMgr(MeshBin)         { bintype = "Mesh"; renderOrder = 0.5; processAddOrder = 0.5; basicOnly = true; } );
    DiffuseRenderPassManager.addManager( new RenderImposterMgr(ImposterBin) { renderOrder = 0.56; processAddOrder = 0.56; } );
    DiffuseRenderPassManager.addManager( new RenderObjectMgr(ObjectBin)     { bintype = "Object"; renderOrder = 0.6; processAddOrder = 0.6; } );
-     
+
    DiffuseRenderPassManager.addManager( new RenderObjectMgr(ShadowBin)     { bintype = "Shadow"; renderOrder = 0.7; processAddOrder = 0.7; } );
    DiffuseRenderPassManager.addManager( new RenderMeshMgr(DecalRoadBin)    { bintype = "DecalRoad"; renderOrder = 0.8; processAddOrder = 0.8; } );
    DiffuseRenderPassManager.addManager( new RenderMeshMgr(DecalBin)        { bintype = "Decal"; renderOrder = 0.81; processAddOrder = 0.81; } );

--- a/Templates/Full/game/core/scripts/client/postFx/GammaPostFX.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/GammaPostFX.cs
@@ -55,6 +55,7 @@ singleton PostEffect( GammaPostFX )
    
    texture[0] = "$backBuffer";  
    texture[1] = $HDRPostFX::colorCorrectionRamp;  
+   targetFormat = "GFXFormatR16G16B16A16F";
 };
 
 function GammaPostFX::preProcess( %this )

--- a/Templates/Full/game/core/scripts/client/renderManager.cs
+++ b/Templates/Full/game/core/scripts/client/renderManager.cs
@@ -33,7 +33,7 @@ function initRenderManager()
    {
       enabled = "false";
       
-      format = "GFXFormatR16G16B16A16F";
+      format = "GFXFormatR8G8B8A8";
       depthFormat = "GFXFormatD24S8";
       aaLevel = 0; // -1 = match backbuffer
       


### PR DESCRIPTION
reverts the token (passtrhough) buffer back to 8888 from 16Fs
puts the gammaPostFX in 16 bit range to handle gamma input with fewe format-conversion based banding issues. 
Removes 10/2 from getBestHDRFormat to kill another source of conflict.