### PR TITLE
Fixes AbstractPolyList::addBox(). Complete each face with missing 2nd triangle.

### DIFF
--- a/Engine/source/collision/abstractPolyList.cpp
+++ b/Engine/source/collision/abstractPolyList.cpp
@@ -56,16 +56,23 @@ void AbstractPolyList::addBox(const Box3F &box, BaseMatInstance* material)
    pos.x += dx; addPoint(pos);
 
    for (S32 i = 0; i < 6; i++) {
-      begin(material, i);
       S32 v1 = base + PolyFace[i][0];
       S32 v2 = base + PolyFace[i][1];
       S32 v3 = base + PolyFace[i][2];
       S32 v4 = base + PolyFace[i][3];
+      // First triangle
+      begin(material, i);
       vertex(v1);
       vertex(v2);
       vertex(v3);
-      vertex(v4);
       plane(v1, v2, v3);
+      end();
+      // Second triangle
+      begin(material, i);
+      vertex(v3);
+      vertex(v4);
+      vertex(v1);
+      plane(v3, v4, v1);
       end();
    }
 }


### PR DESCRIPTION
Hi all,

This is a minefield, which is a class inherited from Trigger. 
![image](https://cloud.githubusercontent.com/assets/2324012/18708571/d9a0f9d2-7ffb-11e6-9e55-efdcec2d3ce9.png)

Ok, and because Military intelligence should work, enemies (Tanks) must avoid go across it, because it's his own minefield! Then I added the minefield to NavMesh. Then I realized that I had to add a buildPolyList function to my class, which uses AbstractPolyList::addBox().

And as you can see, the edges of  the box is not completely etched from the NavMesh.
Looking at AbstractPolyList::addBox() I saw that only add one triangle per face, so I fix it and that the result:

![image](https://cloud.githubusercontent.com/assets/2324012/18708845/330a837a-7ffd-11e6-8fc5-521ec8fb1d08.png)

With this PR it's added the second triangle to the face, but I can't say If this was originally made by design, or if breaks something else... 
