### PR TITLE
Removes the unnecessary include of altbase in nativefiledialogs

### DIFF
--- a/Engine/lib/nativeFileDialogs/nfd_win.cpp
+++ b/Engine/lib/nativeFileDialogs/nfd_win.cpp
@@ -13,7 +13,6 @@
 #include <wchar.h>
 #include <stdio.h>
 #include <assert.h>
-#include <atlbase.h>
 #include <windows.h>
 #include <ShObjIdl.h>
 


### PR DESCRIPTION
Removes the unnecessary include of altbase in nativefiledialogs, which was causing problems with express versions of VS.