### PR TITLE
Alt+C Camera Toggle Bug Fix

### DIFF
--- a/Templates/Full/game/scripts/server/components/game/camera.cs
+++ b/Templates/Full/game/scripts/server/components/game/camera.cs
@@ -100,9 +100,6 @@ function CameraComponent::onClientDisconnect(%this, %client)
    }
 }
 
-//move to the editor later
-GlobalActionMap.bind("keyboard", "alt c", "toggleEditorCam");
-
 function switchCamera(%client, %newCamEntity)
 {
 	if(!isObject(%client) || !isObject(%newCamEntity))


### PR DESCRIPTION
Resolves #1943 
Removed the leftover line of code changing the keybind of the alt+c keyboard command that was supposed to have been moved to a new location, but was not. In the new location, the keyboard command alt+c is bound to a different function that properly toggles the camera as alt+c should.