### PR TITLE
Fixes prefabs in root dirs having extra folders in creator.

### DIFF
--- a/Templates/Empty/game/tools/worldEditor/scripts/editors/creator.ed.cs
+++ b/Templates/Empty/game/tools/worldEditor/scripts/editors/creator.ed.cs
@@ -486,7 +486,7 @@ function EWCreatorWindow::navigate( %this, %address )
          }
          
          // Is this file in the current folder?        
-         if ( stricmp( %pathFolders, %address ) == 0 )
+         if ( (%dirCount == 0 && %address $= "") || stricmp( %pathFolders, %address ) == 0 )
          {
             %this.addPrefabIcon( %fullPath );            
          }

--- a/Templates/Full/game/tools/worldEditor/scripts/editors/creator.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editors/creator.ed.cs
@@ -486,7 +486,7 @@ function EWCreatorWindow::navigate( %this, %address )
          }
          
          // Is this file in the current folder?        
-         if ( stricmp( %pathFolders, %address ) == 0 )
+         if ( (%dirCount == 0 && %address $= "") || stricmp( %pathFolders, %address ) == 0 )
          {
             %this.addPrefabIcon( %fullPath );            
          }


### PR DESCRIPTION
Fixes minor issue where if a prefab was in one of the root directories rather than further in the heirarchy, it would incorrectly add a folder of the prefab's name that contains the prefab in the creator menu's prefabs tab.
