### PR TITLE
Add Filter for dyamic objects when building a navmesh in the editor

### DIFF
--- a/Engine/source/navigation/navMesh.cpp
+++ b/Engine/source/navigation/navMesh.cpp
@@ -873,7 +873,11 @@ unsigned char *NavMesh::buildTileData(const Tile &tile, TileData &data, U32 &dat
    data.geom.clear();
    info.polyList = &data.geom;
    info.key = this;
-   getContainer()->findObjects(box, StaticObjectType | DynamicShapeObjectType, buildCallback, &info);
+
+   if(gEditingMission)
+      getContainer()->findObjects(box, StaticObjectType, buildCallback, &info);
+   else
+      getContainer()->findObjects(box, StaticObjectType | DynamicShapeObjectType, buildCallback, &info);
 
    // Parse water objects into the same list, but remember how much geometry was /not/ water.
    U32 nonWaterVertCount = data.geom.getVertCount();


### PR DESCRIPTION
Makes it so dynamic objects don't contribute to the navmesh when building in the editor. This avoids player objects, vehicles, etc from blocking parts of the navMesh.

When in-game and tiles are rebuilt, it keeps the contribution of dynamic objects so AI can path around other players, etc.