### PR TITLE
Possible fix to issue #1951

### DIFF
--- a/Engine/source/platform/platformNet.cpp
+++ b/Engine/source/platform/platformNet.cpp
@@ -809,7 +809,8 @@ NetSocket Net::openConnectTo(const char *addressString)
       error = Net::WrongProtocolType;
    }
 
-   if (error == NoError || error == NeedHostLookup) // Open socket
+   // Open socket
+   if (error == NoError || error == NeedHostLookup)
    {
       handleFd = openSocket();
    }
@@ -826,9 +827,9 @@ NetSocket Net::openConnectTo(const char *addressString)
          if (::connect(socketFd, (struct sockaddr *)&ipAddr, sizeof(ipAddr)) == -1 &&
             errno != EINPROGRESS)
          {
-            error = PlatformNetState::getLastError(); // Output this error if not 10035 then close
+            error = PlatformNetState::getLastError();
 
-            if (error != Net::WouldBlock) // Resource temporarily unavailable.
+            if (error != Net::WouldBlock)
             {
               Con::errorf("Error connecting %s: %s",
                  addressString, strerror(errno));


### PR DESCRIPTION
[BugFixanalysisforissue1951.docx](https://github.com/GarageGames/Torque3D/files/914377/BugFixanalysisforissue1951.docx)

When two instances of Torque3D are running on the same network, one as a
hosted server and the other as a client, the client is unable to connect
to the server. The program now can open a socket. This was obviously a
typo. To find the error I just searched for keywords containing socket,
open, open socket, and opensocket till I found the correct file. The
other error was in how the program processed “non fatal” errors. I just
outputed the error to the main console and devised that the socket
should not be closed for a WSAEWOULDBLOCK error 10035 "It is normal for
WSAEWOULDBLOCK to be reported as the result from calling connect on a
nonblocking SOCK_STREAM socket, since some time must elapse for the
connection to be established."

Read about the WouldBlock error:

https://msdn.microsoft.com/en-us/library/windows/desktop/ms740668(v=vs.85).aspx

Use of dbgSetParameters ( port , password ):

http://docs.garagegames.com/tge/official/content/documentation/Reference/Console%20Functions/TorqueScript_Console_Functions_2.html#dbgSetParameters_.28_port_.2C_password_.29

Lines:  812, 829-837