### PR TITLE
clang catch: boxBase's getPlanePointIndex method wasn't returning values in all cases.

### DIFF
--- a/Engine/source/math/mBoxBase.h
+++ b/Engine/source/math/mBoxBase.h
@@ -49,7 +49,8 @@ class BoxBase
          FarTopLeft,
          FarBottomLeft,
 
-         NUM_POINTS
+         NUM_POINTS,
+		 InvalidPoint = NUM_POINTS
       };
 
       /// Return the point index for the opposite corner of @a p.
@@ -192,8 +193,6 @@ class BoxBase
                   default: AssertFatal( false, "BoxBase::getPlanePointIndex - Invalid index" );
                }
                break;
-            default:
-               AssertFatal( false, "BoxBase::getPlanePointIndex - Invalid plane" );
             case BottomPlane:
                switch( i )
                {
@@ -204,7 +203,10 @@ class BoxBase
                   default: AssertFatal( false, "BoxBase::getPlanePointIndex - Invalid index" );
                }
                break;
+            default:
+               AssertFatal( false, "BoxBase::getPlanePointIndex - Invalid plane" );
          }
+        return InvalidPoint;
       }
 
       /// Indices for the edges of the box.


### PR DESCRIPTION
assertfatal doesn't do anything in release builds, so also added a failure enum.