### PR TITLE
Potential fix for bug #1975

### DIFF
--- a/Templates/Full/game/scripts/server/components/game/camera.cs
+++ b/Templates/Full/game/scripts/server/components/game/camera.cs
@@ -100,9 +100,6 @@ function CameraComponent::onClientDisconnect(%this, %client)
    }
 }
 
-//move to the editor later
-GlobalActionMap.bind("keyboard", "alt c", "toggleEditorCam");
-
 function switchCamera(%client, %newCamEntity)
 {
 	if(!isObject(%client) || !isObject(%newCamEntity))

--- a/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -1918,7 +1918,8 @@ function Editor::open(%this)
       EditorGui.init();
 
    %this.editorEnabled();
-   Canvas.setContent(EditorGui);   
+   Canvas.setContent(EditorGui);  
+   $isFirstPersonVar = true;
    EditorGui.syncCameraGui();
 }
 

--- a/Templates/Full/game/tools/worldEditor/scripts/editors/worldEditor.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editors/worldEditor.ed.cs
@@ -20,6 +20,8 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
+GlobalActionMap.bind("keyboard", "alt c", "toggleEditorCam");
+
 function WorldEditor::onSelect( %this, %obj )
 {
    EditorTree.addSelection( %obj );


### PR DESCRIPTION
The change was made to the function that is executed when entering the world editor. The boolean variable for first person shooter was set to true, since the camera always defaults to first person on entering the world editor. On setting this boolean variable to be true, the correct camera setting will always be displayed on entering the world editor. This does not affect other camera labels.