### PR TITLE
Fixes blending issues while respecting #1704

### DIFF
--- a/Engine/source/lighting/advanced/hlsl/advancedLightingFeaturesHLSL.cpp
+++ b/Engine/source/lighting/advanced/hlsl/advancedLightingFeaturesHLSL.cpp
@@ -30,6 +30,7 @@
 #include "renderInstance/renderDeferredMgr.h"
 #include "materials/processedMaterial.h"
 #include "materials/materialFeatureTypes.h"
+#include "terrain/terrFeatureTypes.h"
 
 
 void DeferredRTLightingFeatHLSL::processPixMacros( Vector<GFXShaderMacro> &macros, 
@@ -132,6 +133,8 @@ void DeferredRTLightingFeatHLSL::processPix( Vector<ShaderComponent*> &component
    lightBufferTex->uniform = true;
    lightBufferTex->texture = true;
    lightBufferTex->constNum = lightInfoBuffer->constNum;
+   if (fd.features.hasFeature(MFT_TerrainDetailMap))
+      lightInfoBuffer->constNum = 6;
 
    // Declare the RTLighting variables in this feature, they will either be assigned
    // in this feature, or in the tonemap/lightmap feature

--- a/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
+++ b/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
@@ -483,7 +483,7 @@ void TerrainDetailMapFeatHLSL::processPix(   Vector<ShaderComponent*> &component
 
    // Add to the blend total.
 
-   meta->addStatement(new GenOp("   @ = max( @, @ );\r\n", blendTotal, blendTotal, detailBlend));
+   meta->addStatement(new GenOp("   @ += @;\r\n", blendTotal, detailBlend));
 
    // If we had a parallax feature... then factor in the parallax
    // amount so that it fades out with the layer blending.
@@ -786,7 +786,7 @@ void TerrainMacroMapFeatHLSL::processPix(   Vector<ShaderComponent*> &componentL
    }
 
    // Add to the blend total.
-   meta->addStatement(new GenOp("   @ = max( @, @ );\r\n", blendTotal, blendTotal, detailBlend));
+   meta->addStatement(new GenOp("   @ += @;\r\n", blendTotal, detailBlend));
 
    Var *detailColor = (Var*)LangElement::find( "macroColor" ); 
    if ( !detailColor )

--- a/Engine/source/terrain/hlsl/terrFeatureHLSL.h
+++ b/Engine/source/terrain/hlsl/terrFeatureHLSL.h
@@ -41,9 +41,9 @@ protected:
 
 public:
    TerrainFeatHLSL();
-   Var* _getInDetailCoord(Vector<ShaderComponent*> &componentList );
+   Var* _computeAndGetInDetailCoord(MultiLine* meta, Vector<ShaderComponent*> &componentList );
 
-   Var* _getInMacroCoord(Vector<ShaderComponent*> &componentList );
+   Var* _computeAndGetInMacroCoord(MultiLine* meta, Vector<ShaderComponent*> &componentList );
 
    Var* _getNormalMapTex();
 


### PR DESCRIPTION
The corrections to the blendTotal were reverted due to issue #1704 . This will revert that revert, while also making the terrain render in a single pass (at least for up to ~20 textures per terrain cell, which should be reasonable).

In order to allow rendering the terrain in a single pass, I had to move some calculations from vertex to pixel shader, so a benchmark on how this affects performance should definetly be considered.

In theory, it should be possible to solve this issue with the multi-pass rendering technique utilized currently, but I haven't been able to make it work.