### PR TITLE
Enable playerStep and disable playAmbient by default

### DIFF
--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -102,10 +102,10 @@ TSStatic::TSStatic()
    mShapeName        = "";
    mShapeInstance    = NULL;
 
-   mPlayAmbient      = true;
+   mPlayAmbient      = false;
    mAmbientThread    = NULL;
 
-   mAllowPlayerStep = false;
+   mAllowPlayerStep = true;
 
    mConvexList = new Convex;
 


### PR DESCRIPTION
Set player step enabled by default and play ambient disabled by default.

AllowPlayerStep was set to false one time in hope to fix the tree climb bug, but it did not work or just temporarily, since the bug is back. PlayerStep should be enabled by default, since in 99% of the time you will want it on, since otherwise you get stuck on every little step on your models, even if it is just 1cm, which can be very annoying and frustrating for newbies, since they have to research first what is wrong.

And playAmbient should be false by default as well, since in 99,9% of the time you will not need it on your models and even if you want it, it is problematic, since as soon as you put the model into the scene it starts animating and it is almost impossible to stop it at the root pose again.