### PR TITLE
Fix  for NavPath is not updated when navMesh has change. 

### DIFF
--- a/Engine/source/navigation/navMesh.cpp
+++ b/Engine/source/navigation/navMesh.cpp
@@ -838,7 +838,7 @@ void NavMesh::buildNextTile()
          ctx->stopTimer(RC_TIMER_TOTAL);
          if(getEventManager())
          {
-            String str = String::ToString("%d %.3f", getId(), ctx->getAccumulatedTime(RC_TIMER_TOTAL) / 1000.0f);
+            String str = String::ToString("%d", getId());
             getEventManager()->postEvent("NavMeshUpdate", str.c_str());
             setMaskBits(LoadFlag);
          }


### PR DESCRIPTION

It's not working because on onNavMeshUpdate the string comparation will never succeed, and will never call  call navpath::plan()

```
DefineEngineMethod(NavPath, onNavMeshUpdate, void, (const char *data),,
   "@brief Callback when this path's NavMesh is loaded or rebuilt.")
{
   if(object->mMesh && !dStrcmp(data, object->mMesh->getIdString()))
      object->plan();
}
```