### PR TITLE
Adding depth option to the texture of guiOffscreenCanvas

### DIFF
--- a/Engine/source/gui/core/guiOffscreenCanvas.cpp
+++ b/Engine/source/gui/core/guiOffscreenCanvas.cpp
@@ -18,6 +18,7 @@ GuiOffscreenCanvas::GuiOffscreenCanvas()
    mTargetName = "offscreenCanvas";
    mTargetDirty = true;
    mDynamicTarget = false;
+   mUseDepth = false;
 }
 
 GuiOffscreenCanvas::~GuiOffscreenCanvas()
@@ -30,6 +31,7 @@ void GuiOffscreenCanvas::initPersistFields()
    addField( "targetFormat", TypeGFXFormat, Offset( mTargetFormat, GuiOffscreenCanvas ), "");
    addField( "targetName", TypeRealString, Offset( mTargetName, GuiOffscreenCanvas ), "");
    addField( "dynamicTarget", TypeBool, Offset( mDynamicTarget, GuiOffscreenCanvas ), "");
+   addField( "useDepth", TypeBool, Offset( mUseDepth, GuiOffscreenCanvas ), "");
 
    Parent::initPersistFields();
 }
@@ -70,6 +72,7 @@ void GuiOffscreenCanvas::onRemove()
 
    mTarget = NULL;
    mTargetTexture = NULL;
+   mTargetDepth = NULL;
 
    Parent::onRemove();
 }
@@ -89,6 +92,13 @@ void GuiOffscreenCanvas::_setupTargets()
       mTargetTexture.set( mTargetSize.x, mTargetSize.y, mTargetFormat, &GFXDefaultRenderTargetProfile, avar( "%s() - (line %d)", __FUNCTION__, __LINE__ ), 1, 0 );
    }
 
+   // Update depth if needed
+   if (mUseDepth && (!mTargetDepth.isValid() || mTargetSize != mTargetDepth.getWidthHeight()))
+   {
+      mTargetDepth.set( mTargetSize.x, mTargetSize.y, GFXFormatD24S8, &GFXDefaultZTargetProfile, avar( "%s() - (line %d)", __FUNCTION__, __LINE__ ), 1, 0 );
+      mTarget->attachTexture( GFXTextureTarget::RenderSlot(GFXTextureTarget::DepthStencil), mTargetDepth );
+   }
+
    mTarget->attachTexture( GFXTextureTarget::RenderSlot(GFXTextureTarget::Color0), mTargetTexture );
    mNamedTarget.setTexture(0, mTargetTexture);
 }
@@ -97,6 +107,7 @@ void GuiOffscreenCanvas::_teardownTargets()
 {
    mNamedTarget.release();
    mTargetTexture = NULL;
+   mTargetDepth = NULL;
    mTargetDirty = true;
 }
 

--- a/Engine/source/gui/core/guiOffscreenCanvas.h
+++ b/Engine/source/gui/core/guiOffscreenCanvas.h
@@ -56,6 +56,9 @@ protected:
 
    bool mTargetDirty;
    bool mDynamicTarget;
+   
+   bool mUseDepth;
+   GFXTexHandle mTargetDepth;
 
 public:
    static Vector<GuiOffscreenCanvas*> sList;


### PR DESCRIPTION
Related to: http://forums.torque3d.org/viewtopic.php?f=10&p=6964#p6964

These small changes fix the rendering in the named texture of a guiOffscreenCanvas with 3d views.
Without this change, the objects in the 3d view are copied as they're created and that causes depth issues (objects behind being rendered in front).

Creating the gui with the field "useDepth" as true enables the fix.
It's off by default so guiOffscreenCanvas that don't use 3d views or don't need the texture part won't get the extra workload of the fix.

-Example of its use-
Add these functions to a .cs script in a "Full" project and exec it:
`                                                  

       //createRearView(0);
       //createRearView(1);
       function createRearView(%depthtest)
       {
          if(!isObject(RearViewUpdater))
          {
             %tickObj = new ScriptTickObject(RearViewUpdater);
             %tickObj.setProcessTicks(true);
             MissionCleanup.add(%tickObj);
            
            %guiOffscreen = new GuiOffscreenCanvas() {
               targetSize = "300 300";
               targetFormat = "GFXFormatR8G8B8A8";
               targetName = "RearViewTexture";
               dynamicTarget = "1";
               useDepth = %depthtest; //this one to enable the depth fix
               numFences = "0";
               displayWindow = "1";
               position = "0 0";
               extent = "300 300";
               visible = "1";
               active = "1";
               
               new GameTSCtrl() {
                  cameraZRot = "180";
                  position = "0 0";
                  extent = "300 300";
               };
            };
            %guiOffscreen.cursorOff();
            
            %tickObj.guiOffCan = %guiOffscreen;
            
            %playGuiRearWindow = new GuiBitmapCtrl() {
               position = "100 100";
               extent = "150 150";
            };
            PlayGui.add(%playGuiRearWindow);
            
            %tickObj.miniWindow = %playGuiRearWindow;
         }
      }

      function RearViewUpdater::onInterpolateTick(%this, %delta)
      {
         (%this.miniWindow).setNamedTexture("RearViewTexture");
      }

      function RearViewUpdater::onRemove(%this)
      {
         (%this.miniWindow).delete();
         (%this.guiOffCan).delete();
      }
`

After that, start the desert level. If you add a few TSStatic and half-bury them in the terrain the fix will be shown better.

Now, use in the console:
`   createRearView(0);`

This will create a guiOffscreenCanvas with the fix disabled as its useDepth field is zero.

You'll see a small window showing the rear view of the soldier. This window has depth errors like objects not being correctly covered by the terrain.

Delete the window and the guiOffscreenCanvas with:
`   RearViewUpdater.delete();`

Finally use:
`   createRearView(1);`

to create a guiOffscreenCanvas with the fix enabled (useDepth field is true).

Now the window should show the objects being correctly rendered.

