### PR TITLE
clang: The unit test suite doesn't play nice with -wundef

### DIFF
--- a/Tools/CMake/modules/module_testing.cmake
+++ b/Tools/CMake/modules/module_testing.cmake
@@ -20,7 +20,7 @@
 # IN THE SOFTWARE.
 # -----------------------------------------------------------------------------
 
-option(TORQUE_TESTING "Enable unit test module" ON)
+option(TORQUE_TESTING "Enable unit test module" OFF)
 mark_as_advanced(TORQUE_TESTING)
 
 if(TORQUE_TESTING)


### PR DESCRIPTION
(test for #if +uninitialized #defines)
leaving that as an option, but off by default to allow filtering through engine specific #defines for issues, rather than wading through the spam kicked up by the plugin.
