### PR TITLE
Ai turret ignore list functions

### DIFF
--- a/Engine/source/T3D/turret/aiTurretShape.cpp
+++ b/Engine/source/T3D/turret/aiTurretShape.cpp
@@ -564,6 +564,16 @@ void AITurretShape::removeFromIgnoreList(ShapeBase* obj)
    mIgnoreObjects.removeObject(obj);
 }
 
+S32 AITurretShape::ignoreListCount()
+{
+   return mIgnoreObjects.size();
+}
+
+SimObject* AITurretShape::getIgnoreListObject(S32 index)
+{
+   return mIgnoreObjects.at(index);
+}
+
 //----------------------------------------------------------------------------
 
 void AITurretShape::_initState()
@@ -1242,6 +1252,21 @@ DefineEngineMethod( AITurretShape, removeFromIgnoreList, void, (ShapeBase* obj),
    "@param obj The ShapeBase object to once again allow for targeting.\n")
 {
    object->removeFromIgnoreList(obj);
+}
+
+DefineEngineMethod( AITurretShape, ignoreListCount, S32, (),,
+   "@brief Returns the number of objects in the turrets ignore list.\n\n"
+   "All objects in this list will be ignored by the turret's targeting.\n")
+{
+   return object->ignoreListCount();
+}
+
+DefineEngineMethod( AITurretShape, getIgnoreListObject, SimObject*, (S32 index),,
+   "@brief Returns the object in the ignore list at index.\n\n"
+   "All objects in this list will be ignored by the turret's targeting.\n"
+   "@param index The index of the object in the ignore list being retrieved.\n")
+{
+   return object->getIgnoreListObject(index);
 }
 
 DefineEngineMethod( AITurretShape, setTurretState, void, (const char* newState, bool force), (false),

--- a/Engine/source/T3D/turret/aiTurretShape.h
+++ b/Engine/source/T3D/turret/aiTurretShape.h
@@ -257,6 +257,8 @@ public:
 
    void addToIgnoreList(ShapeBase* obj);
    void removeFromIgnoreList(ShapeBase* obj);
+   S32  ignoreListCount();
+   SimObject* getIgnoreListObject(S32 index);  
 
    void setTurretStateName(const char* newState, bool force=false);
    void setTurretState(U32 newState, bool force=false);


### PR DESCRIPTION
Implements feature(s) requested in issue #1272 
The first feature is exposing a function to Torquescript that allows retrieving the count of the total number of objects on a turret's ai ignore list, ignoreListCount().

The second feature is exposing a function to Torquescript that allows retrieving a reference to an object on an AI turret's ignore list based off of the index in the list of that object, rather than the object's ID (so the object's ID does not have to be known beforehand).  The feature request issue #1272 requests for this feature to return the object's ID but then shows an example modifying the object directly (increasing the health of the object by 10), so to fulfill the requested functionality based on the example, this feature returns a reference to the object itself so that properties can be called and modified on the object directly, as shown in the example on the feature request.