### PR TITLE
Better bug fix for #1738 (str.cpp)

### DIFF
--- a/Engine/source/core/util/str.cpp
+++ b/Engine/source/core/util/str.cpp
@@ -1620,7 +1620,7 @@ String String::GetTrailingNumber(const char* str, S32& number)
    if ((*p == '-') || (*p == '_'))
       number = -dAtoi(p + 1);
    else
-      number = (isdigit(*p) && (p == base.c_str()) ? dAtoi(p) : dAtoi(++p));
+      number = (isdigit(*p) ? dAtoi(p) : dAtoi(++p));
 
    // Remove space between the name and the number
    while ((p > base.c_str()) && dIsspace(*(p-1)))


### PR DESCRIPTION
Fixes #1738 without redundant checks. Because of the while loop on line 1616 giving the variable p its value, the check against base is redundant.