### PR TITLE
Added _physicsEnabled() function to Player class

### DIFF
--- a/Engine/source/T3D/player.h
+++ b/Engine/source/T3D/player.h
@@ -606,6 +606,7 @@ protected:
    Point3F _move( const F32 travelTime, Collision *outCol );
    F32 _doCollisionImpact( const Collision *collision, bool fallingCollision);
    void _handleCollision( const Collision &collision );
+   bool _physicsEnabled();
    virtual bool updatePos(const F32 travelTime = TickSec);
 
    ///Update head animation


### PR DESCRIPTION
This PR allows you to move the player around in the editor with a physics plugin when you don't have the simulation enabled (default for the editor)