### PR TITLE
D3D11 shadermodel version fix

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11CardProfiler.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11CardProfiler.cpp
@@ -47,10 +47,25 @@ void GFXD3D11CardProfiler::init()
 
       mCardDescription = adapter.description;
       mChipSet = adapter.chipSet;
-      mVersionString = adapter.driverVersion;
+      mVersionString = _getFeatureLevelStr();
       mVideoMemory = adapter.vram;
    }
    Parent::init();
+}
+
+String GFXD3D11CardProfiler::_getFeatureLevelStr()
+{
+   switch (D3D11->getFeatureLevel())
+   {
+   case D3D_FEATURE_LEVEL_11_0:
+      return String("Feature level 11.0");
+   case D3D_FEATURE_LEVEL_10_1:
+      return String("Feature level 10.1");
+   case D3D_FEATURE_LEVEL_10_0:
+      return String("Feature level 10.0");
+   default:
+      return String("Unknown feature level");
+   }
 }
 
 void GFXD3D11CardProfiler::setupCardCapabilities()

--- a/Engine/source/gfx/D3D11/gfxD3D11CardProfiler.h
+++ b/Engine/source/gfx/D3D11/gfxD3D11CardProfiler.h
@@ -41,6 +41,7 @@ protected:
    void setupCardCapabilities();
    bool _queryCardCap(const String &query, U32 &foundResult);
    bool _queryFormat(const GFXFormat fmt, const GFXTextureProfile *profile, bool &inOutAutogenMips);
+   String _getFeatureLevelStr();
 };
 
 #endif

--- a/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
@@ -106,6 +106,7 @@ GFXD3D11Device::GFXD3D11Device(U32 index)
 
    mVertexShaderTarget = String::EmptyString;
    mPixelShaderTarget = String::EmptyString;
+   mShaderModel = String::EmptyString;
 
    mDrawInstancesCount = 0;
 
@@ -491,16 +492,19 @@ void GFXD3D11Device::init(const GFXVideoMode &mode, PlatformWindow *window)
       mVertexShaderTarget = "vs_5_0";
       mPixelShaderTarget = "ps_5_0";
       mPixVersion = 5.0f;
+      mShaderModel = "50";
       break;
    case D3D_FEATURE_LEVEL_10_1:
       mVertexShaderTarget = "vs_4_1";
       mPixelShaderTarget = "ps_4_1";
       mPixVersion = 4.1f;
+      mShaderModel = "41";
       break;
    case D3D_FEATURE_LEVEL_10_0:
       mVertexShaderTarget = "vs_4_0";
       mPixelShaderTarget = "ps_4_0";
       mPixVersion = 4.0f;
+      mShaderModel = "40";
       break;
    default:
       AssertFatal(false, "GFXD3D11Device::init - We don't support this feature level");

--- a/Engine/source/gfx/D3D11/gfxD3D11Device.h
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.h
@@ -140,6 +140,8 @@ protected:
    // Shader Model targers
    String mVertexShaderTarget;
    String mPixelShaderTarget;
+   // String for use with shader macros in the form of shader model version * 10
+   String mShaderModel;
 
    bool mDebugLayers;
 
@@ -306,10 +308,11 @@ public:
    DXGI_SAMPLE_DESC getMultisampleType() const { return mMultisampleDesc; }
 
    // Get feature level this gfx device supports
-   D3D_FEATURE_LEVEL getFeatureLevel() const { mFeatureLevel; }
+   D3D_FEATURE_LEVEL getFeatureLevel() const { return mFeatureLevel; }
    // Shader Model targers
    const String &getVertexShaderTarget() const { return mVertexShaderTarget; }
    const String &getPixelShaderTarget() const { return mPixelShaderTarget; }
+   const String &getShaderModel() const { return mShaderModel; }
 
    // grab the sampler map
    const SamplerMap &getSamplersMap() const { return mSamplersMap; }

--- a/Engine/source/gfx/D3D11/gfxD3D11Shader.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Shader.cpp
@@ -790,9 +790,8 @@ bool GFXD3D11Shader::_init()
       d3dMacros[i+smGlobalMacros.size()].Definition = mMacros[i].value.c_str();
    }
 
-   //TODO support D3D_FEATURE_LEVEL properly with shaders instead of hard coding at hlsl 5
    d3dMacros[macroCount - 2].Name = "TORQUE_SM";
-   d3dMacros[macroCount - 2].Definition = "50";
+   d3dMacros[macroCount - 2].Definition = D3D11->getShaderModel().c_str();
 
    memset(&d3dMacros[macroCount - 1], 0, sizeof(D3D_SHADER_MACRO));
 


### PR DESCRIPTION
*Fixes up a problem where shader model version was not getting set for shader macros.
*Adds feature level string to the version string of the card profiler.