### PR TITLE
Fix for dae2dts tool

### DIFF
--- a/Engine/source/platform/nativeDialogs/fileDialog.cpp
+++ b/Engine/source/platform/nativeDialogs/fileDialog.cpp
@@ -29,11 +29,13 @@
 #include "console/consoleTypes.h"
 #include "platform/profiler.h"
 #include "console/engineAPI.h"
-#include <nfd.h>
 #include "core/strings/stringUnit.h"
 #include "core/frameAllocator.h"
 
 #if defined(TORQUE_SDL)
+
+#include <nfd.h>
+
 //-----------------------------------------------------------------------------
 // PlatformFileDlgData Implementation
 //-----------------------------------------------------------------------------

--- a/Engine/source/ts/loader/tsShapeLoader.cpp
+++ b/Engine/source/ts/loader/tsShapeLoader.cpp
@@ -1228,7 +1228,11 @@ void TSShapeLoader::install()
    shape->radius = (shape->bounds.maxExtents - shape->center).len();
    shape->tubeRadius = shape->radius;
 
-   shape->init();
+   if (TSShape::smInitOnRead)
+   {
+      shape->init();
+   }
+
    shape->finalizeEditable();
 }
 

--- a/Tools/dae2dts/source/main.cpp
+++ b/Tools/dae2dts/source/main.cpp
@@ -122,6 +122,10 @@ S32 TorqueMain( S32 argc, const char **argv )
    {
       Con::errorf( "Error: no DAE file specified.\n" );
       printUsage();
+
+      // Clean everything up.
+      StandardMainLoop::shutdown();
+
       return -1;
    }
 

--- a/Tools/dae2dts/source/main.cpp
+++ b/Tools/dae2dts/source/main.cpp
@@ -156,6 +156,8 @@ S32 TorqueMain( S32 argc, const char **argv )
    if ( verbose )
       Con::printf( "Reading dae file...\n" );
 
+   TSShape::smInitOnRead = false;
+
    // Attempt to load the DAE file
    Resource<TSShape> shape = ResourceManager::get().load( srcPath );
    if ( !shape )

--- a/Tools/dae2dts/source/main.cpp
+++ b/Tools/dae2dts/source/main.cpp
@@ -159,64 +159,66 @@ S32 TorqueMain( S32 argc, const char **argv )
    TSShape::smInitOnRead = false;
 
    // Attempt to load the DAE file
-   Resource<TSShape> shape = ResourceManager::get().load( srcPath );
-   if ( !shape )
    {
-      Con::errorf( "Failed to convert DAE file: %s\n", srcPath.getFullPath() );
-      failed = 1;
-   }
-   else
-   {
-      if ( compatMode && !shape->canWriteOldFormat() )
+      Resource<TSShape> shape = ResourceManager::get().load( srcPath );
+      if ( !shape )
       {
-         Con::errorf( "Warning: Attempting to save to DTS v24 but the shape "
-                      "contains v26 features. Resulting DTS file may not be valid." );
+         Con::errorf( "Failed to convert DAE file: %s\n", srcPath.getFullPath() );
+         failed = 1;
       }
-
-      FileStream outStream;
-
-      if ( saveDSQ )
+      else
       {
-         Torque::Path dsqPath( destPath );
-         dsqPath.setExtension( "dsq" );
-
-         for ( S32 i = 0; i < shape->sequences.size(); i++ )
+         if ( compatMode && !shape->canWriteOldFormat() )
          {
-            const String& seqName = shape->getName( shape->sequences[i].nameIndex );
-            if ( verbose )
-               Con::printf( "Writing DSQ file for sequence '%s'...\n", seqName.c_str() );
+            Con::errorf( "Warning: Attempting to save to DTS v24 but the shape "
+                        "contains v26 features. Resulting DTS file may not be valid." );
+         }
 
-            dsqPath.setFileName( destPath.getFileName() + "_" + seqName );
+         FileStream outStream;
 
-            if ( outStream.open( dsqPath, Torque::FS::File::Write ) )
+         if ( saveDSQ )
+         {
+            Torque::Path dsqPath( destPath );
+            dsqPath.setExtension( "dsq" );
+
+            for ( S32 i = 0; i < shape->sequences.size(); i++ )
             {
-               shape->exportSequence( &outStream, shape->sequences[i], compatMode );
+               const String& seqName = shape->getName( shape->sequences[i].nameIndex );
+               if ( verbose )
+                  Con::printf( "Writing DSQ file for sequence '%s'...\n", seqName.c_str() );
+
+               dsqPath.setFileName( destPath.getFileName() + "_" + seqName );
+
+               if ( outStream.open( dsqPath, Torque::FS::File::Write ) )
+               {
+                  shape->exportSequence( &outStream, shape->sequences[i], compatMode );
+                  outStream.close();
+               }
+               else
+               {
+                  Con::errorf( "Failed to save sequence to %s\n", dsqPath.getFullPath().c_str() );
+                  failed = 1;
+               }
+            }
+         }
+         if ( saveDTS )
+         {
+            if ( verbose )
+               Con::printf( "Writing DTS file...\n" );
+
+            if ( outStream.open( destPath, Torque::FS::File::Write ) )
+            {
+               if ( saveDSQ )
+                  shape->sequences.setSize(0);
+
+               shape->write( &outStream, compatMode );
                outStream.close();
             }
             else
             {
-               Con::errorf( "Failed to save sequence to %s\n", dsqPath.getFullPath().c_str() );
+               Con::errorf( "Failed to save shape to %s\n", destPath.getFullPath().c_str() );
                failed = 1;
             }
-         }
-      }
-      if ( saveDTS )
-      {
-         if ( verbose )
-            Con::printf( "Writing DTS file...\n" );
-
-         if ( outStream.open( destPath, Torque::FS::File::Write ) )
-         {
-            if ( saveDSQ )
-               shape->sequences.setSize(0);
-
-            shape->write( &outStream, compatMode );
-            outStream.close();
-         }
-         else
-         {
-            Con::errorf( "Failed to save shape to %s\n", destPath.getFullPath().c_str() );
-            failed = 1;
          }
       }
    }

--- a/Tools/projectGenerator/modules/T3D.inc
+++ b/Tools/projectGenerator/modules/T3D.inc
@@ -66,6 +66,7 @@ addEngineSrcDir('T3D/sfx');
 addEngineSrcDir('T3D/gameBase');
 addEngineSrcDir('T3D/turret');
 addEngineSrcDir('T3D/assets');
+addEngineSrcDir('T3D/components');
 
 global $TORQUE_HIFI_NET;
 global $TORQUE_EXTENDED_MOVE;

--- a/Tools/projectGenerator/modules/core.inc
+++ b/Tools/projectGenerator/modules/core.inc
@@ -204,7 +204,7 @@ addIncludePath( getAppLibSrcDir() ); 	   // main lib source dir relative to app 
 if ( T3D_Generator::$platform == "win32" )
 {
    addIncludePath( getAppLibSrcDir() . 'directx8' );
-   addIncludePath( getAppLibSrcDir() . 'openal/win32' );
+   addIncludePath( getAppLibSrcDir() . 'openal-soft/include' );
    
    addProjectLibDir( getAppLibSrcDir() . 'SDL/win32' );
    addProjectLibDir( getAppLibSrcDir() . 'unicode' );

--- a/Tools/projectGenerator/modules/openal.inc
+++ b/Tools/projectGenerator/modules/openal.inc
@@ -27,6 +27,6 @@ addEngineSrcDir('sfx/openal/mac');
 addEngineSrcDir('sfx/openal/win32');
 
 if ( T3D_Generator::$platform == "win32" )
-   addIncludePath( getAppLibSrcDir() . 'openal/win32' );
+   addIncludePath( getAppLibSrcDir() . 'openal-soft/include' );
 
 ?>


### PR DESCRIPTION
This fixes the dae2dts tool when compiled using VisualStudio 2012.

The first compilation issue is that the compiler cannot open `nfd.h`. This is because  `${libDir}/nativeFileDialogs/include`  is not added to the project include paths when `TORQUE_SDL` is disabled. I fixed this by moving `#include <nfd.h>`  to within the  `#if defined(TORQUE_SDL)` preprocessor directive.

The second compilation issue is that the compiler cannot open `al/al.h`. This is because `openal/win32` is added to the project include paths instead of `openal-soft/include`. I fixed this by updating the include paths in the core and T3D project generator modules.

The last compilation issue is that `Component::setOwner(class Entity *)`  is undefined. This is because the `T3D/components` engine source directory is not included. I fixed this by adding it to the T3D project generator module.

After getting the program to compile it then generates a fatal error `SimObject::object missing call to SimObject::onRemove` when run without specifying a DAE file. This is because the program terminates without shutting down the platform. I fixed this by shutting down the platform before terminating.

When you run the program again with a DAE file, it generates an error when `TSShapeLoader` initializes the `TSShape`, as there is no GFX device to initialize the vertex buffers. I fixed this by setting `TSShape::smInitOnRead` to `false` and making `TSShapeLoader` adhere to this setting when initializing the `TSShape`.

After fixing this the program converts DAE models to DTS shapes successfully, however generates a write access violation error when the program exits. This is because the TSShape resource is not unloaded until it goes out of scope, after the platform has shutdown. I fixed this by adding a block scope to the TSShape resource to ensure it goes out of scope before the platform is shutdown.

To generate the project files I am doing the following:
* Open the dae2dts directory
* Run generateProjects.bat
* Open the buildFiles directory
* Copy torque.ico and Torque.rc from VisualStudio 2008\projects to VisualStudio 2012\projects
* Open VisualStudio 2012\dae2dts.sln
* On the dae2dts project, go to it's properties, then:
  * Change Configuration Properties -> General -> Configuration Type to Application (.exe)
  * Change Configuration Properties -> Linker -> General -> Output File to $(OutDir)dae2dts_DEBUG.exe
  *  Remove Configuration Properties -> Linker -> Input -> Module Definition File

I am not sure if this is the correct way to fix all of these issues so please let me know if you have any feedback.