### PR TITLE
Added Alt+C to worldEditor.ed.cs

### DIFF
--- a/Templates/Full/game/tools/worldEditor/scripts/editors/worldEditor.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editors/worldEditor.ed.cs
@@ -20,6 +20,8 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
+GlobalActionMap.bind("keyboard", "alt c", "toggleEditorCam");
+
 function WorldEditor::onSelect( %this, %obj )
 {
    EditorTree.addSelection( %obj );


### PR DESCRIPTION
Moved the Alt+C binding from Templates/Full/game/scripts/server/components/game/camera.cs to worldEditor.ed.cs. Alt+C should only be accessible to the world editor and not the user interface.