### PR TITLE
BugFix for GFXDrawUtil::drawTextN()

### DIFF
--- a/Engine/source/gfx/gfxDrawUtil.cpp
+++ b/Engine/source/gfx/gfxDrawUtil.cpp
@@ -148,9 +148,8 @@ U32 GFXDrawUtil::drawTextN( GFont *font, const Point2I &ptDraw, const UTF8 *in_s
       return ptDraw.x;
 
    // Convert to UTF16 temporarily.
-   n++; // space for null terminator
-   FrameTemp<UTF16> ubuf( n );
-   convertUTF8toUTF16N(in_string, ubuf, n);
+   FrameTemp<UTF16> ubuf( n + 1 ); // (n+1) to add space for null terminator
+   convertUTF8toUTF16N(in_string, ubuf, n + 1);
 
    return drawTextN( font, ptDraw, ubuf, n, colorTable, maxColorIndex, rot );
 }


### PR DESCRIPTION
This PR fixes a bug that was causing GFXDrawUtil::drawTextN() to draw one character more than requested if in_string is longer than n. This bug shows up in the GuiMessageVectorCtrl when lines are split. The first character of the second part of the string is duplicated on the line above. You can trace through from here: https://github.com/GarageGames/Torque3D/blob/development/Engine/source/gui/game/guiMessageVectorCtrl.cpp#L717 to see it happen, if you have a control with split lines.
Specifically,
GFX->getDrawUtil()->drawTextN(mProfile->mFont, start, "0123456789", 5, mProfile->mFontColors, mMaxColorIndex, 0.0f);
will render 6 characters instead of 5 as requested.