### PR TITLE
Fixes up some erroneous behavior with Simgroup parentage.

### DIFF
--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -4113,10 +4113,20 @@ void GuiTreeViewCtrl::onRenderCell(Point2I offset, Point2I cell, bool, bool )
       {
          if ( pGroup != NULL)
          {
-            if (item->isExpanded())
-               item->mIcon = SimGroup1;
+            //Check if we're a SceneObject, and pick the default icon as appropriate
+            
+            if (pObject->getClassName() != String("SimGroup"))
+            {
+               item->mIcon = Icon31;
+            }
             else
-               item->mIcon = SimGroup2;
+            {
+               //If we're purely a SimGroup, pick our icon.
+               if (item->isExpanded())
+                  item->mIcon = SimGroup1;
+               else
+                  item->mIcon = SimGroup2;
+            }
          }
          else
             item->mIcon = SimGroup2;

--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -3631,7 +3631,18 @@ void WorldEditor::makeSelectionPrefab( const char *filename )
       {
          for ( S32 i = 0; i < grp->size(); i++ )
             stack.push_back( grp->at(i) );
-         cleanup.push_back( grp );
+         
+         SceneObject* scn = dynamic_cast< SceneObject* >(grp);
+         if (scn)
+         {
+            if (Prefab::isValidChild(obj, true))
+               found.push_back(obj);
+         }
+         else
+         {
+            //Only push the cleanup of the group if it's ONLY a SimGroup.
+            cleanup.push_back(grp);
+         }
       }
       else
       {


### PR DESCRIPTION
Fixes Prefab creation handling of SceneObjects and SimGroups.
Fixes SceneObjects where the default icon incorrectly defaulted to the simgroup folder rather than the generic class object when the class has no specific class icon.
