### PR TITLE
SDL Menubar accelerator fix

### DIFF
--- a/Engine/source/platform/input/event.h
+++ b/Engine/source/platform/input/event.h
@@ -429,7 +429,7 @@ struct InputEventInfo
    U16 ascii;
    
    /// Modifiers to action: SI_LSHIFT, SI_LCTRL, etc.
-   InputModifiers modifier;
+   U32 modifier;
 
    inline void postToSignal(InputEvent &ie)
    {

--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -51,23 +51,41 @@ namespace
    {
       U32 ret = 0;
 
-      if(mod & KMOD_LSHIFT)
-         ret |= IM_LSHIFT;
+      if (mod & KMOD_LSHIFT)
+      {
+         ret |= SI_LSHIFT;
+         ret |= SI_SHIFT;
+      }
 
-      if(mod & KMOD_RSHIFT)
-         ret |= IM_RSHIFT;
+      if (mod & KMOD_RSHIFT)
+      {
+         ret |= SI_RSHIFT;
+         ret |= SI_SHIFT;
+      }
 
-      if(mod & KMOD_LCTRL)
-         ret |= IM_LCTRL;
+      if (mod & KMOD_LCTRL)
+      {
+         ret |= SI_LCTRL;
+         ret |= SI_CTRL;
+      }
 
-      if(mod & KMOD_RCTRL)
-         ret |= IM_RCTRL;
+      if (mod & KMOD_RCTRL)
+      {
+         ret |= SI_RCTRL;
+         ret |= SI_CTRL;
+      }
 
-      if(mod & KMOD_LALT)
-         ret |= IM_LALT;
+      if (mod & KMOD_LALT)
+      {
+         ret |= SI_LALT;
+         ret |= SI_ALT;
+      }
 
-      if(mod & KMOD_RALT)
-         ret |= IM_RALT;
+      if (mod & KMOD_RALT)
+      {
+         ret |= SI_RALT;
+         ret |= SI_ALT;
+      }
 
       return ret;
    }

--- a/Engine/source/windowManager/windowInputGenerator.cpp
+++ b/Engine/source/windowManager/windowInputGenerator.cpp
@@ -145,7 +145,11 @@ void WindowInputGenerator::handleMouseMove( WindowId did, U32 modifier, S32 x, S
    event.deviceType = MouseDeviceType;
    event.deviceInst = 0;
    event.objType    = SI_AXIS;
-   event.modifier   = modifier;
+#ifdef TORQUE_SDL
+   event.modifier = modifier;
+#else
+   event.modifier = convertModifierBits(modifier);
+#endif
    event.ascii      = 0;
 
    // Generate delta movement along each axis
@@ -231,7 +235,11 @@ void WindowInputGenerator::handleMouseButton( WindowId did, U32 modifiers, U32 a
    event.deviceInst = 0;
    event.objType    = SI_BUTTON;
    event.objInst    = (InputObjectInstances)(KEY_BUTTON0 + button);
-   event.modifier   = modifiers;
+#ifdef TORQUE_SDL
+   event.modifier = modifiers;
+#else
+   event.modifier = convertModifierBits(modifiers);
+#endif
    event.ascii      = 0;
    event.action     = (action==IA_MAKE) ? SI_MAKE : SI_BREAK;
    event.fValue     = (action==IA_MAKE) ? 1.0 : 0.0;
@@ -248,7 +256,11 @@ void WindowInputGenerator::handleMouseWheel( WindowId did, U32 modifiers, S32 wh
    event.deviceType = MouseDeviceType;
    event.deviceInst = 0;
    event.objType    = SI_AXIS;
-   event.modifier   = modifiers;
+#ifdef TORQUE_SDL
+   event.modifier = modifiers;
+#else
+   event.modifier = convertModifierBits(modifiers);
+#endif
    event.ascii      = 0;
    event.action     = SI_MOVE;
 
@@ -281,7 +293,11 @@ void WindowInputGenerator::handleCharInput( WindowId did, U32 modifier, U16 key 
    event.deviceInst  = 0;
    event.objType     = SI_KEY;
    event.objInst     = KEY_NULL;
-   event.modifier    = modifier;
+#ifdef TORQUE_SDL
+   event.modifier = modifier;
+#else
+   event.modifier = convertModifierBits(modifier);
+#endif
    event.ascii       = key;
    event.action      = SI_MAKE;
    event.fValue      = 1.0;
@@ -303,7 +319,11 @@ void WindowInputGenerator::handleKeyboard( WindowId did, U32 modifier, U32 actio
    event.deviceInst  = 0;
    event.objType     = SI_KEY;
    event.objInst     = (InputObjectInstances)key;
+#ifdef TORQUE_SDL
    event.modifier    = modifier;
+#else
+   event.modifier = convertModifierBits(modifier);
+#endif
    event.ascii       = 0;
 
    switch(action)

--- a/Engine/source/windowManager/windowInputGenerator.cpp
+++ b/Engine/source/windowManager/windowInputGenerator.cpp
@@ -95,7 +95,7 @@ void WindowInputGenerator::generateInputEvent( InputEventInfo &inputEvent )
       {
          const AccKeyMap &acc = mAcceleratorMap[i];
          if (!mWindow->getKeyboardTranslation() &&
-            (acc.modifier & inputEvent.modifier || (acc.modifier == 0 && inputEvent.modifier == 0))
+            ((acc.modifier == inputEvent.modifier && acc.modifier != 0) || (acc.modifier == 0 && inputEvent.modifier == 0))
             && acc.keyCode == inputEvent.objInst)
          {
             Con::evaluatef(acc.cmd);
@@ -145,7 +145,7 @@ void WindowInputGenerator::handleMouseMove( WindowId did, U32 modifier, S32 x, S
    event.deviceType = MouseDeviceType;
    event.deviceInst = 0;
    event.objType    = SI_AXIS;
-   event.modifier   = convertModifierBits(modifier);
+   event.modifier   = modifier;
    event.ascii      = 0;
 
    // Generate delta movement along each axis
@@ -231,7 +231,7 @@ void WindowInputGenerator::handleMouseButton( WindowId did, U32 modifiers, U32 a
    event.deviceInst = 0;
    event.objType    = SI_BUTTON;
    event.objInst    = (InputObjectInstances)(KEY_BUTTON0 + button);
-   event.modifier   = convertModifierBits(modifiers);
+   event.modifier   = modifiers;
    event.ascii      = 0;
    event.action     = (action==IA_MAKE) ? SI_MAKE : SI_BREAK;
    event.fValue     = (action==IA_MAKE) ? 1.0 : 0.0;
@@ -248,7 +248,7 @@ void WindowInputGenerator::handleMouseWheel( WindowId did, U32 modifiers, S32 wh
    event.deviceType = MouseDeviceType;
    event.deviceInst = 0;
    event.objType    = SI_AXIS;
-   event.modifier   = convertModifierBits(modifiers);
+   event.modifier   = modifiers;
    event.ascii      = 0;
    event.action     = SI_MOVE;
 
@@ -281,7 +281,7 @@ void WindowInputGenerator::handleCharInput( WindowId did, U32 modifier, U16 key 
    event.deviceInst  = 0;
    event.objType     = SI_KEY;
    event.objInst     = KEY_NULL;
-   event.modifier    = convertModifierBits(modifier);
+   event.modifier    = modifier;
    event.ascii       = key;
    event.action      = SI_MAKE;
    event.fValue      = 1.0;
@@ -303,7 +303,7 @@ void WindowInputGenerator::handleKeyboard( WindowId did, U32 modifier, U32 actio
    event.deviceInst  = 0;
    event.objType     = SI_KEY;
    event.objInst     = (InputObjectInstances)key;
-   event.modifier    = convertModifierBits(modifier);
+   event.modifier    = modifier;
    event.ascii       = 0;
 
    switch(action)


### PR DESCRIPTION
Fixes the accelerator keybinds - most specifically the compound ones like Ctrl-Shift-Alt up - so that they behave properly when using SDL. Old code is retained for non-SDL so behavior is consistent across the board.