### PR TITLE
Multiple canvas support for GL and DX11

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
@@ -261,16 +261,9 @@ void GFXD3D11Device::enumerateVideoModes()
    SAFE_RELEASE(DXGIFactory);
 }
 
-IDXGISwapChain* GFXD3D11Device::getSwapChain()
-{
-   return mSwapChain;
-}
-
 void GFXD3D11Device::init(const GFXVideoMode &mode, PlatformWindow *window)
 {
    AssertFatal(window, "GFXD3D11Device::init - must specify a window!");
-
-   HWND winHwnd = (HWND)window->getSystemWindow( PlatformWindow::WindowSystem_Windows );
 
    UINT createDeviceFlags = D3D11_CREATE_DEVICE_SINGLETHREADED | D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 #ifdef TORQUE_DEBUG
@@ -278,56 +271,49 @@ void GFXD3D11Device::init(const GFXVideoMode &mode, PlatformWindow *window)
    mDebugLayers = true;
 #endif
 
-   DXGI_SWAP_CHAIN_DESC d3dpp = setupPresentParams(mode, winHwnd);
-
    D3D_FEATURE_LEVEL deviceFeature;
    D3D_DRIVER_TYPE driverType = D3D_DRIVER_TYPE_HARDWARE;// use D3D_DRIVER_TYPE_REFERENCE for reference device
-   // create a device, device context and swap chain using the information in the d3dpp struct
-   HRESULT hres = D3D11CreateDeviceAndSwapChain(NULL,
-                                 driverType,
-                                 NULL,
-                                 createDeviceFlags,
-                                 NULL,
-                                 0,
-                                 D3D11_SDK_VERSION,
-                                 &d3dpp,
-                                 &mSwapChain,
-                                 &mD3DDevice,
-                                 &deviceFeature,
-                                 &mD3DDeviceContext);
+   // create a device & device context
+   HRESULT hres = D3D11CreateDevice(NULL,
+                                    driverType,
+                                    NULL,
+                                    createDeviceFlags,
+                                    NULL,
+                                    0,
+                                    D3D11_SDK_VERSION,
+                                    &mD3DDevice,
+                                    &deviceFeature,
+                                    &mD3DDeviceContext);
 
    if(FAILED(hres))
    {
       #ifdef TORQUE_DEBUG
-      //try again without debug device layer enabled
-      createDeviceFlags &= ~D3D11_CREATE_DEVICE_DEBUG;
-      HRESULT hres = D3D11CreateDeviceAndSwapChain(NULL, driverType,NULL,createDeviceFlags,NULL, 0,
-         D3D11_SDK_VERSION,
-         &d3dpp,
-         &mSwapChain,
-         &mD3DDevice,
-         &deviceFeature,
-         &mD3DDeviceContext);
-      //if we failed again than we definitely have a problem
-      if (FAILED(hres))
-         AssertFatal(false, "GFXD3D11Device::init - D3D11CreateDeviceAndSwapChain failed!");
+         //try again without debug device layer enabled
+         createDeviceFlags &= ~D3D11_CREATE_DEVICE_DEBUG;
+         hres = D3D11CreateDevice(NULL,
+                                  driverType,
+                                  NULL,
+                                  createDeviceFlags,
+                                  NULL,
+                                  0,
+                                  D3D11_SDK_VERSION,
+                                  &mD3DDevice,
+                                  &deviceFeature,
+                                  &mD3DDeviceContext);
+         //if we failed again than we definitely have a problem
+         if (FAILED(hres))
+            AssertFatal(false, "GFXD3D11Device::init - D3D11CreateDeviceAndSwapChain failed!");
 
-      Con::warnf("GFXD3D11Device::init - Debug layers not detected!");
-      mDebugLayers = false;
+         Con::warnf("GFXD3D11Device::init - Debug layers not detected!");
+         mDebugLayers = false;
       #else
-      AssertFatal(false, "GFXD3D11Device::init - D3D11CreateDeviceAndSwapChain failed!");
+         AssertFatal(false, "GFXD3D11Device::init - D3D11CreateDeviceAndSwapChain failed!");
       #endif
    }
 
-   //set the fullscreen state here if we need to
-   if(mode.fullScreen)
-   {
-      hres = mSwapChain->SetFullscreenState(TRUE, NULL);
-      if(FAILED(hres))
-      {
-         AssertFatal(false, "GFXD3D11Device::init- Failed to set fullscreen state!");
-      }
-   }
+#ifdef TORQUE_DEBUG
+   _suppressDebugMessages();
+#endif
 
    mTextureManager = new GFXD3D11TextureManager();
 
@@ -354,68 +340,6 @@ void GFXD3D11Device::init(const GFXVideoMode &mode, PlatformWindow *window)
    
    mCardProfiler = new GFXD3D11CardProfiler();
    mCardProfiler->init();
-
-   D3D11_TEXTURE2D_DESC desc;
-   desc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
-   desc.CPUAccessFlags = 0;
-   desc.Format = GFXD3D11TextureFormat[GFXFormatD24S8];
-   desc.MipLevels = 1;
-   desc.ArraySize = 1;
-   desc.Usage = D3D11_USAGE_DEFAULT;
-   desc.Width = mode.resolution.x;
-   desc.Height = mode.resolution.y;
-   desc.SampleDesc.Count =1;
-   desc.SampleDesc.Quality =0;
-   desc.MiscFlags = 0;
-
-   HRESULT hr = mD3DDevice->CreateTexture2D(&desc, NULL, &mDeviceDepthStencil);
-   if(FAILED(hr)) 
-   {
-      AssertFatal(false, "GFXD3D11Device::init - couldn't create device's depth-stencil surface.");
-   }
-
-   D3D11_DEPTH_STENCIL_VIEW_DESC depthDesc;
-   depthDesc.Format = GFXD3D11TextureFormat[GFXFormatD24S8];
-   depthDesc.Flags =0 ;
-   depthDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
-   depthDesc.Texture2D.MipSlice = 0;
-
-   hr = mD3DDevice->CreateDepthStencilView(mDeviceDepthStencil, &depthDesc, &mDeviceDepthStencilView);
-
-   if(FAILED(hr))
-   {
-      AssertFatal(false, "GFXD3D11Device::init - couldn't create depth stencil view");
-   }
-
-   hr = mSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)&mDeviceBackbuffer);
-   if(FAILED(hr))
-     AssertFatal(false, "GFXD3D11Device::init - coudln't retrieve backbuffer ref");
-
-   //create back buffer view
-   D3D11_RENDER_TARGET_VIEW_DESC RTDesc;
-
-   RTDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
-   RTDesc.Texture2D.MipSlice = 0;
-   RTDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
-
-   hr = mD3DDevice->CreateRenderTargetView(mDeviceBackbuffer, &RTDesc, &mDeviceBackBufferView);
-
-   if(FAILED(hr))
-       AssertFatal(false, "GFXD3D11Device::init - couldn't create back buffer target view");
-
-#ifdef TORQUE_DEBUG
-   String backBufferName = "MainBackBuffer";
-   String depthSteniclName = "MainDepthStencil";
-   String backBuffViewName = "MainBackBuffView";
-   String depthStencViewName = "MainDepthView";
-   mDeviceBackbuffer->SetPrivateData(WKPDID_D3DDebugObjectName, backBufferName.size(), backBufferName.c_str());
-   mDeviceDepthStencil->SetPrivateData(WKPDID_D3DDebugObjectName, depthSteniclName.size(), depthSteniclName.c_str());
-   mDeviceDepthStencilView->SetPrivateData(WKPDID_D3DDebugObjectName, depthStencViewName.size(), depthStencViewName.c_str());
-   mDeviceBackBufferView->SetPrivateData(WKPDID_D3DDebugObjectName, backBuffViewName.size(), backBuffViewName.c_str());
-
-   _suppressDebugMessages();
-
-#endif
 
    gScreenShot = new ScreenShotD3D11;
 
@@ -466,14 +390,35 @@ GFXWindowTarget * GFXD3D11Device::allocWindowTarget(PlatformWindow *window)
 {
    AssertFatal(window,"GFXD3D11Device::allocWindowTarget - no window provided!");
 
-   // Allocate the device.
-   init(window->getVideoMode(), window);
-
    // Set up a new window target...
    GFXD3D11WindowTarget *gdwt = new GFXD3D11WindowTarget();
    gdwt->mWindow = window;
    gdwt->mSize = window->getClientExtent();
-   gdwt->initPresentationParams();
+   
+   if (!mInitialized)
+   {
+      gdwt->mSecondaryWindow = false;
+      // Allocate the device.
+      init(window->getVideoMode(), window);
+      gdwt->initPresentationParams();
+      gdwt->createSwapChain();
+      gdwt->createBuffersAndViews();
+
+      mSwapChain = gdwt->getSwapChain();
+      mDeviceBackbuffer = gdwt->getBackBuffer();
+      mDeviceDepthStencil = gdwt->getDepthStencil();
+      mDeviceBackBufferView = gdwt->getBackBufferView();
+      mDeviceDepthStencilView = gdwt->getDepthStencilView();
+
+   }
+   else //additional window/s
+   {
+      gdwt->mSecondaryWindow = true;
+      gdwt->initPresentationParams();
+      gdwt->createSwapChain();
+      gdwt->createBuffersAndViews();
+   }
+   
    gdwt->registerResourceWithDevice(this);
 
    return gdwt;
@@ -487,12 +432,14 @@ GFXTextureTarget* GFXD3D11Device::allocRenderToTextureTarget()
    return targ;
 }
 
-void GFXD3D11Device::reset(DXGI_SWAP_CHAIN_DESC &d3dpp)
+void GFXD3D11Device::beginReset()
 {
    if (!mD3DDevice)
       return;
 
    mInitialized = false;
+
+   releaseDefaultPoolResources();
 
    // Clean up some commonly dangling state. This helps prevents issues with
    // items that are destroyed by the texture manager callbacks and recreated
@@ -504,117 +451,26 @@ void GFXD3D11Device::reset(DXGI_SWAP_CHAIN_DESC &d3dpp)
 
    mD3DDeviceContext->ClearState();
 
-   DXGI_MODE_DESC displayModes;
-   displayModes.Format = d3dpp.BufferDesc.Format;
-   displayModes.Height = d3dpp.BufferDesc.Height;
-   displayModes.Width = d3dpp.BufferDesc.Width;
-   displayModes.RefreshRate = d3dpp.BufferDesc.RefreshRate;
-   displayModes.Scaling = d3dpp.BufferDesc.Scaling;
-   displayModes.ScanlineOrdering = d3dpp.BufferDesc.ScanlineOrdering;
-
-   HRESULT hr;
-   if (!d3dpp.Windowed)
-   {
-      hr = mSwapChain->ResizeTarget(&displayModes);
-
-      if (FAILED(hr))
-      {
-         AssertFatal(false, "D3D11Device::reset - failed to resize target!");
-      }
-   }
-
-   // First release all the stuff we allocated from D3DPOOL_DEFAULT
-   releaseDefaultPoolResources();
-
-   //release the backbuffer, depthstencil, and their views
-   SAFE_RELEASE(mDeviceBackBufferView);
-   SAFE_RELEASE(mDeviceBackbuffer);
+   //release old buffers and views
    SAFE_RELEASE(mDeviceDepthStencilView);
+   SAFE_RELEASE(mDeviceBackBufferView);
    SAFE_RELEASE(mDeviceDepthStencil);
+   SAFE_RELEASE(mDeviceBackbuffer);
+}
 
-   hr = mSwapChain->ResizeBuffers(d3dpp.BufferCount, d3dpp.BufferDesc.Width, d3dpp.BufferDesc.Height, d3dpp.BufferDesc.Format, d3dpp.Windowed ? 0 : DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH);
-
-   if (FAILED(hr))
-   {
-      AssertFatal(false, "D3D11Device::reset - failed to resize back buffer!");
-   }
-
-   //recreate backbuffer view. depth stencil view and texture
-   D3D11_TEXTURE2D_DESC desc;
-   desc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
-   desc.CPUAccessFlags = 0;
-   desc.Format = GFXD3D11TextureFormat[GFXFormatD24S8];
-   desc.MipLevels = 1;
-   desc.ArraySize = 1;
-   desc.Usage = D3D11_USAGE_DEFAULT;
-   desc.Width = d3dpp.BufferDesc.Width;
-   desc.Height = d3dpp.BufferDesc.Height;
-   desc.SampleDesc.Count = 1;
-   desc.SampleDesc.Quality = 0;
-   desc.MiscFlags = 0;
-
-   hr = mD3DDevice->CreateTexture2D(&desc, NULL, &mDeviceDepthStencil);
-   if (FAILED(hr))
-   {
-      AssertFatal(false, "GFXD3D11Device::reset - couldn't create device's depth-stencil surface.");
-   }
-
-   D3D11_DEPTH_STENCIL_VIEW_DESC depthDesc;
-   depthDesc.Format = GFXD3D11TextureFormat[GFXFormatD24S8];
-   depthDesc.Flags = 0;
-   depthDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
-   depthDesc.Texture2D.MipSlice = 0;
-
-   hr = mD3DDevice->CreateDepthStencilView(mDeviceDepthStencil, &depthDesc, &mDeviceDepthStencilView);
-
-   if (FAILED(hr))
-   {
-      AssertFatal(false, "GFXD3D11Device::reset - couldn't create depth stencil view");
-   }
-
-   hr = mSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)&mDeviceBackbuffer);
-   if (FAILED(hr))
-      AssertFatal(false, "GFXD3D11Device::reset - coudln't retrieve backbuffer ref");
-
-   //create back buffer view
-   D3D11_RENDER_TARGET_VIEW_DESC RTDesc;
-
-   RTDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
-   RTDesc.Texture2D.MipSlice = 0;
-   RTDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
-
-   hr = mD3DDevice->CreateRenderTargetView(mDeviceBackbuffer, &RTDesc, &mDeviceBackBufferView);
-
-   if (FAILED(hr))
-      AssertFatal(false, "GFXD3D11Device::reset - couldn't create back buffer target view");
+void GFXD3D11Device::endReset(GFXD3D11WindowTarget *windowTarget)
+{
+   //grab new references
+   mDeviceBackbuffer = windowTarget->getBackBuffer();
+   mDeviceDepthStencil = windowTarget->getDepthStencil();
+   mDeviceBackBufferView = windowTarget->getBackBufferView();
+   mDeviceDepthStencilView = windowTarget->getDepthStencilView();
 
    mD3DDeviceContext->OMSetRenderTargets(1, &mDeviceBackBufferView, mDeviceDepthStencilView);
 
-   hr = mSwapChain->SetFullscreenState(!d3dpp.Windowed, NULL);
-
-   if (FAILED(hr))
-   {
-      AssertFatal(false, "D3D11Device::reset - failed to change screen states!");
-   }
-
-   //Microsoft recommend this, see DXGI documentation
-   if (!d3dpp.Windowed)
-   {
-      displayModes.RefreshRate.Numerator = 0;
-      displayModes.RefreshRate.Denominator = 0;
-      hr = mSwapChain->ResizeTarget(&displayModes);
-
-      if (FAILED(hr))
-      {
-         AssertFatal(false, "D3D11Device::reset - failed to resize target!");
-      }
-   }
-
-   mInitialized = true;
-
-   // Now re aquire all the resources we trashed earlier
+   // Now reacquire all the resources we trashed earlier
    reacquireDefaultPoolResources();
-
+   mInitialized = true;
    // Mark everything dirty and flush to card, for sanity.
    updateStates(true);
 }

--- a/Engine/source/gfx/D3D11/gfxD3D11Device.h
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.h
@@ -146,7 +146,6 @@ protected:
    virtual GFXD3D11VertexBuffer* findVBPool( const GFXVertexFormat *vertexFormat, U32 numVertsNeeded );
    virtual GFXD3D11VertexBuffer* createVBPool( const GFXVertexFormat *vertexFormat, U32 vertSize );
 
-   IDXGISwapChain* getSwapChain();
    // State overrides
    // {
 
@@ -281,7 +280,8 @@ public:
    ID3D11Device* getDevice(){ return mD3DDevice; }
 
    /// Reset
-   void reset( DXGI_SWAP_CHAIN_DESC &d3dpp );
+   void beginReset();
+   void endReset(GFXD3D11WindowTarget *windowTarget);
 
    virtual void setupGenericShaders( GenericShaderType type  = GSColor );
 

--- a/Engine/source/gfx/D3D11/gfxD3D11Target.h
+++ b/Engine/source/gfx/D3D11/gfxD3D11Target.h
@@ -76,16 +76,21 @@ class GFXD3D11WindowTarget : public GFXWindowTarget
    friend class GFXD3D11Device;
 
    /// Our backbuffer
-   ID3D11Texture2D *mBackbuffer;
+   ID3D11Texture2D *mBackBuffer;
+   ID3D11Texture2D *mDepthStencil;
+   ID3D11RenderTargetView* mBackBufferView;
+   ID3D11DepthStencilView* mDepthStencilView;
+   IDXGISwapChain *mSwapChain;
 
    /// Maximum size we can render to.
    Point2I mSize;
-
    /// D3D presentation info.
    DXGI_SWAP_CHAIN_DESC mPresentationParams;
-
    /// Internal interface that notifies us we need to reset our video mode.
    void resetMode();
+
+   /// Is this a secondary window
+   bool mSecondaryWindow;
 
 public:
 
@@ -97,7 +102,9 @@ public:
    virtual bool present();
 
    void initPresentationParams();
-   void setImplicitSwapChain();
+   void createSwapChain();
+   void createBuffersAndViews();
+   void setBackBuffer();
 
    virtual void activate();   
 
@@ -105,6 +112,13 @@ public:
    void resurrect();
 
    virtual void resolveTo( GFXTextureObject *tex );
+
+   // These are all reference counted and must be released by whomever uses the get* function
+   IDXGISwapChain *getSwapChain();
+   ID3D11Texture2D *getBackBuffer();
+   ID3D11Texture2D *getDepthStencil();
+   ID3D11RenderTargetView* getBackBufferView();
+   ID3D11DepthStencilView* getDepthStencilView();
 };
 
 #endif

--- a/Engine/source/gfx/gl/gfxGLWindowTarget.cpp
+++ b/Engine/source/gfx/gl/gfxGLWindowTarget.cpp
@@ -37,7 +37,7 @@ GFX_ImplementTextureProfile( BackBufferDepthProfile,
 
 GFXGLWindowTarget::GFXGLWindowTarget(PlatformWindow *win, GFXDevice *d)
       : GFXWindowTarget(win), mDevice(d), mContext(NULL), mFullscreenContext(NULL)
-      , mCopyFBO(0), mBackBufferFBO(0)
+      , mCopyFBO(0), mBackBufferFBO(0), mSecondaryWindow(false)
 {      
    win->appEvent.notify(this, &GFXGLWindowTarget::_onAppSignal);
 }
@@ -52,7 +52,14 @@ GFXGLWindowTarget::~GFXGLWindowTarget()
 
 void GFXGLWindowTarget::resetMode()
 {
-   if(mWindow->getVideoMode().fullScreen != mWindow->isFullscreen())
+   // Do some validation...
+   bool fullscreen = mWindow->getVideoMode().fullScreen;
+   if (fullscreen && mSecondaryWindow)
+   {
+      AssertFatal(false, "GFXGLWindowTarget::resetMode - Cannot go fullscreen with secondary window!");
+   }
+
+   if(fullscreen != mWindow->isFullscreen())
    {
       _teardownCurrentMode();
       _setupNewMode();

--- a/Engine/source/gfx/gl/gfxGLWindowTarget.h
+++ b/Engine/source/gfx/gl/gfxGLWindowTarget.h
@@ -50,6 +50,9 @@ public:
    virtual void resolveTo(GFXTextureObject* obj);
    
    void _onAppSignal(WindowId wnd, S32 event);
+
+   // create pixel format for the window
+   void createPixelFormat();
    
 private:
    friend class GFXGLDevice;
@@ -58,6 +61,8 @@ private:
    GFXTexHandle mBackBufferColorTex, mBackBufferDepthTex;
    Point2I size;   
    GFXDevice* mDevice;
+   /// Is this a secondary window
+   bool mSecondaryWindow;
    void* mContext;
    void* mFullscreenContext;
    void _teardownCurrentMode();
@@ -66,6 +71,7 @@ private:
    void _WindowPresent();
    //set this windows context to be current
    void _makeContextCurrent();
+   
 };
 
 #endif

--- a/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
+++ b/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
@@ -191,19 +191,21 @@ U32 GFXGLDevice::getTotalVideoMemory()
 
 GFXWindowTarget *GFXGLDevice::allocWindowTarget( PlatformWindow *window )
 {
-    AssertFatal(!mContext, "This GFXGLDevice is already assigned to a window");
-    
-    GFXGLWindowTarget* ggwt = 0;
-    if( !mContext )
-    {
-        // no context, init the device now
-        init(window->getVideoMode(), window);
-        ggwt = new GFXGLWindowTarget(window, this);
-        ggwt->registerResourceWithDevice(this);
-        ggwt->mContext = mContext;
-    }
+   GFXGLWindowTarget* ggwt = new GFXGLWindowTarget(window, this);
 
-    return ggwt;
+   //first window
+   if (!mContext)
+   {
+      init(window->getVideoMode(), window);
+      ggwt->mSecondaryWindow = false;
+   }
+   else
+      ggwt->mSecondaryWindow = true;
+
+   ggwt->registerResourceWithDevice(this);
+   ggwt->mContext = mContext;
+
+   return ggwt;
 }
 
 GFXFence* GFXGLDevice::_createPlatformSpecificFence()


### PR DESCRIPTION
Add support for multiple canvas for GL & DX11. Do note there is a problem with SDL and multiple windows but that is a separate case. All 3 gfx work perfectly with win32 platform code.