### PR TITLE
Physics timing

### DIFF
--- a/Engine/source/T3D/physics/bullet/btWorld.cpp
+++ b/Engine/source/T3D/physics/bullet/btWorld.cpp
@@ -123,8 +123,8 @@ void BtWorld::tickPhysics( U32 elapsedMs )
    // Convert it to seconds.
    const F32 elapsedSec = (F32)elapsedMs * 0.001f;
 
-   // Simulate... it is recommended to always use Bullet's default fixed timestep/
-   mDynamicsWorld->stepSimulation( elapsedSec * mEditorTimeScale );
+   // Simulate
+   mDynamicsWorld->stepSimulation( elapsedSec * mEditorTimeScale, smPhysicsMaxSubSteps, smPhysicsStepTime);
 
    mIsSimulating = true;
 

--- a/Engine/source/T3D/physics/physicsWorld.cpp
+++ b/Engine/source/T3D/physics/physicsWorld.cpp
@@ -23,6 +23,9 @@
 #include "platform/platform.h"
 #include "T3D/physics/physicsWorld.h"
 
+//Physics timing
+F32 PhysicsWorld::smPhysicsStepTime = 1.0f / 60.f; //default 60fps
+U32 PhysicsWorld::smPhysicsMaxSubSteps = 4;
 
 PhysicsWorld::PhysicsWorld()
    : mGravity( 0, 0, -20.0f ) // NOTE: This matches the gravity used for player objects.

--- a/Engine/source/T3D/physics/physicsWorld.h
+++ b/Engine/source/T3D/physics/physicsWorld.h
@@ -111,6 +111,10 @@ public:
    virtual PhysicsBody* castRay( const Point3F &start, const Point3F &end, U32 bodyTypes = BT_All ) = 0;
 
    virtual void explosion( const Point3F &pos, F32 radius, F32 forceMagnitude ) = 0;
+
+   /// Physics timing
+   static F32 smPhysicsStepTime;
+   static U32 smPhysicsMaxSubSteps;
 };
 
 

--- a/Engine/source/T3D/physics/physx3/px3World.h
+++ b/Engine/source/T3D/physics/physx3/px3World.h
@@ -69,8 +69,6 @@ protected:
 	static physx::PxProfileZoneManager* smProfileZoneManager;
 	static physx::PxDefaultCpuDispatcher* smCpuDispatcher;
 	static physx::PxVisualDebuggerConnection* smPvdConnection;
-   static F32 smPhysicsStepTime;
-   static U32 smPhysicsMaxIterations;
 	F32 mAccumulator;
 	bool _simulate(const F32 dt);
 
@@ -103,7 +101,6 @@ public:
 	static bool restartSDK( bool destroyOnly = false, Px3World *clientWorld = NULL, Px3World *serverWorld = NULL );
 	static void releaseWriteLocks();
 	static physx::PxCooking *getCooking();
-   static void setTiming(F32 stepTime,U32 maxIterations);
    static void lockScenes();
    static void unlockScenes();
 };


### PR DESCRIPTION
Allows tuning of the physics substeps and step time. Bullet before was using the default of 1 substep. Potentially these would be good values to have in the levelInfo so they can be tuned on a per level basis depending on the physics needs of that level.

Thanks @JeffProgrammer for pointing out the bullet side, never noticed it before.