### PR TITLE
VS2017 compiler workaround

### DIFF
--- a/Engine/source/console/engineFunctions.h
+++ b/Engine/source/console/engineFunctions.h
@@ -108,7 +108,17 @@ private:
       std::tie(std::get<I + (sizeof...(ArgTs) - sizeof...(TailTs))>(args)...) = defaultArgs;
    }
    
+#ifdef _MSC_VER == 1910
+   template<typename ...TailTs>
+   struct DodgyVCHelper
+   {
+      using type = typename std::enable_if<sizeof...(TailTs) <= sizeof...(ArgTs), decltype(mArgs)>::type;
+   };
+
+   template<typename ...TailTs> using MaybeSelfEnabled = typename DodgyVCHelper<TailTs...>::type;
+#else
    template<typename ...TailTs> using MaybeSelfEnabled = typename std::enable_if<sizeof...(TailTs) <= sizeof...(ArgTs), decltype(mArgs)>::type;
+#endif
    
    template<typename ...TailTs> static MaybeSelfEnabled<TailTs...> tailInit(TailTs ...tail) {
       std::tuple<DefVST<ArgTs>...> argsT;


### PR DESCRIPTION
Works around the regressive behavior in the VSC++ compiler for VS2017 where the variadic templates would not compile correctly. Issue should be patched in future versions, so for now it'll target the 1910 version specifically.