### PR TITLE
Fix load with DTS shapes introduced with HW skinning changes

### DIFF
--- a/Engine/source/ts/tsMesh.cpp
+++ b/Engine/source/ts/tsMesh.cpp
@@ -3429,8 +3429,8 @@ void TSBasicVertexFormat::addMeshRequirements(TSMesh *mesh)
    bool hasTexcoord2 = false;
    bool hasSkin = false;
 
-   hasColors = mesh->getHasColor() || (texCoordOffset != -1);
-   hasTexcoord2 = mesh->getHasTVert2() || (colorOffset != -1);
+   hasColors = mesh->getHasColor() || (colorOffset != -1);
+   hasTexcoord2 = mesh->getHasTVert2() || (texCoordOffset != -1);
    hasSkin = (mesh->getMeshType() == TSMesh::SkinMeshType) || (boneOffset != -1);
 
    S32 offset = sizeof(TSMesh::__TSMeshVertexBase);

--- a/Engine/source/ts/tsMesh.cpp
+++ b/Engine/source/ts/tsMesh.cpp
@@ -2606,7 +2606,7 @@ void TSMesh::disassemble()
    tsalloc.copyToBuffer32( (S32*)&mCenter, 3 );
    tsalloc.set32( (S32)mRadius );
 
-   bool shouldMakeEditable = TSShape::smVersion < 27;
+   bool shouldMakeEditable = TSShape::smVersion < 27 || mVertSize == 0;
 
    // Re-create the vectors
    if (shouldMakeEditable)

--- a/Engine/source/ts/tsMesh.cpp
+++ b/Engine/source/ts/tsMesh.cpp
@@ -2799,6 +2799,18 @@ void TSSkinMesh::assemble( bool skip )
          batchData.initialNorms.set((Point3F*)ptr32, numVerts);
          encodedNorms.set(NULL, 0);
       }
+
+      // Sometimes we'll have a mesh with 0 verts but initialVerts is set,
+      // so set these accordingly
+      if (verts.size() == 0)
+      {
+         verts = batchData.initialVerts;
+      }
+
+      if (norms.size() == 0)
+      {
+         norms = batchData.initialNorms;
+      }
    }
    else
    {

--- a/Engine/source/ts/tsShape.h
+++ b/Engine/source/ts/tsShape.h
@@ -413,6 +413,7 @@ class TSShape
    GFXPrimitiveBufferHandle mShapeVertexIndices;
 
    bool mSequencesConstructed;
+   bool mNeedReinit;
 
 
    // shape class has few methods --
@@ -427,7 +428,10 @@ class TSShape
    bool preloadMaterialList(const Torque::Path &path); ///< called to preload and validate the materials in the mat list
 
    void setupBillboardDetails( const String &cachePath );
-   
+
+   /// Inits object list (no geometry buffers)
+   void initObjects();
+
    /// Initializes the main vertex buffer
    void initVertexBuffers();
 
@@ -557,8 +561,6 @@ class TSShape
 
    const GFXVertexFormat* getVertexFormat() const { return &mVertexFormat; }
 
-   bool needsBufferUpdate();
-
    /// @}
 
    /// @name Alpha Transitions
@@ -685,6 +687,10 @@ class TSShape
 
    bool setSequenceBlend(const String& seqName, bool blend, const String& blendRefSeqName, S32 blendRefFrame);
    bool setSequenceGroundSpeed(const String& seqName, const Point3F& trans, const Point3F& rot);
+
+   void makeEditable();
+   bool needsReinit();
+   bool needsBufferUpdate();
    /// @}
 };
 

--- a/Engine/source/ts/tsShapeConstruct.h
+++ b/Engine/source/ts/tsShapeConstruct.h
@@ -246,6 +246,7 @@ public:
 
    TSShape*                mShape;        // Edited shape; NULL while not loaded; not a Resource<TSShape> as we don't want it to prevent from unloading.
    ColladaUtils::ImportOptions   mOptions;
+   bool mLoadingShape;
 
 public:
 
@@ -261,6 +262,7 @@ public:
    bool onAdd();
 
    void onScriptChanged(const Torque::Path& path);
+   void onActionPerformed();
 
    bool writeField(StringTableEntry fieldname, const char *value);
    void writeChangeSet();
@@ -383,8 +385,16 @@ typedef domUpAxisType TSShapeConstructorUpAxis;
 typedef ColladaUtils::ImportOptions::eLodType TSShapeConstructorLodType;
 
 DefineEnumType( TSShapeConstructorUpAxis );
-DefineEnumType( TSShapeConstructorLodType );
+DefineEnumType(TSShapeConstructorLodType);
 
+class TSShapeConstructorMethodActionCallback
+{
+   TSShapeConstructor* mObject;
+
+public:
+   TSShapeConstructorMethodActionCallback(TSShapeConstructor *object) : mObject(object) { ; }
+   ~TSShapeConstructorMethodActionCallback() { mObject->onActionPerformed(); }
+};
 
 /* This macro simplifies the definition of a TSShapeConstructor API method. It
    wraps the actual EngineMethod definition and automatically calls the real
@@ -403,6 +413,7 @@ DefineEnumType( TSShapeConstructorLodType );
          Con::errorf( "TSShapeConstructor::" #name " - shape not loaded" );                     \
          return defRet;                                                                         \
       }                                                                                         \
+      TSShapeConstructorMethodActionCallback actionCallback(object);                            \
       return object->name rawArgs ;                                                             \
    }                                                                                            \
    /* Define the real TSShapeConstructor method */                                              \

--- a/Engine/source/ts/tsShapeEdit.cpp
+++ b/Engine/source/ts/tsShapeEdit.cpp
@@ -435,6 +435,9 @@ bool TSShape::addNode(const String& name, const String& parentName, const Point3
       }
    }
 
+   // Need to make everything editable since node indexes etc will change
+   makeEditable();
+
    // Insert node at the end of the subshape
    S32 subShapeIndex = (parentIndex >= 0) ? getSubShapeForNode(parentIndex) : 0;
    S32 nodeIndex = subShapeNumNodes[subShapeIndex];
@@ -493,8 +496,7 @@ bool TSShape::addNode(const String& name, const String& parentName, const Point3
       }
    }
 
-   // Re-initialise the shape
-   init();
+   initObjects();
 
    return true;
 }
@@ -547,6 +549,9 @@ bool TSShape::removeNode(const String& name)
          "will be reassigned to the node's parent ('%s')", name.c_str(), nodeObjects.size(),
          ((nodeParentIndex >= 0) ? getName(nodes[nodeParentIndex].nameIndex).c_str() : "null"));
    }
+
+   // Need to make everything editable since node indexes etc will change
+   makeEditable();
 
    // Update animation sequences
    for (S32 iSeq = 0; iSeq < sequences.size(); iSeq++)
@@ -626,8 +631,7 @@ bool TSShape::removeNode(const String& name)
    // Remove the sequence name if it is no longer in use
    removeName(name);
 
-   // Re-initialise the shape
-   init();
+   initObjects();
 
    return true;
 }
@@ -855,6 +859,9 @@ bool TSShape::removeObject(const String& name)
       return false;
    }
 
+   // Need to make everything editable since node indexes etc will change
+   makeEditable();
+
    // Destroy all meshes in the object
    TSShape::Object& obj = objects[objIndex];
    while ( obj.numMeshes )
@@ -893,14 +900,7 @@ bool TSShape::removeObject(const String& name)
    // Update smallest visible detail
    updateSmallestVisibleDL();
 
-   // Ensure shape is dirty
-   if (meshes[0])
-   {
-      meshes[0]->makeEditable();
-   }
-
-   // Re-initialise the shape
-   init();
+   initObjects();
 
    return true;
 }
@@ -960,6 +960,9 @@ bool TSShape::addMesh(TSMesh* mesh, const String& meshName)
 { 
    // Ensure mesh is in editable state
    mesh->makeEditable();
+
+   // Need to make everything editable since node indexes etc will change
+   makeEditable();
 
    // Determine the object name and detail size from the mesh name
    S32 detailSize = 999;
@@ -1049,8 +1052,7 @@ bool TSShape::addMesh(TSMesh* mesh, const String& meshName)
       }
    }
 
-   // Re-initialise the shape
-   init();
+   initObjects();
 
    return true;
 }
@@ -1140,6 +1142,9 @@ bool TSShape::setMeshSize(const String& meshName, S32 size)
       return false;
    }
 
+   // Need to make everything editable since node indexes etc will change
+   makeEditable();
+
    // Remove the mesh from the object, but don't destroy it
    TSShape::Object& obj = objects[objIndex];
    TSMesh* mesh = meshes[obj.startMeshIndex + meshIndex];
@@ -1151,8 +1156,7 @@ bool TSShape::setMeshSize(const String& meshName, S32 size)
    // Update smallest visible detail
    updateSmallestVisibleDL();
 
-   // Re-initialise the shape
-   init();
+   initObjects();
 
    return true;
 }
@@ -1167,6 +1171,9 @@ bool TSShape::removeMesh(const String& meshName)
       return false;
    }
 
+   // Need to make everything editable since node indexes etc will change
+   makeEditable();
+
    // Destroy and remove the mesh
    TSShape::Object& obj = objects[objIndex];
    destructInPlace(meshes[obj.startMeshIndex + meshIndex]);
@@ -1179,8 +1186,7 @@ bool TSShape::removeMesh(const String& meshName)
    // Update smallest visible detail
    updateSmallestVisibleDL();
 
-   // Re-initialise the shape
-   init();
+   initObjects();
 
    return true;
 }
@@ -1294,8 +1300,8 @@ S32 TSShape::setDetailSize(S32 oldSize, S32 newSize)
    // Update smallest visible detail
    updateSmallestVisibleDL();
 
-   // Re-initialise the shape
-   init();
+   // Nothing major, just reint object lists
+   initObjects();
 
    return newIndex;
 }
@@ -1309,6 +1315,9 @@ bool TSShape::removeDetail( S32 size )
       Con::errorf( "TSShape::removeDetail: Invalid detail index (%d)", dl );
       return false;
    }
+
+   // Need to make everything editable since node indexes etc will change
+   makeEditable();
 
    // Destroy and remove each mesh in the detail level
    for ( S32 objIndex = objects.size()-1; objIndex >= 0; objIndex-- )
@@ -1339,17 +1348,10 @@ bool TSShape::removeDetail( S32 size )
       billboardDetails.erase( dl );
    }
 
-   // Ensure shape is dirty
-   if (meshes[0])
-   {
-      meshes[0]->makeEditable();
-   }
-
    // Update smallest visible detail
    updateSmallestVisibleDL();
 
-   // Re-initialise the shape
-   init();
+   initObjects();
 
    return true;
 }
@@ -2115,7 +2117,7 @@ bool TSShape::setSequenceGroundSpeed(const String& seqName, const Point3F& trans
 
    // Fixup ground frame indices
    seq.numGroundFrames += frameAdjust;
-   for (S32 i = seqIndex+1; i < sequences.size(); i++)
+   for (S32 i = seqIndex + 1; i < sequences.size(); i++)
       sequences[i].firstGroundFrame += frameAdjust;
 
    // Generate the ground-frames
@@ -2139,4 +2141,26 @@ bool TSShape::setSequenceGroundSpeed(const String& seqName, const Point3F& trans
    seq.flags |= TSShape::MakePath;
 
    return true;
+}
+
+void TSShape::makeEditable()
+{
+   mNeedReinit = true;
+   if (mShapeVertexData.base == NULL)
+      return;
+
+   for (U32 i = 0; i < meshes.size(); i++)
+   {
+      if (meshes[i])
+      {
+         meshes[i]->makeEditable();
+      }
+   }
+
+   mShapeVertexData.set(NULL, 0);
+}
+
+bool TSShape::needsReinit()
+{
+   return mVertexSize == 0 || mShapeVertexData.base == NULL || mNeedReinit;
 }

--- a/Engine/source/ts/tsShapeEdit.cpp
+++ b/Engine/source/ts/tsShapeEdit.cpp
@@ -742,8 +742,25 @@ void TSShape::removeMeshFromObject(S32 objIndex, S32 meshIndex)
       {
          if (meshIndex < objects[i].numMeshes)
          {
-            meshes.erase(objects[i].startMeshIndex + meshIndex);
+            U32 idxToRemove = objects[i].startMeshIndex + meshIndex;
+            meshes.erase(idxToRemove);
             objects[i].numMeshes--;
+
+            // Clear invalid parent
+            for (U32 k = 0; k < meshes.size(); k++)
+            {
+               if (meshes[k] == NULL)
+                  continue;
+
+               if (meshes[k]->parentMesh == idxToRemove)
+               {
+                  meshes[k]->parentMesh = -1;
+               }
+               else if (meshes[k]->parentMesh > idxToRemove)
+               {
+                  meshes[k]->parentMesh--;
+               }
+            }
 
             for (S32 j = 0; j < objects.size(); j++)
             {
@@ -770,7 +787,25 @@ void TSShape::removeMeshFromObject(S32 objIndex, S32 meshIndex)
    S32 oldNumMeshes = obj.numMeshes;
    while (obj.numMeshes && !meshes[obj.startMeshIndex + obj.numMeshes - 1])
    {
-      meshes.erase(obj.startMeshIndex + obj.numMeshes - 1);
+      U32 idxToRemove = obj.startMeshIndex + obj.numMeshes - 1;
+      meshes.erase(idxToRemove);
+
+      // Clear invalid parent
+      for (U32 k = 0; k < meshes.size(); k++)
+      {
+         if (meshes[k] == NULL)
+            continue;
+
+         if (meshes[k]->parentMesh == idxToRemove)
+         {
+            meshes[k]->parentMesh = -1;
+         }
+         else if (meshes[k]->parentMesh > idxToRemove)
+         {
+            meshes[k]->parentMesh--;
+         }
+      }
+
       obj.numMeshes--;
    }
 
@@ -857,6 +892,12 @@ bool TSShape::removeObject(const String& name)
 
    // Update smallest visible detail
    updateSmallestVisibleDL();
+
+   // Ensure shape is dirty
+   if (meshes[0])
+   {
+      meshes[0]->makeEditable();
+   }
 
    // Re-initialise the shape
    init();
@@ -1296,6 +1337,12 @@ bool TSShape::removeDetail( S32 size )
      }
      
       billboardDetails.erase( dl );
+   }
+
+   // Ensure shape is dirty
+   if (meshes[0])
+   {
+      meshes[0]->makeEditable();
    }
 
    // Update smallest visible detail

--- a/Engine/source/ts/tsShapeInstance.cpp
+++ b/Engine/source/ts/tsShapeInstance.cpp
@@ -169,6 +169,7 @@ void TSShapeInstance::buildInstanceData(TSShape * _shape, bool loadMaterials)
    // material list...
    mMaterialList = NULL;
    mOwnMaterialList = false;
+   mUseOwnBuffer = false;
 
    //
    mData = 0;
@@ -532,7 +533,7 @@ void TSShapeInstance::render( const TSRenderState &rdata, S32 dl, F32 intraDL )
    S32 end = rdata.isNoRenderTranslucent() ? mShape->subShapeFirstTranslucentObject[ss] : mShape->subShapeFirstObject[ss] + mShape->subShapeNumObjects[ss];
    TSVertexBufferHandle *realBuffer;
 
-   if (TSShape::smUseHardwareSkinning)
+   if (TSShape::smUseHardwareSkinning && !mUseOwnBuffer)
    {
       // For hardware skinning, just using the buffer associated with the shape will work fine
       realBuffer = &mShape->mShapeVertexBuffer;
@@ -893,3 +894,7 @@ bool TSShapeInstance::hasAccumulation()
    return result;
 }
 
+void TSShapeInstance::setUseOwnBuffer()
+{
+   mUseOwnBuffer = true;
+}

--- a/Engine/source/ts/tsShapeInstance.h
+++ b/Engine/source/ts/tsShapeInstance.h
@@ -279,6 +279,7 @@ protected:
    TSVertexBufferHandle mSoftwareVertexBuffer;
 
    bool            mOwnMaterialList; ///< Does this own the material list pointer?
+   bool            mUseOwnBuffer; ///< Force using our own copy of the vertex buffer
 
    bool           mAlphaAlways;
    F32            mAlphaAlwaysValue;
@@ -341,6 +342,7 @@ protected:
    /// an optional feature set.
    void initMaterialList(  const FeatureSet *features = NULL );
 
+   void setUseOwnBuffer();
    bool ownMaterialList() const { return mOwnMaterialList; }
 
    /// Get the number of material targets in this shape instance


### PR DESCRIPTION
Due to a few typos and bad edge cases, meshes which use the following wont load correctly with the HW skinning changes:

- Secondary UV coords
- Colors
- Parented meshes combined with removed meshes
- Loading meshes using a 64bit memory address


This PR fixes this problem.