### PR TITLE
Console Classes dump allocation fix

### DIFF
--- a/Engine/source/console/consoleDoc.cpp
+++ b/Engine/source/console/consoleDoc.cpp
@@ -85,7 +85,7 @@ void printClassHeader(const char* usage, const char * className, const char * su
       Con::printf("///       information was available for this class.");
    }
 
-   if( usage != NULL )
+   if( usage != NULL && usage != "")
    {
       // Copy Usage Document
       S32 usageLen = dStrlen( usage );

--- a/Engine/source/console/consoleDoc.cpp
+++ b/Engine/source/console/consoleDoc.cpp
@@ -85,7 +85,7 @@ void printClassHeader(const char* usage, const char * className, const char * su
       Con::printf("///       information was available for this class.");
    }
 
-   if( usage != NULL && usage != "")
+   if((usage != NULL) && strlen(usage))
    {
       // Copy Usage Document
       S32 usageLen = dStrlen( usage );


### PR DESCRIPTION
Console Classes dump fix. It was running aground on having a case where there was a empty string value for the 'usage' field in the class header. This would break the allocation because we're allocating nothing. This rejects it if the usage field is an empty string.

This is in reference to issue #2005.