### PR TITLE
Ups the #pragma pack call from 4 to 8 when using 64bit

### DIFF
--- a/Engine/source/console/engineFunctions.h
+++ b/Engine/source/console/engineFunctions.h
@@ -80,7 +80,7 @@ struct EngineFunctionDefaultArguments
 
 // Need byte-aligned packing for the default argument structures.
 #ifdef _WIN64
-#pragma pack( push, 4 )
+#pragma pack( push, 8 )
 #else
 #pragma pack( push, 1 )
 #endif


### PR DESCRIPTION
ps the #pragma pack call from 4 to 8 when using 64bit, as per suggested settings. This shaves off a lot of compatibility warnings.