### PR TITLE
Does better sanity checking on cleanup for the splash screen closing in SDL

### DIFF
--- a/Engine/source/windowManager/sdl/sdlSplashScreen.cpp
+++ b/Engine/source/windowManager/sdl/sdlSplashScreen.cpp
@@ -103,10 +103,26 @@ bool Platform::displaySplashWindow( String path )
 
 bool Platform::closeSplashWindow()
 {
-   SDL_DestroyTexture(gSplashTexture);
-   SDL_FreeSurface(gSplashImage);
-   SDL_DestroyRenderer(gSplashRenderer);
-   SDL_DestroyWindow(gSplashWindow);
+   if (gSplashTexture != nullptr)
+   {
+      SDL_DestroyTexture(gSplashTexture);
+      gSplashTexture = nullptr;
+   }
+   if (gSplashImage != nullptr)
+   {
+      SDL_FreeSurface(gSplashImage);
+      gSplashImage = nullptr;
+   }
+   if (gSplashRenderer != nullptr)
+   {
+      SDL_DestroyRenderer(gSplashRenderer);
+      gSplashRenderer = nullptr;
+   }
+   if (gSplashWindow != nullptr)
+   {
+      SDL_DestroyWindow(gSplashWindow);
+      gSplashWindow = nullptr;
+   }
 
    return true;
 }


### PR DESCRIPTION
Does better sanity checking on cleanup for the splash screen closing with SDL. Could erroneously get called a second time and if we'd already cleared the images and textures, it could crash.

This fixes that.