### PR TITLE
Checking Torque3D with PVS-Studio static analyzer

### DIFF
--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -2148,7 +2148,7 @@ DefineEngineFunction( displaySplashWindow, bool, (const char* path), (""),
    "@return True if the splash window could be successfully initialized.\n\n"
    "@ingroup Platform" )
 {
-   if (path == "")
+   if (path == NULL || *path == '\0')
    {
       path = Con::getVariable("$Core::splashWindowImage");
    }

--- a/Engine/source/core/strings/unicode.cpp
+++ b/Engine/source/core/strings/unicode.cpp
@@ -469,7 +469,7 @@ U32 oneUTF32toUTF8(const UTF32 codepoint, UTF8 *threeByteCodeunitBuf)
 
    //-----------------
    U8  mask = sgByteMask8LUT[0];            // 0011 1111
-   U8  marker = ( ~mask << 1);            // 1000 0000
+   U8  marker = ( ~static_cast<U32>(mask) << 1u);            // 1000 0000
    
    // Process the low order bytes, shifting the codepoint down 6 each pass.
    for( S32 i = bytecount-1; i > 0; i--)

--- a/Engine/source/core/util/tSignal.h
+++ b/Engine/source/core/util/tSignal.h
@@ -161,8 +161,8 @@ protected:
    SignalSig *mSignal;
 
 private:
-   SignalSlot( const SignalSlot&) {}
-   SignalSlot& operator=( const SignalSlot&) {}
+   SignalSlot( const SignalSlot&);
+   SignalSlot& operator=( const SignalSlot&);
 };
 
 template<typename Signature> class SignalBaseT : public SignalBase

--- a/Engine/source/forest/forestCollision.h
+++ b/Engine/source/forest/forestCollision.h
@@ -58,7 +58,7 @@ public:
       mData          = cv.mData;
       mScale         = cv.mScale;
       hullId         = cv.hullId;
-      box            = box;
+      box            = cv.box;
    }
 
    void           calculateTransform( const MatrixF &worldXfrm );

--- a/Engine/source/sfx/media/sfxVorbisStream.cpp
+++ b/Engine/source/sfx/media/sfxVorbisStream.cpp
@@ -198,7 +198,7 @@ S32 SFXVorbisStream::read( U8 *buffer,
    // requests longer than this.
    const U32 MAXREAD = 4096;
 
-   U32 bytesRead = 0;
+   S64 bytesRead = 0;
    U32 offset = 0;
    U32 bytesToRead = 0;
 


### PR DESCRIPTION
Hello,
I have found and fixed some bugs using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

Analyzer warnings:

* [V591](https://www.viva64.com/en/w/V591/) Non-void function should return a value. [Engine/source/core/util/tSignal.h 165](https://github.com/GarageGames/Torque3D/blob/development/Engine/source/core/util/tSignal.h#L165)

  _Comment_: If there is needed to prevent the copying of the object, then there is no need to provide the definition of the copy constructor and the assignment operator, because the member functions and `friend` functions can still call them. 

  _Note_: If the code is compiled by a compiler with support for the C++11 standard, you can delete them using the keyword `delete` like this:
  
  <pre><code>....
  public:
    SignalSlot( const SignalSlot&) = delete;
    SignalSlot& operator=( const SignalSlot&) = delete;
  ....</code></pre>


* [V547](https://www.viva64.com/en/w/V547/) Expression 'bytesRead < 0' is always false. Unsigned type value is never < 0. [Engine/source/sfx/media/sfxVorbisStream.cpp 217](https://github.com/GarageGames/Torque3D/blob/development/Engine/source/sfx/media/sfxVorbisStream.cpp#L217)

  _Comment_: The variable `bytesRead` of type `unsigned int` stores the result of the `ov_read` function, which returns a signed value (`long`). Comparison `bytesRead < 0` does not make sense.

* [V547](https://www.viva64.com/en/w/V547/) Expression 'path == ""' is always false. To compare strings you should use strcmp() function. [Engine/source/console/consoleFunctions.cpp 2151](https://github.com/GarageGames/Torque3D/blob/development/Engine/source/console/consoleFunctions.cpp#L2151)

  _Comment_: The comparison `path == ""` will not be as expected. To compare a C-string to an empty string, either use the `strcmp` function, or compare the first byte of the string with the null-terminal character.

* [V610](https://www.viva64.com/en/w/V610/) Undefined behavior. Check the shift operator '<<'. The left operand '~mask' is negative. [Engine/source/core/strings/unicode.cpp 472](https://github.com/GarageGames/Torque3D/blob/development/Engine/source/core/strings/unicode.cpp#L472)

  _Comment_:  	In an arithmetic expression, all the variables whose values can be represented with type `int` will be promoted to this type. Therefore,  the variable `mask` will be promoted to the `int` type and the result of the `~mask` expression will be a negative number. By the C++ standard, shifting a negative number to the left leads to an undefined behavior.

* [V570](https://www.viva64.com/en/w/V570/) The 'box' variable is assigned to itself. [Engine/source/forest/forestCollision.h 61](https://github.com/GarageGames/Torque3D/blob/development/Engine/source/forest/forestCollision.h#L61)

  _Comment_: When copying a `cv` object, its `cv.box` field was not copied.

In addition, I suggest having a look at the emails, sent from @pvs-studio.com.

Best regards,
Phillip Khandeliants