### PR TITLE
re-enable face culling for the terrain

### DIFF
--- a/Engine/source/terrain/terrCellMaterial.cpp
+++ b/Engine/source/terrain/terrCellMaterial.cpp
@@ -152,11 +152,17 @@ void TerrainCellMaterial::_updateDefaultAnisotropy()
          } // for ( U32 m=0; m < pass.materials.size(); m++ )
 
          // Set the updated stateblock.
+         desc.setCullMode( GFXCullCCW );
          pass.stateBlock = GFX->createStateBlock( desc );
+
+         //reflection
+         desc.setCullMode( GFXCullCW );
+         pass.reflectionStateBlock = GFX->createStateBlock(desc);
 
          // Create the wireframe state blocks.
          GFXStateBlockDesc wireframe( desc );
          wireframe.fillMode = GFXFillWireframe;
+         wireframe.setCullMode( GFXCullCCW );
          pass.wireframeStateBlock = GFX->createStateBlock( wireframe );
 
       } // for ( U32 p=0; i < (*iter)->mPasses.size(); p++ )
@@ -668,15 +674,17 @@ bool TerrainCellMaterial::_createPass( Vector<MaterialInfo*> *materials,
    if ( prePassMat )
       desc.addDesc( RenderPrePassMgr::getOpaqueStenciWriteDesc( false ) );
 
-   // Shut off culling for prepass materials (reflection support).
-   if ( prePassMat )
-      desc.setCullMode( GFXCullNone );
+   desc.setCullMode( GFXCullCCW );
+   pass->stateBlock = GFX->createStateBlock(desc);
 
-   pass->stateBlock = GFX->createStateBlock( desc );
+   //reflection stateblock
+   desc.setCullMode( GFXCullCW );
+   pass->reflectionStateBlock = GFX->createStateBlock(desc);
 
    // Create the wireframe state blocks.
    GFXStateBlockDesc wireframe( desc );
    wireframe.fillMode = GFXFillWireframe;
+   wireframe.setCullMode( GFXCullCCW );
    pass->wireframeStateBlock = GFX->createStateBlock( wireframe );
 
    return true;
@@ -776,6 +784,8 @@ bool TerrainCellMaterial::setupPass(   const SceneRenderState *state,
 
    if ( sceneData.wireframe )
       GFX->setStateBlock( pass.wireframeStateBlock );
+   else if ( state->isReflectPass( ))
+      GFX->setStateBlock( pass.reflectionStateBlock );
    else
       GFX->setStateBlock( pass.stateBlock );
 

--- a/Engine/source/terrain/terrCellMaterial.h
+++ b/Engine/source/terrain/terrCellMaterial.h
@@ -108,6 +108,7 @@ protected:
 
       GFXStateBlockRef stateBlock;
       GFXStateBlockRef wireframeStateBlock;
+      GFXStateBlockRef reflectionStateBlock;
 
       GFXShaderConstHandle *modelViewProjConst;
       GFXShaderConstHandle *worldViewOnly;


### PR DESCRIPTION
This just re-enables face culling for the terrain that was disabled when deferred shading replaced deferred lighting. 