### PR TITLE
Texture crash

### DIFF
--- a/Engine/source/gfx/bitmap/gBitmap.cpp
+++ b/Engine/source/gfx/bitmap/gBitmap.cpp
@@ -327,7 +327,10 @@ void GBitmap::allocateBitmap(const U32 in_width, const U32 in_height, const bool
 
          mNumMipLevels++;
          allocPixels += currWidth * currHeight * mBytesPerPixel;
-      } while (currWidth != 1 && currHeight != 1);
+      } while (currWidth != 1 || currHeight != 1);
+
+      U32 expectedMips = mFloor(mLog2(mMax(in_width, in_height))) + 1;
+      AssertFatal(mNumMipLevels == expectedMips, "GBitmap::allocateBitmap: mipmap count wrong");
    }
    AssertFatal(mNumMipLevels <= c_maxMipLevels, "GBitmap::allocateBitmap: too many miplevels");
 

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -1085,21 +1085,7 @@ void GFXTextureManager::_validateTexParams( const U32 width, const U32 height,
       // NOTE: Does this belong here?
       if( inOutNumMips == 0 && !autoGenSupp )
       {
-         U32 currWidth  = width;
-         U32 currHeight = height;
-
-         inOutNumMips = 1;
-         do 
-         {
-            currWidth  >>= 1;
-            currHeight >>= 1;
-            if( currWidth == 0 )
-               currWidth  = 1;
-            if( currHeight == 0 ) 
-               currHeight = 1;
-
-            inOutNumMips++;
-         } while ( currWidth != 1 && currHeight != 1 );
+         inOutNumMips = mFloor(mLog2(mMax(width, height))) + 1;
       }
    }
 }

--- a/Engine/source/math/mMathFn.h
+++ b/Engine/source/math/mMathFn.h
@@ -320,6 +320,11 @@ inline F32 mLog(const F32 val)
    return (F32) log(val);
 }
 
+inline F32 mLog2(const F32 val)
+{
+   return (F32) log2(val);
+}
+
 inline F32 mExp(const F32 val)
 {
    return (F32) exp(val);
@@ -380,6 +385,10 @@ inline F64 mLog(const F64 val)
    return (F64) log(val);
 }
 
+inline F64 mLog2(const F64 val)
+{
+   return (F64) log2(val);
+}
 
 inline F32 mCatmullrom(F32 t, F32 p0, F32 p1, F32 p2, F32 p3)
 {


### PR DESCRIPTION
Fixtures a problem where textures created with GBitmap class that are non square (i.e like 1024x512) have an incorrect mipmap level calculated.