### PR TITLE
Drag coefficient misspelled

### DIFF
--- a/Templates/Full/game/art/datablocks/weapons/grenadefx.cs
+++ b/Templates/Full/game/art/datablocks/weapons/grenadefx.cs
@@ -55,7 +55,7 @@ datablock LightDescription(GrenadeLauncherLightDesc)
 datablock ParticleData(GrenadeDebrisFireParticle)
 {
    textureName = "art/particles/impact";
-   dragCoeffiecient = 0;
+   dragCoefficient = 0;
    gravityCoefficient = -1.00366;
    inheritedVelFactor = 0.0;
    constantAcceleration = 0.0;
@@ -298,7 +298,7 @@ datablock SplashData(GrenadeSplash)
 datablock ParticleData(GrenadeExpFire)
 {
    textureName = "art/particles/fireball.png";
-   dragCoeffiecient = 0;
+   dragCoefficient = 0;
    windCoeffiecient = 0.5;
    gravityCoefficient = -1;
    inheritedVelFactor = 0;
@@ -462,7 +462,7 @@ datablock ParticleEmitterData(GrenadeExpSparksEmitter)
 datablock ParticleData(GrenadeExpSmoke)
 {
    textureName = "art/particles/smoke";
-   dragCoeffiecient = 0;
+   dragCoefficient = 0;
    gravityCoefficient = -0.40293;
    inheritedVelFactor = 0.0;
    constantAcceleration = 0.0;
@@ -630,7 +630,7 @@ datablock ParticleEmitterData(GLWaterExpSparkEmitter)
 datablock ParticleData(GLWaterExpSmoke)
 {
    textureName = "art/particles/smoke";
-   dragCoeffiecient = 0.4;
+   dragCoefficient = 0.4;
    gravityCoefficient = -0.25;
    inheritedVelFactor = 0.025;
    constantAcceleration = -1.1;
@@ -845,7 +845,7 @@ datablock ParticleEmitterData(GrenadeTrailWaterEmitter)
 datablock ParticleData(GrenadeProjSmokeTrail)
 {
    textureName = "art/particles/smoke";
-   dragCoeffiecient = 0.0;
+   dragCoefficient = 0.0;
    gravityCoefficient = -0.2;
    inheritedVelFactor = 0.0;
    constantAcceleration = 0.0;

--- a/Templates/Full/game/art/datablocks/weapons/rocketfx.cs
+++ b/Templates/Full/game/art/datablocks/weapons/rocketfx.cs
@@ -28,7 +28,7 @@ datablock SFXProfile(RocketLauncherExplosionSound)
 datablock ParticleData(RocketDebrisTrailParticle)
 {
    textureName = "art/particles/impact";
-   dragCoeffiecient = 0;
+   dragCoefficient = 0;
    inheritedVelFactor = 0.0;
    constantAcceleration = 0.0;
    lifetimeMS = 1200;//1000;

--- a/Templates/Modules/FPSGameplay/scripts/datablocks/weapons/grenadefx.cs
+++ b/Templates/Modules/FPSGameplay/scripts/datablocks/weapons/grenadefx.cs
@@ -55,7 +55,7 @@ datablock LightDescription(GrenadeLauncherLightDesc)
 datablock ParticleData(GrenadeDebrisFireParticle)
 {
    textureName = "data/FPSGameplay/art/particles/impact";
-   dragCoeffiecient = 0;
+   dragCoefficient = 0;
    gravityCoefficient = -1.00366;
    inheritedVelFactor = 0.0;
    constantAcceleration = 0.0;
@@ -298,7 +298,7 @@ datablock SplashData(GrenadeSplash)
 datablock ParticleData(GrenadeExpFire)
 {
    textureName = "data/FPSGameplay/art/particles/fireball.png";
-   dragCoeffiecient = 0;
+   dragCoefficient = 0;
    windCoeffiecient = 0.5;
    gravityCoefficient = -1;
    inheritedVelFactor = 0;
@@ -462,7 +462,7 @@ datablock ParticleEmitterData(GrenadeExpSparksEmitter)
 datablock ParticleData(GrenadeExpSmoke)
 {
    textureName = "data/FPSGameplay/art/particles/smoke";
-   dragCoeffiecient = 0;
+   dragCoefficient = 0;
    gravityCoefficient = -0.40293;
    inheritedVelFactor = 0.0;
    constantAcceleration = 0.0;
@@ -630,7 +630,7 @@ datablock ParticleEmitterData(GLWaterExpSparkEmitter)
 datablock ParticleData(GLWaterExpSmoke)
 {
    textureName = "data/FPSGameplay/art/particles/smoke";
-   dragCoeffiecient = 0.4;
+   dragCoefficient = 0.4;
    gravityCoefficient = -0.25;
    inheritedVelFactor = 0.025;
    constantAcceleration = -1.1;
@@ -845,7 +845,7 @@ datablock ParticleEmitterData(GrenadeTrailWaterEmitter)
 datablock ParticleData(GrenadeProjSmokeTrail)
 {
    textureName = "data/FPSGameplay/art/particles/smoke";
-   dragCoeffiecient = 0.0;
+   dragCoefficient = 0.0;
    gravityCoefficient = -0.2;
    inheritedVelFactor = 0.0;
    constantAcceleration = 0.0;

--- a/Templates/Modules/FPSGameplay/scripts/datablocks/weapons/rocketfx.cs
+++ b/Templates/Modules/FPSGameplay/scripts/datablocks/weapons/rocketfx.cs
@@ -28,7 +28,7 @@ datablock SFXProfile(RocketLauncherExplosionSound)
 datablock ParticleData(RocketDebrisTrailParticle)
 {
    textureName = "data/FPSGameplay/art/particles/impact";
-   dragCoeffiecient = 0;
+   dragCoefficient = 0;
    inheritedVelFactor = 0.0;
    constantAcceleration = 0.0;
    lifetimeMS = 1200;//1000;


### PR DESCRIPTION
This addresses issue #1501 
The property variable "dragCoefficient" was misspelled in various datablocks in the grenadeFX.cs and rocketFX.cs files, both in the Templates directory locations and the Modules directory locations.  It was misspelled as "dragCoeffiecient", as noted in the issue ticket.  Some but not all of those locations were spelled correct, but the property was misspelled in numerous other locations in those two files as well.  This corrects the spelling of those properties so that users trying to reference those properties in other parts of the Torquescript will be able to reference them by the correct name.  
For instance, if one had a list of datablocks that included some where the property was spelled correctly and some where it was spelled incorrectly, and wanted to iterate through that list, changing the "dragCoefficient"property for each, they would get an error as some of the datablocks would not have the "dragCoefficient" property, as it was misspelled in them.
This also makes it more intuitive for users to reference that property in other parts of Torquescript even when referencing it for a single datablock as they now do not need to know that the property is misspelled, and how it is misspelled.