### PR TITLE
Fixed old names of decal properties

### DIFF
--- a/Templates/Full/game/art/decals/managedDecalData.cs
+++ b/Templates/Full/game/art/decals/managedDecalData.cs
@@ -39,8 +39,8 @@ datablock DecalData(ScorchRXDecal)
    texRows = "2";
    texCols = "2";
    clippingAngle = "80";
-   screenStartRadius = "200";
-   screenEndRadius = "100";
+   fadeStartPixelSize = "200";
+   fadeEndPixelSize = "100";
 };
 
 datablock DecalData(bulletHoleDecal)
@@ -51,7 +51,7 @@ datablock DecalData(bulletHoleDecal)
    randomize = "1";
    texRows = "2";
    texCols = "2";
-   screenStartRadius = "20";
-   screenEndRadius = "5";
+   fadeStartPixelSize = "20";
+   fadeEndPixelSize = "5";
    clippingAngle = "180";
 };


### PR DESCRIPTION
Renamed the screenStartRadius and screenEndRadius properties in the bulletHoleDecal datablock and ScorchRXDecal datablock to fadeStartPixelSize and fadeEndPixelSize properties, respectively, to match names of the properties as defined in the decalData.cpp file, as noted in issue #1498
Among other possible fixes, this makes the size of the bullet hole decal's actually random in size now, instead of always being the exact same size.