### PR TITLE
GL::Workaround::noCompressedNPoTTextures profile is no longer used

### DIFF
--- a/Engine/source/gfx/gl/gfxGLTextureManager.cpp
+++ b/Engine/source/gfx/gl/gfxGLTextureManager.cpp
@@ -316,7 +316,7 @@ bool GFXGLTextureManager::_loadTexture(GFXTextureObject *aTexture, DDSFile *dds)
 
       if(isCompressedFormat(dds->mFormat))
       {
-         if((!isPow2(dds->getWidth()) || !isPow2(dds->getHeight())) && GFX->getCardProfiler()->queryProfile("GL::Workaround::noCompressedNPoTTextures"))
+         if((!isPow2(dds->getWidth()) || !isPow2(dds->getHeight())))
          {
             U32 squishFlag = squish::kDxt1;
             switch (dds->mFormat)


### PR DESCRIPTION
fixes up #1863