### PR TITLE
VolumetricFog memory leak fix

### DIFF
--- a/Engine/source/environment/VolumetricFog.cpp
+++ b/Engine/source/environment/VolumetricFog.cpp
@@ -142,7 +142,7 @@ VolumetricFog::VolumetricFog()
 
 VolumetricFog::~VolumetricFog()
 {
-   if (isClientObject())
+   if (!isClientObject())
       return;
 
    for (S32 i = 0; i < det_size.size(); i++)
@@ -152,12 +152,11 @@ VolumetricFog::~VolumetricFog()
       if (det_size[i].piArray != NULL)
          delete(det_size[i].piArray);
       if (det_size[i].verts != NULL)
-         delete(det_size[i].verts);
+         delete [] (det_size[i].verts);
    }
    det_size.clear();
 
-   if (z_buf.isValid())
-      SAFE_DELETE(z_buf);
+   z_buf = NULL;
 
    if (!mTexture.isNull())
       mTexture.free();
@@ -365,7 +364,7 @@ bool VolumetricFog::LoadShape()
       if (det_size[i].piArray != NULL)
          delete(det_size[i].piArray);
       if (det_size[i].verts != NULL)
-         delete(det_size[i].verts);
+         delete [] (det_size[i].verts);
    }
    det_size.clear();
 


### PR DESCRIPTION
Fixes a memory leak on clients and prevents a crash from deleting a RTT target while it's still registered with the GFX device.