### PR TITLE
clang report: getPlanePointIndex wasn't returning a valid result in all cases.

### DIFF
--- a/Engine/source/math/mBoxBase.h
+++ b/Engine/source/math/mBoxBase.h
@@ -49,7 +49,8 @@ class BoxBase
          FarTopLeft,
          FarBottomLeft,
 
-         NUM_POINTS
+         NUM_POINTS,
+		 InvalidPoint = NUM_POINTS
       };
 
       /// Return the point index for the opposite corner of @a p.
@@ -192,8 +193,6 @@ class BoxBase
                   default: AssertFatal( false, "BoxBase::getPlanePointIndex - Invalid index" );
                }
                break;
-            default:
-               AssertFatal( false, "BoxBase::getPlanePointIndex - Invalid plane" );
             case BottomPlane:
                switch( i )
                {
@@ -204,6 +203,9 @@ class BoxBase
                   default: AssertFatal( false, "BoxBase::getPlanePointIndex - Invalid index" );
                }
                break;
+            default:
+               AssertFatal( false, "BoxBase::getPlanePointIndex - Invalid plane" );
+			   return InvalidPoint;
          }
       }
 


### PR DESCRIPTION
while this is an entirely unused method in the current codebase, since assertfatal is shortcircuited entirely for release builds, fed the returned point an invalid value to return for folks to check if they wish to make use of the method.