### PR TITLE
fix SDL text events from generating a ~ key when opening the console

### DIFF
--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -486,6 +486,19 @@ void PlatformWindowSDL::_triggerKeyNotify(const SDL_Event& evt)
    {
       keyEvent.trigger(getWindowId(), torqueModifiers, inputAction, torqueKey);
       //Con::printf("Key %d : %d", tKey.sym, inputAction);
+
+      if (inputAction == IA_MAKE && SDL_IsTextInputActive())
+      {
+         // We have to check if we already have a first responder active.
+         // We don't want to type the character if it actually creates another responder!
+         if (mWindowInputGenerator->lastKeyWasGlobalActionMap())
+         {
+            // Turn off Text input, and the next frame turn it back on. This tells SDL
+            // to not generate a text event for this global action map key.
+            SDL_StopTextInput();
+            mOwningManager->updateSDLTextInputState(PlatformWindowManagerSDL::KeyboardInputState::TEXT_INPUT);
+         }
+      }
    }
 }
 

--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -607,8 +607,10 @@ const UTF16 *PlatformWindowSDL::getCurtainWindowClassName()
 void PlatformWindowSDL::setKeyboardTranslation(const bool enabled)
 {
    mEnableKeyboardTranslation = enabled;
-   if (mEnableKeyboardTranslation)
-      SDL_StartTextInput();
+
+   // Flag for update. Let SDL know what kind of input state we are changing to.
+   if (enabled)
+      mOwningManager->updateSDLTextInputState(PlatformWindowManagerSDL::KeyboardInputState::TEXT_INPUT);
    else
-      SDL_StopTextInput();
+      mOwningManager->updateSDLTextInputState(PlatformWindowManagerSDL::KeyboardInputState::RAW_INPUT);
 }

--- a/Engine/source/windowManager/sdl/sdlWindowMgr.h
+++ b/Engine/source/windowManager/sdl/sdlWindowMgr.h
@@ -34,6 +34,30 @@ class FileDialog; // TODO SDL REMOVE
 /// SDL2 implementation of the window manager interface.
 class PlatformWindowManagerSDL : public PlatformWindowManager
 {
+public:
+   /// An enum that holds an event loop frame of the state of the
+   /// keyboard for how the keyboard is interpreted inside of Torque.
+   ///
+   /// SDL has a concept of text editing events as well as raw input
+   /// events. Because of this, SDL needs notified whenever it needs
+   /// to fire text based events. SDL will continue firing raw input
+   /// events as well during this time.
+   ///
+   /// The reason why this was created is because we needed time to
+   /// transition between raw input to raw input + text based events.
+   /// If we take a raw input and notify SDL we wanted text during the
+   /// event loop, SDL will issue a text input event as well. This was
+   /// causing issues with the console, where the console key would be
+   /// appended to the console buffer upon opening it. We fix this by
+   /// delaying the notification to SDL until the event loop is complete.
+   enum class KeyboardInputState
+   {
+      NONE = 0,       /// < No state change during this event loop cycle.
+      TEXT_INPUT = 1, /// < We want to change to text based events & raw input.
+      RAW_INPUT = 2   /// < We only want raw input.
+   };
+
+protected:
    friend class PlatformWindowSDL;
    friend class FileDialog; // TODO SDL REMOVE
 
@@ -69,6 +93,10 @@ class PlatformWindowManagerSDL : public PlatformWindowManager
 
    SignalSlot<void()> mOnProcessSignalSlot;
 
+   /// The input state that will change whenever SDL needs notified.
+   /// After it is handled, it will return to state NONE.
+   KeyboardInputState mInputState;
+
 public:
    PlatformWindowManagerSDL();
    ~PlatformWindowManagerSDL();
@@ -100,6 +128,12 @@ public:
    virtual void raiseCurtain();
 
    virtual void setDisplayWindow(bool set) { mDisplayWindow = set; }
+
+   /// Stores the input state so that the event loop will fire a check if we need
+   /// to change how keyboard input is being handled.
+   /// @param state The state of the keyboard input, either being raw input or text
+   ///  based input.
+   void updateSDLTextInputState(KeyboardInputState state);
 };
 
 #endif

--- a/Engine/source/windowManager/windowInputGenerator.cpp
+++ b/Engine/source/windowManager/windowInputGenerator.cpp
@@ -39,7 +39,8 @@ WindowInputGenerator::WindowInputGenerator( PlatformWindow *window ) :
                                              mLastCursorPos(0,0),
                                              mClampToWindow(true),
                                              mFocused(false),
-                                             mPixelsPerMickey(1.0f)
+                                             mPixelsPerMickey(1.0f),
+                                             mLastPressWasGlobalActionMap(false)
 {
    AssertFatal(mWindow, "NULL PlatformWindow on WindowInputGenerator creation");
 
@@ -82,6 +83,9 @@ WindowInputGenerator::~WindowInputGenerator()
 //-----------------------------------------------------------------------------
 void WindowInputGenerator::generateInputEvent( InputEventInfo &inputEvent )
 {
+   // Reset last press being global
+   mLastPressWasGlobalActionMap = false;
+
    if (!mInputController)// || !mFocused)
       return;
 
@@ -102,7 +106,10 @@ void WindowInputGenerator::generateInputEvent( InputEventInfo &inputEvent )
 
    // Give the ActionMap first shot.
    if (ActionMap::handleEventGlobal(&inputEvent))
+   {
+      mLastPressWasGlobalActionMap = true;
       return;
+   }
 
    if (mInputController->processInputEvent(inputEvent))
       return;

--- a/Engine/source/windowManager/windowInputGenerator.h
+++ b/Engine/source/windowManager/windowInputGenerator.h
@@ -51,6 +51,9 @@ class WindowInputGenerator
       /// (one unit of mouse movement is a mickey) to units in the GUI.
       F32             mPixelsPerMickey;
 
+      /// This tells us if the last key we pressed was used from the global action map.
+      bool mLastPressWasGlobalActionMap;
+
       // Event Handlers
       void handleMouseButton(WindowId did, U32 modifier,  U32 action, U16 button);
       void handleMouseWheel (WindowId did, U32 modifier,  S32 wheelDeltaX, S32 wheelDeltaY);
@@ -82,6 +85,13 @@ class WindowInputGenerator
       /// Returns true if the given keypress event should be send as a raw keyboard
       /// event even if it maps to a character input event.
       bool wantAsKeyboardEvent( U32 modifiers, U32 key );
+
+      /// Tells us if the last key was used within the global action map.
+      /// @return true if the key was a global action map key, false otherwise.
+      /// @note Useful and currently used to tell if we just opened the console 
+      ///  by using the console key. Currently this is used to fix a bug in SDL
+      ///  but it is not limited to that use.
+      bool lastKeyWasGlobalActionMap() const { return mLastPressWasGlobalActionMap; }
 
     void addAcceleratorKey( void *hnd, const String &cmd, U32 keycode, U32 modifier)
     {


### PR DESCRIPTION
Fixes a bug with SDL where the ~ would be applied to the console text entry responder. could apply to other first responders as well.