### PR TITLE
Fixes some issues with forest editor.

### DIFF
--- a/Engine/source/forest/editor/forestSelectionTool.cpp
+++ b/Engine/source/forest/editor/forestSelectionTool.cpp
@@ -197,6 +197,9 @@ void ForestSelectionTool::_selectItem( const ForestItem &item )
 
 void ForestSelectionTool::deleteSelection()
 {
+   if (!mEditor)
+      return;
+
    ForestDeleteUndoAction *action = new ForestDeleteUndoAction( mForest->getData(), mEditor );
 
    for ( U32 i=0; i < mSelection.size(); i++ )

--- a/Templates/Empty/game/tools/forestEditor/forestEditorGui.gui
+++ b/Templates/Empty/game/tools/forestEditor/forestEditorGui.gui
@@ -252,7 +252,7 @@
                   objectNamesOnly = "1";
                   useInspectorTooltips = "0";
                   tooltipOnWidthOnly = "0";
-                  compareToObjectID = "1";
+                  compareToObjectID = "0";
                   canRenameObjects = "1";
                   renameInternal = "0";
                   isContainer = "1";

--- a/Templates/Full/game/tools/forestEditor/forestEditorGui.gui
+++ b/Templates/Full/game/tools/forestEditor/forestEditorGui.gui
@@ -252,7 +252,7 @@
                   objectNamesOnly = "1";
                   useInspectorTooltips = "0";
                   tooltipOnWidthOnly = "0";
-                  compareToObjectID = "1";
+                  compareToObjectID = "0";
                   canRenameObjects = "1";
                   renameInternal = "0";
                   isContainer = "1";


### PR DESCRIPTION
Fixes a crash when you try to delete things without being in selection mode in the forest editor. Adds a sanity check that everything is properly set up before attempting the delete action.

Also adds a fix to the mesh item tab in the forest editor to correct odd selection behavior that could erroneously cause selection of two items in the list when you only clicked one.

In reference to #1936