### PR TITLE
Revert TORQUE_CPU_X64 changes to oggTheoraDecoder

### DIFF
--- a/Engine/source/core/ogg/oggTheoraDecoder.cpp
+++ b/Engine/source/core/ogg/oggTheoraDecoder.cpp
@@ -285,7 +285,7 @@ U32 OggTheoraDecoder::read( OggTheoraFrame** buffer, U32 num )
       
       // Transcode the packet.
       
-      #if ( defined( TORQUE_COMPILER_GCC ) || defined( TORQUE_COMPILER_VISUALC ) ) && (defined( TORQUE_CPU_X86 ) || defined( TORQUE_CPU_X64 ))      
+      #if ( defined( TORQUE_COMPILER_GCC ) || defined( TORQUE_COMPILER_VISUALC ) ) && (defined( TORQUE_CPU_X86 ) )      
       if(      ( mTranscoder == TRANSCODER_Auto || mTranscoder == TRANSCODER_SSE2420RGBA ) &&
                getDecoderPixelFormat() == PIXEL_FORMAT_420 &&
                Platform::SystemInfo.processor.properties & CPU_PROP_SSE2 &&
@@ -419,7 +419,7 @@ void OggTheoraDecoder::_transcode( th_ycbcr_buffer ycbcr, U8* buffer, const U32 
 }
 
 //-----------------------------------------------------------------------------
-#if (defined( TORQUE_CPU_X86 ) || defined( TORQUE_CPU_X64 ))
+#if defined( TORQUE_CPU_X86 )
 void OggTheoraDecoder::_transcode420toRGBA_SSE2( th_ycbcr_buffer ycbcr, U8* buffer, U32 width, U32 height, U32 pitch )
 {
    AssertFatal( width % 2 == 0, "OggTheoraDecoder::_transcode420toRGBA_SSE2() - width must be multiple of 2" );
@@ -559,7 +559,7 @@ void OggTheoraDecoder::_transcode420toRGBA_SSE2( th_ycbcr_buffer ycbcr, U8* buff
          jnz hloop
    };
    
-   #elif defined( TORQUE_COMPILER_GCC ) && (defined( TORQUE_CPU_X86 )  || defined( TORQUE_CPU_X64 ))
+   #elif defined( TORQUE_COMPILER_GCC ) && defined( TORQUE_CPU_X86 ) 
 
    asm(  "pushal\n"                                // Save all general-purpose registers.
          

--- a/Engine/source/core/ogg/oggTheoraDecoder.h
+++ b/Engine/source/core/ogg/oggTheoraDecoder.h
@@ -172,7 +172,7 @@ class OggTheoraDecoder : public OggDecoder,
       /// Generic transcoder going from any of the Y'CbCr pixel formats to
       /// any RGB format (that is supported by GFXFormatUtils).
       void _transcode( th_ycbcr_buffer ycbcr, U8* buffer, U32 width, U32 height );
-#if (defined( TORQUE_CPU_X86 ) || defined( TORQUE_CPU_X64 ))
+#if defined( TORQUE_CPU_X86 )
       /// Transcoder with fixed 4:2:0 to RGBA conversion using SSE2 assembly. Unused on 64 bit archetecture.
       void _transcode420toRGBA_SSE2( th_ycbcr_buffer ycbcr, U8* buffer, U32 width, U32 height, U32 pitch );
 #endif


### PR DESCRIPTION
Reverts changes to oggTheoraDecoder.cpp which prevent compiling and running on 64bit systems.