### PR TITLE
extra option for terrain block to disable the update of the basetexture

### DIFF
--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -196,7 +196,8 @@ TerrainBlock::TerrainBlock()
    mPhysicsRep( NULL ),
    mScreenError( 16 ),
    mCastShadows( true ),
-   mZoningDirty( false )
+   mZoningDirty( false ),
+   mUpdateBasetex ( true )
 {
    mTypeMask = TerrainObjectType | StaticObjectType | StaticShapeObjectType;
    mNetFlags.set(Ghostable | ScopeAlways);
@@ -961,7 +962,7 @@ bool TerrainBlock::onAdd()
       // If the cached base texture is older that the terrain file or
       // it doesn't exist then generate and cache it.
       String baseCachePath = _getBaseTexCacheFileName();
-      if ( Platform::compareModifiedTimes( baseCachePath, mTerrFileName ) < 0 )
+      if ( Platform::compareModifiedTimes( baseCachePath, mTerrFileName ) < 0 && mUpdateBasetex )
          _updateBaseTexture( true );
 
       // The base texture should have been cached by now... so load it.
@@ -1145,6 +1146,8 @@ void TerrainBlock::initPersistFields()
          "Light map dimensions in pixels." );
 
       addField( "screenError", TypeS32, Offset( mScreenError, TerrainBlock ), "Not yet implemented." );
+	
+      addField( "updateBasetex", TypeBool, Offset( mUpdateBasetex, TerrainBlock ), "Whether or not to update the Base Texture" );
 
    endGroup( "Misc" );
 
@@ -1198,6 +1201,8 @@ U32 TerrainBlock::packUpdate(NetConnection* con, U32 mask, BitStream *stream)
       stream->write( mScreenError );
 
    stream->writeInt(mBaseTexFormat, 32);
+	
+   stream->writeFlag( mUpdateBasetex );
 
    return retMask;
 }
@@ -1267,6 +1272,8 @@ void TerrainBlock::unpackUpdate(NetConnection* con, BitStream *stream)
       stream->read( &mScreenError );
 
    mBaseTexFormat = (BaseTexFormat)stream->readInt(32);
+	
+   mUpdateBasetex = stream->readFlag();
 }
 
 void TerrainBlock::getMinMaxHeight( F32 *minHeight, F32 *maxHeight ) const 


### PR DESCRIPTION
This adds another checkbox in the terrain datablock in the editor, where you can disable the auto generation of the basetexture, which allows you to use a custom basetexture for the whole terrain. Terrain generation software often puts out a precalculated basetexture and with this option you can use it by just renaming it into level.basetex.png or whatever and the engine will use it and not overwrite it.