### PR TITLE
Hotfix to re-add the prior static function fix in platformNet

### DIFF
--- a/Engine/source/platform/platformNet.h
+++ b/Engine/source/platform/platformNet.h
@@ -214,11 +214,6 @@ struct Net
    static bool smMulticastEnabled;
    static bool smIpv4Enabled;
    static bool smIpv6Enabled;
-  
-   static ConnectionNotifyEvent*   smConnectionNotify;
-   static ConnectionAcceptedEvent* smConnectionAccept;
-   static ConnectionReceiveEvent*  smConnectionReceive;
-   static PacketReceiveEvent*      smPacketReceive;
 
    static bool init();
    static void shutdown();


### PR DESCRIPTION
Hotfix to re-add the prior static function fix for these functions that was accidentally removed.