### PR TITLE
Adds a check to the record movie call

### DIFF
--- a/Engine/source/gfx/video/videoCapture.cpp
+++ b/Engine/source/gfx/video/videoCapture.cpp
@@ -314,6 +314,9 @@ DefineEngineFunction( startVideoCapture, void,
    "@see stopVideoCapture\n"
    "@ingroup Rendering\n" )
 {
+#ifdef TORQUE_DEBUG
+   Con::errorf("Recording video is disabled in debug!");
+#else
    if ( !canvas )
    {
       Con::errorf("startVideoCapture -Please specify a GuiCanvas object to record from!");
@@ -328,6 +331,7 @@ DefineEngineFunction( startVideoCapture, void,
       VIDCAP->setResolution(resolution);
 
    VIDCAP->begin(canvas);
+#endif
 }
 
 DefineEngineFunction( stopVideoCapture, void, (),,


### PR DESCRIPTION
Adds a check to the record movie call so that it only happens in Release mode, to avoid crash issues with theora and debug mode. Related to notes on #1894