### PR TITLE
Change VS to use the default fp:precise

### DIFF
--- a/Tools/CMake/basics.cmake
+++ b/Tools/CMake/basics.cmake
@@ -365,7 +365,7 @@ if(WIN32)
     set(TORQUE_CXX_FLAGS_LIBS "/W0" CACHE TYPE STRING)
     mark_as_advanced(TORQUE_CXX_FLAGS_LIBS)
 
-    set(TORQUE_CXX_FLAGS_COMMON_DEFAULT "-DUNICODE -D_UNICODE -D_CRT_SECURE_NO_WARNINGS /MP /O2 /Ob2 /Oi /Ot /Oy /GT /Zi /W4 /nologo /GF /EHsc /GS- /Gy- /Qpar- /fp:fast /fp:except- /GR /Zc:wchar_t-" )
+    set(TORQUE_CXX_FLAGS_COMMON_DEFAULT "-DUNICODE -D_UNICODE -D_CRT_SECURE_NO_WARNINGS /MP /O2 /Ob2 /Oi /Ot /Oy /GT /Zi /W4 /nologo /GF /EHsc /GS- /Gy- /Qpar- /fp:precise /fp:except- /GR /Zc:wchar_t-" )
     if( TORQUE_CPU_X32 )
        set(TORQUE_CXX_FLAGS_COMMON_DEFAULT "${TORQUE_CXX_FLAGS_COMMON_DEFAULT} /arch:SSE2")
     endif()


### PR DESCRIPTION
Turns out Visual Studio 2015 is doing some aggressive optimizations that where not present in older versions of Visual Studio. Using fp:fast is causing slight floating point inaccuracies that eventually filter down and we end up getting rotations that are wrong and causing havoc when saving mission files. Changed the setting back to the default fp:precise 