### PR TITLE
#if cleanup for the VS2017 workaround

### DIFF
--- a/Engine/source/console/engineFunctions.h
+++ b/Engine/source/console/engineFunctions.h
@@ -108,7 +108,7 @@ private:
       std::tie(std::get<I + (sizeof...(ArgTs) - sizeof...(TailTs))>(args)...) = defaultArgs;
    }
    
-#ifdef _MSC_VER == 1910
+#if _MSC_VER == 1910
    template<typename ...TailTs>
    struct DodgyVCHelper
    {


### PR DESCRIPTION
Fixes the #if rather than using the #ifdef.