### PR TITLE
Force enums using unsigned values to actually hard type to U32

### DIFF
--- a/Engine/source/T3D/gameBase/moveManager.h
+++ b/Engine/source/T3D/gameBase/moveManager.h
@@ -36,7 +36,12 @@ class BitStream;
 
 struct Move
 {
-   enum { ChecksumBits = 16, ChecksumMask = ((1<<ChecksumBits)-1), ChecksumMismatch = U32(-1) };
+   enum : U32 
+   { 
+      ChecksumBits = 16, 
+      ChecksumMask = ((1<<ChecksumBits)-1), 
+      ChecksumMismatch = U32(-1) 
+   };
 
    // packed storage rep, set in clamp
    S32 px, py, pz;

--- a/Engine/source/T3D/objectTypes.h
+++ b/Engine/source/T3D/objectTypes.h
@@ -151,7 +151,7 @@ enum SceneObjectTypes
    /// @}
 };
 
-enum SceneObjectTypeMasks
+enum SceneObjectTypeMasks : U32
 {
    STATIC_COLLISION_TYPEMASK = (StaticShapeObjectType |
    EntityObjectType),

--- a/Engine/source/console/consoleObject.h
+++ b/Engine/source/console/consoleObject.h
@@ -441,7 +441,7 @@ public:
    /// @see addGroup, endGroup
    /// @see addGroup, endGroup
    /// @see addDeprecatedField
-   enum ACRFieldTypes
+   enum ACRFieldTypes : U32
    {
       /// The first custom field type... all fields
       /// types greater or equal to this one are not

--- a/Engine/source/console/sim.h
+++ b/Engine/source/console/sim.h
@@ -61,7 +61,7 @@ typedef U32 SimObjectId;
 /// The RootGroupId is assigned to gRootGroup, in which most SimObjects
 /// are addded as child members. See simManager.cc for details, particularly
 /// Sim::initRoot() and following.
-enum SimObjectsConstants
+enum SimObjectsConstants : U32
 {
    DataBlockObjectIdFirst = 3,
    DataBlockObjectIdBitSize = 14,

--- a/Engine/source/core/stream/fileStream.h
+++ b/Engine/source/core/stream/fileStream.h
@@ -33,7 +33,7 @@
 class FileStream : public Stream
 {
 public:
-   enum
+   enum : U32
    {
       BUFFER_SIZE = 8 * 1024,       // this can be changed to anything appropriate [in k]
       BUFFER_INVALID = 0xffffffff   // file offsets must all be less than this

--- a/Engine/source/gfx/sim/debugDraw.h
+++ b/Engine/source/gfx/sim/debugDraw.h
@@ -148,7 +148,8 @@ public:
    /// Set the TTL for the last item we entered...
    ///
    /// Primitives default to lasting one frame (ie, ttl=0)
-   enum {
+   enum : U32
+   {
       DD_INFINITE = U32_MAX
    };
    // How long should this primitive be draw for, 0 = one frame, DD_INFINITE = draw forever

--- a/Engine/source/gui/controls/guiTextListCtrl.h
+++ b/Engine/source/gui/controls/guiTextListCtrl.h
@@ -48,7 +48,8 @@ class GuiTextListCtrl : public GuiArrayCtrl
       UP = 0,
       DOWN = 1
    };
-   enum {
+   enum : U32
+   {
       InvalidId = 0xFFFFFFFF
    };
    Vector<S32> mColumnOffsets;

--- a/Engine/source/math/mBoxBase.h
+++ b/Engine/source/math/mBoxBase.h
@@ -125,7 +125,7 @@ class BoxBase
          NUM_PLANES
       };
 
-      enum PlaneMasks
+      enum PlaneMasks : U32
       {
          PlaneMaskLeft     = ( 1 << LeftPlane ),
          PlaneMaskRight    = ( 1 << RightPlane ),

--- a/Engine/source/math/util/frustum.h
+++ b/Engine/source/math/util/frustum.h
@@ -118,7 +118,7 @@ struct FrustumData : public PolyhedronData
       };
 
       /// Used to mask out planes for testing.
-      enum 
+      enum : U32
       {
          PlaneMaskLeft     = ( 1 << PlaneLeft ),
          PlaneMaskRight    = ( 1 << PlaneRight ),

--- a/Engine/source/platform/platformMemory.cpp
+++ b/Engine/source/platform/platformMemory.cpp
@@ -53,7 +53,8 @@ void * gMemMutex = NULL;
 #undef new
 #endif
 
-enum MemConstants {
+enum MemConstants : U32
+{
    Allocated            = BIT(0),
    Array                = BIT(1),
    DebugFlag            = BIT(2),

--- a/Engine/source/scene/simPath.h
+++ b/Engine/source/scene/simPath.h
@@ -49,7 +49,8 @@ class Path : public SimGroup
    typedef SimGroup Parent;
 
   public:
-   enum {
+   enum : U32
+   {
       NoPathIndex = 0xFFFFFFFF
    };
 

--- a/Engine/source/scene/zones/sceneZoneSpaceManager.h
+++ b/Engine/source/scene/zones/sceneZoneSpaceManager.h
@@ -65,7 +65,7 @@ class SceneZoneSpaceManager
       ///   of time.
       typedef Signal< void( SceneZoneSpaceManager* ) > ZoningChangedSignal;
 
-      enum
+      enum : U32
       {
          /// Zone ID of the exterior zone.
          RootZoneId = 0,

--- a/Engine/source/sfx/sfxSoundscape.h
+++ b/Engine/source/sfx/sfxSoundscape.h
@@ -73,7 +73,7 @@ class SFXSoundscape
          FlagUnique        = BIT( 1 ),    ///< No other instance of this ambience on stack.
       };
       
-      enum DirtyBits
+      enum DirtyBits : U32
       {
          AmbienceDirty = BIT( 0 ),        ///< Associated ambience has changed.
          AllDirty = 0xFFFFFFFF

--- a/Engine/source/sim/netStringTable.h
+++ b/Engine/source/sim/netStringTable.h
@@ -44,7 +44,8 @@ class NetStringTable
    friend class RemoteCommandEvent;
 #endif
 
-   enum Constants {
+   enum Constants : U32
+   {
       InitialSize = 16,
       InvalidEntry = 0xFFFFFFFF,
       HashTableSize = 2128,

--- a/Engine/source/terrain/terrRender.h
+++ b/Engine/source/terrain/terrRender.h
@@ -27,7 +27,7 @@
 #include "terrain/terrData.h"
 #endif
 
-enum TerrConstants 
+enum TerrConstants : U32
 {
    MaxClipPlanes       = 8, ///< left, right, top, bottom - don't need far tho...
    //MaxTerrainMaterials = 256,


### PR DESCRIPTION
Tweaks any enums that use uint_max values so that they have hard types to avoid any compiler kerfluffles with C++11 value narrowing, specifically pertaining to clang.