### PR TITLE
Sanity check for if the GuiPlatformGenericMenuBar class

### DIFF
--- a/Templates/Empty/game/tools/gui/guiPlatformGenericMenubar.ed.cs
+++ b/Templates/Empty/game/tools/gui/guiPlatformGenericMenubar.ed.cs
@@ -1,1 +1,19 @@
-exec("./guiPlatformGenericMenubar.ed.gui");
+if(isClass(GuiPlatformGenericMenuBar))
+{
+   exec("./guiPlatformGenericMenubar.ed.gui");
+}
+else
+{
+   %guiContent = new GuiControl(PlatformGenericMenubar) {
+      profile = "GuiModelessDialogProfile";
+      
+      new GuiControl()
+      {
+         internalName = "menubar";
+         extent = "1024 20";
+         minExtent = "320 20";
+         horizSizing = "width";
+         profile = "GuiMenuBarProfile";
+      };
+   };
+}

--- a/Templates/Full/game/tools/gui/guiPlatformGenericMenubar.ed.cs
+++ b/Templates/Full/game/tools/gui/guiPlatformGenericMenubar.ed.cs
@@ -1,1 +1,19 @@
-exec("./guiPlatformGenericMenubar.ed.gui");
+if(isClass(GuiPlatformGenericMenuBar))
+{
+   exec("./guiPlatformGenericMenubar.ed.gui");
+}
+else
+{
+   %guiContent = new GuiControl(PlatformGenericMenubar) {
+      profile = "GuiModelessDialogProfile";
+      
+      new GuiControl()
+      {
+         internalName = "menubar";
+         extent = "1024 20";
+         minExtent = "320 20";
+         horizSizing = "width";
+         profile = "GuiMenuBarProfile";
+      };
+   };
+}


### PR DESCRIPTION
Sanity check for if the GuiPlatformGenericMenuBar class is valid before trying to load a menubar that uses it, in the event that SDL isn't enabled, or other similar circumstances.

Corrects issue #1745.