### PR TITLE
Reworks the $Core::commonShaderPath variable usage

### DIFF
--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -960,7 +960,7 @@ const char *getObjectTokenField(const char *name)
    return NULL;
 }
 
-const char *getVariable(const char *name)
+const char *getVariable(const char *name, const char* def)
 {
    const char *objField = getObjectTokenField(name);
    if (objField)
@@ -970,7 +970,7 @@ const char *getVariable(const char *name)
    else
    {
       Dictionary::Entry *entry = getVariableEntry(name);
-      return entry ? entry->getStringValue() : "";
+      return entry ? entry->getStringValue() : def;
    }
 }
 

--- a/Engine/source/console/console.h
+++ b/Engine/source/console/console.h
@@ -620,7 +620,7 @@ namespace Con
    /// Retrieve the string value of a global console variable
    /// @param name   Global Console variable name to query
    /// @return       The string value of the variable or "" if the variable does not exist.
-   const char* getVariable(const char* name);
+   const char* getVariable(const char* name, const char* def = "");
 
    /// Retrieve the string value of an object field
    /// @param name   "object.field" string to query

--- a/Engine/source/forest/glsl/windDeformationGLSL.cpp
+++ b/Engine/source/forest/glsl/windDeformationGLSL.cpp
@@ -60,7 +60,7 @@ MODULE_END;
 
 
 WindDeformationGLSL::WindDeformationGLSL()
-   : mDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/wind.glsl" ))
+   : mDep(ShaderGen::smCommonShaderPath + String("/gl/wind.glsl" ))
 {
    addDependency( &mDep );
 }

--- a/Engine/source/forest/hlsl/windDeformationHLSL.cpp
+++ b/Engine/source/forest/hlsl/windDeformationHLSL.cpp
@@ -60,7 +60,7 @@ MODULE_END;
 
 
 WindDeformationHLSL::WindDeformationHLSL()
-   : mDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/wind.hlsl" ))
+   : mDep(ShaderGen::smCommonShaderPath + String("/wind.hlsl" ))
 {
    addDependency( &mDep );
 }

--- a/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
@@ -37,6 +37,7 @@
 #include "windowManager/platformWindow.h"
 #include "gfx/D3D11/screenshotD3D11.h"
 #include "materials/shaderData.h"
+#include "shaderGen/shaderGen.h"
 
 #ifdef TORQUE_DEBUG
 #include "d3d11sdklayers.h"
@@ -838,8 +839,8 @@ void GFXD3D11Device::setupGenericShaders(GenericShaderType type)
       //shader model 4.0 is enough for the generic shaders
       const char* shaderModel = "4.0";
       shaderData = new ShaderData();
-      shaderData->setField("DXVertexShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/colorV.hlsl"));
-      shaderData->setField("DXPixelShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/colorP.hlsl"));
+      shaderData->setField("DXVertexShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/colorV.hlsl"));
+      shaderData->setField("DXPixelShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/colorP.hlsl"));
       shaderData->setField("pixVersion", shaderModel);
       shaderData->registerObject();
       mGenericShader[GSColor] =  shaderData->getShader();
@@ -848,8 +849,8 @@ void GFXD3D11Device::setupGenericShaders(GenericShaderType type)
       Sim::getRootGroup()->addObject(shaderData);
 
       shaderData = new ShaderData();
-      shaderData->setField("DXVertexShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/modColorTextureV.hlsl"));
-      shaderData->setField("DXPixelShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/modColorTextureP.hlsl"));
+      shaderData->setField("DXVertexShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/modColorTextureV.hlsl"));
+      shaderData->setField("DXPixelShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/modColorTextureP.hlsl"));
       shaderData->setField("pixVersion", shaderModel);
       shaderData->registerObject();
       mGenericShader[GSModColorTexture] = shaderData->getShader();
@@ -858,8 +859,8 @@ void GFXD3D11Device::setupGenericShaders(GenericShaderType type)
       Sim::getRootGroup()->addObject(shaderData);
 
       shaderData = new ShaderData();
-      shaderData->setField("DXVertexShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/addColorTextureV.hlsl"));
-      shaderData->setField("DXPixelShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/addColorTextureP.hlsl"));
+      shaderData->setField("DXVertexShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/addColorTextureV.hlsl"));
+      shaderData->setField("DXPixelShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/addColorTextureP.hlsl"));
       shaderData->setField("pixVersion", shaderModel);
       shaderData->registerObject();
       mGenericShader[GSAddColorTexture] = shaderData->getShader();
@@ -868,8 +869,8 @@ void GFXD3D11Device::setupGenericShaders(GenericShaderType type)
       Sim::getRootGroup()->addObject(shaderData);
 
       shaderData = new ShaderData();
-      shaderData->setField("DXVertexShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/textureV.hlsl"));
-      shaderData->setField("DXPixelShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/textureP.hlsl"));
+      shaderData->setField("DXVertexShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/textureV.hlsl"));
+      shaderData->setField("DXPixelShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/textureP.hlsl"));
       shaderData->setField("pixVersion", shaderModel);
       shaderData->registerObject();
       mGenericShader[GSTexture] = shaderData->getShader();

--- a/Engine/source/gfx/gl/gfxGLDevice.cpp
+++ b/Engine/source/gfx/gl/gfxGLDevice.cpp
@@ -46,6 +46,7 @@
 #include "gfx/gl/gfxGLStateCache.h"
 #include "gfx/gl/gfxGLVertexAttribLocation.h"
 #include "gfx/gl/gfxGLVertexDecl.h"
+#include "shaderGen/shaderGen.h"
 
 GFXAdapter::CreateDeviceInstanceDelegate GFXGLDevice::mCreateDeviceInstance(GFXGLDevice::createInstance); 
 
@@ -781,8 +782,8 @@ void GFXGLDevice::setupGenericShaders( GenericShaderType type )
       ShaderData *shaderData;
 
       shaderData = new ShaderData();
-      shaderData->setField("OGLVertexShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/gl/colorV.glsl"));
-      shaderData->setField("OGLPixelShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/gl/colorP.glsl"));
+      shaderData->setField("OGLVertexShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/gl/colorV.glsl"));
+      shaderData->setField("OGLPixelShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/gl/colorP.glsl"));
       shaderData->setField("pixVersion", "2.0");
       shaderData->registerObject();
       mGenericShader[GSColor] =  shaderData->getShader();
@@ -791,8 +792,8 @@ void GFXGLDevice::setupGenericShaders( GenericShaderType type )
       Sim::getRootGroup()->addObject(shaderData);
 
       shaderData = new ShaderData();
-      shaderData->setField("OGLVertexShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/gl/modColorTextureV.glsl"));
-      shaderData->setField("OGLPixelShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/gl/modColorTextureP.glsl"));
+      shaderData->setField("OGLVertexShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/gl/modColorTextureV.glsl"));
+      shaderData->setField("OGLPixelShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/gl/modColorTextureP.glsl"));
       shaderData->setSamplerName("$diffuseMap", 0);
       shaderData->setField("pixVersion", "2.0");
       shaderData->registerObject();
@@ -802,8 +803,8 @@ void GFXGLDevice::setupGenericShaders( GenericShaderType type )
       Sim::getRootGroup()->addObject(shaderData);
 
       shaderData = new ShaderData();
-      shaderData->setField("OGLVertexShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/gl/addColorTextureV.glsl"));
-      shaderData->setField("OGLPixelShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/gl/addColorTextureP.glsl"));
+      shaderData->setField("OGLVertexShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/gl/addColorTextureV.glsl"));
+      shaderData->setField("OGLPixelShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/gl/addColorTextureP.glsl"));
       shaderData->setSamplerName("$diffuseMap", 0);
       shaderData->setField("pixVersion", "2.0");
       shaderData->registerObject();
@@ -813,8 +814,8 @@ void GFXGLDevice::setupGenericShaders( GenericShaderType type )
       Sim::getRootGroup()->addObject(shaderData);
 
       shaderData = new ShaderData();
-      shaderData->setField("OGLVertexShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/gl/textureV.glsl"));
-      shaderData->setField("OGLPixelShaderFile", String(Con::getVariable("$Core::CommonShaderPath")) + String("/fixedFunction/gl/textureP.glsl"));
+      shaderData->setField("OGLVertexShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/gl/textureV.glsl"));
+      shaderData->setField("OGLPixelShaderFile", ShaderGen::smCommonShaderPath + String("/fixedFunction/gl/textureP.glsl"));
       shaderData->setSamplerName("$diffuseMap", 0);
       shaderData->setField("pixVersion", "2.0");
       shaderData->registerObject();

--- a/Engine/source/shaderGen/GLSL/bumpGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/bumpGLSL.cpp
@@ -29,7 +29,7 @@
 #include "materials/processedMaterial.h"
 #include "materials/materialFeatureTypes.h"
 #include "shaderGen/shaderGenVars.h"
-
+#include "shaderGen/shaderGen.h"
 
 void BumpFeatGLSL::processVert(  Vector<ShaderComponent*> &componentList, 
                                  const MaterialFeatureData &fd )
@@ -235,7 +235,7 @@ void BumpFeatGLSL::setTexData(   Material::StageData &stageDat,
 
 
 ParallaxFeatGLSL::ParallaxFeatGLSL()
-   : mIncludeDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/torque.glsl" ))
+   : mIncludeDep(ShaderGen::smCommonShaderPath + String("/gl/torque.glsl" ))
 {
    addDependency( &mIncludeDep );
 }

--- a/Engine/source/shaderGen/GLSL/pixSpecularGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/pixSpecularGLSL.cpp
@@ -27,10 +27,10 @@
 #include "shaderGen/shaderOp.h"
 #include "shaderGen/shaderGenVars.h"
 #include "gfx/gfxStructs.h"
-
+#include "shaderGen/shaderGen.h"
 
 PixelSpecularGLSL::PixelSpecularGLSL()
-   : mDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/lighting.glsl" ))
+   : mDep(ShaderGen::smCommonShaderPath + String("/gl/lighting.glsl" ))
 {
    addDependency( &mDep );
 }

--- a/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
@@ -35,6 +35,8 @@
 #include "lighting/advanced/advancedLightBinManager.h"
 #include "ts/tsShape.h"
 
+#include "shaderGen/shaderGen.h"
+
 LangElement * ShaderFeatureGLSL::setupTexSpaceMat( Vector<ShaderComponent*> &, // componentList
                                                    Var **texSpaceMat )
 {
@@ -830,7 +832,7 @@ Var* ShaderFeatureGLSL::addOutDetailTexCoord(   Vector<ShaderComponent*> &compon
 //****************************************************************************
 
 DiffuseMapFeatGLSL::DiffuseMapFeatGLSL()
-: mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/torque.glsl"))
+: mTorqueDep(ShaderGen::smCommonShaderPath + String("/gl/torque.glsl"))
 {
 	addDependency(&mTorqueDep);
 }
@@ -1951,7 +1953,7 @@ void ReflectCubeFeatGLSL::setTexData(  Material::StageData &stageDat,
 //****************************************************************************
 
 RTLightingFeatGLSL::RTLightingFeatGLSL()
-   : mDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/lighting.glsl" ))
+   : mDep(ShaderGen::smCommonShaderPath + String("/gl/lighting.glsl" ))
 {
    addDependency( &mDep );
 }
@@ -2164,7 +2166,7 @@ ShaderFeature::Resources RTLightingFeatGLSL::getResources( const MaterialFeature
 //****************************************************************************
 
 FogFeatGLSL::FogFeatGLSL()
-   : mFogDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/torque.glsl" ))
+   : mFogDep(ShaderGen::smCommonShaderPath + String("/gl/torque.glsl" ))
 {
    addDependency( &mFogDep );
 }
@@ -2294,7 +2296,7 @@ ShaderFeature::Resources FogFeatGLSL::getResources( const MaterialFeatureData &f
 //****************************************************************************
 
 VisibilityFeatGLSL::VisibilityFeatGLSL()
-   : mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/torque.glsl" ))
+   : mTorqueDep(ShaderGen::smCommonShaderPath + String("/gl/torque.glsl" ))
 {
    addDependency( &mTorqueDep );
 }
@@ -2460,7 +2462,7 @@ void RenderTargetZeroGLSL::processPix( Vector<ShaderComponent*> &componentList, 
 //****************************************************************************
 
 HDROutGLSL::HDROutGLSL()
-   : mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/torque.glsl" ))
+   : mTorqueDep(ShaderGen::smCommonShaderPath + String("/gl/torque.glsl" ))
 {
    addDependency( &mTorqueDep );
 }
@@ -2481,7 +2483,7 @@ void HDROutGLSL::processPix(  Vector<ShaderComponent*> &componentList,
 #include "T3D/fx/groundCover.h"
 
 FoliageFeatureGLSL::FoliageFeatureGLSL()
-: mDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/foliage.glsl" ))
+: mDep(ShaderGen::smCommonShaderPath + String("/gl/foliage.glsl" ))
 {
    addDependency( &mDep );
 }
@@ -2627,7 +2629,7 @@ void ParticleNormalFeatureGLSL::processVert(Vector<ShaderComponent*> &componentL
 //****************************************************************************
 
 ImposterVertFeatureGLSL::ImposterVertFeatureGLSL()
-   :  mDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/imposter.glsl" ))
+   :  mDep(ShaderGen::smCommonShaderPath + String("/gl/imposter.glsl" ))
 {
    addDependency( &mDep );
 }

--- a/Engine/source/shaderGen/GLSL/shaderGenGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderGenGLSL.cpp
@@ -37,7 +37,7 @@ void ShaderGenPrinterGLSL::printShaderHeader( Stream& stream )
    stream.write( dStrlen(header1), header1 );
 
    // Cheap HLSL compatibility.
-   String header3 = String("#include \"") + String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/hlslCompat.glsl\"\r\n");
+   String header3 = String("#include \"") + ShaderGen::smCommonShaderPath + String("/gl/hlslCompat.glsl\"\r\n");
    stream.write(dStrlen(header3), header3.c_str());
 
    const char* header4 = "\r\n";      

--- a/Engine/source/shaderGen/HLSL/bumpHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/bumpHLSL.cpp
@@ -29,7 +29,7 @@
 #include "materials/processedMaterial.h"
 #include "materials/materialFeatureTypes.h"
 #include "shaderGen/shaderGenVars.h"
-
+#include "shaderGen/shaderGen.h"
 
 void BumpFeatHLSL::processVert(  Vector<ShaderComponent*> &componentList, 
                                  const MaterialFeatureData &fd )
@@ -239,7 +239,7 @@ void BumpFeatHLSL::setTexData(   Material::StageData &stageDat,
 
 
 ParallaxFeatHLSL::ParallaxFeatHLSL()
-   : mIncludeDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/torque.hlsl" ))
+   : mIncludeDep(ShaderGen::smCommonShaderPath + String("/torque.hlsl" ))
 {
    addDependency( &mIncludeDep );
 }

--- a/Engine/source/shaderGen/HLSL/pixSpecularHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/pixSpecularHLSL.cpp
@@ -27,10 +27,10 @@
 #include "shaderGen/shaderOp.h"
 #include "shaderGen/shaderGenVars.h"
 #include "gfx/gfxStructs.h"
-
+#include "shaderGen/shaderGen.h"
 
 PixelSpecularHLSL::PixelSpecularHLSL()
-   : mDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/lighting.hlsl" ))
+   : mDep(ShaderGen::smCommonShaderPath + String("/lighting.hlsl" ))
 {
    addDependency( &mDep );
 }

--- a/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
@@ -35,6 +35,8 @@
 #include "lighting/advanced/advancedLightBinManager.h"
 #include "ts/tsShape.h"
 
+#include "shaderGen/shaderGen.h"
+
 LangElement * ShaderFeatureHLSL::setupTexSpaceMat( Vector<ShaderComponent*> &, // componentList
                                                    Var **texSpaceMat )
 {
@@ -821,7 +823,7 @@ Var* ShaderFeatureHLSL::addOutDetailTexCoord(   Vector<ShaderComponent*> &compon
 //****************************************************************************
 
 DiffuseMapFeatHLSL::DiffuseMapFeatHLSL()
-: mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/torque.hlsl"))
+: mTorqueDep(ShaderGen::smCommonShaderPath + String("/torque.hlsl"))
 {
 	addDependency(&mTorqueDep);
 }
@@ -2021,7 +2023,7 @@ void ReflectCubeFeatHLSL::setTexData(  Material::StageData &stageDat,
 //****************************************************************************
 
 RTLightingFeatHLSL::RTLightingFeatHLSL()
-   : mDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/lighting.hlsl" ))
+   : mDep(ShaderGen::smCommonShaderPath + String("/lighting.hlsl" ))
 {
    addDependency( &mDep );
 }
@@ -2234,7 +2236,7 @@ ShaderFeature::Resources RTLightingFeatHLSL::getResources( const MaterialFeature
 //****************************************************************************
 
 FogFeatHLSL::FogFeatHLSL()
-   : mFogDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/torque.hlsl" ))
+   : mFogDep(ShaderGen::smCommonShaderPath + String("/torque.hlsl" ))
 {
    addDependency( &mFogDep );
 }
@@ -2364,7 +2366,7 @@ ShaderFeature::Resources FogFeatHLSL::getResources( const MaterialFeatureData &f
 //****************************************************************************
 
 VisibilityFeatHLSL::VisibilityFeatHLSL()
-   : mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/torque.hlsl" ))
+   : mTorqueDep(ShaderGen::smCommonShaderPath + String("/torque.hlsl" ))
 {
    addDependency( &mTorqueDep );
 }
@@ -2531,7 +2533,7 @@ void RenderTargetZeroHLSL::processPix( Vector<ShaderComponent*> &componentList, 
 //****************************************************************************
 
 HDROutHLSL::HDROutHLSL()
-   : mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/torque.hlsl" ))
+   : mTorqueDep(ShaderGen::smCommonShaderPath + String("/torque.hlsl" ))
 {
    addDependency( &mTorqueDep );
 }
@@ -2552,7 +2554,7 @@ void HDROutHLSL::processPix(  Vector<ShaderComponent*> &componentList,
 #include "T3D/fx/groundCover.h"
 
 FoliageFeatureHLSL::FoliageFeatureHLSL()
-: mDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/foliage.hlsl" ))
+: mDep(ShaderGen::smCommonShaderPath + String("/foliage.hlsl" ))
 {
    addDependency( &mDep );
 }
@@ -2698,7 +2700,7 @@ void ParticleNormalFeatureHLSL::processVert(Vector<ShaderComponent*> &componentL
 //****************************************************************************
 
 ImposterVertFeatureHLSL::ImposterVertFeatureHLSL()
-   :  mDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/imposter.hlsl" ))
+   :  mDep(ShaderGen::smCommonShaderPath + String("/imposter.hlsl" ))
 {
    addDependency( &mDep );
 }

--- a/Engine/source/shaderGen/shaderGen.cpp
+++ b/Engine/source/shaderGen/shaderGen.cpp
@@ -49,7 +49,7 @@ MODULE_BEGIN( ShaderGen )
 
 MODULE_END;
 
-String ShaderGen::smCommonShaderPath(Con::getVariable("$Core::CommonShaderPath", "shaders/common"));
+String ShaderGen::smCommonShaderPath("shaders/common");
 
 ShaderGen::ShaderGen()
 {

--- a/Engine/source/shaderGen/shaderGen.cpp
+++ b/Engine/source/shaderGen/shaderGen.cpp
@@ -49,6 +49,7 @@ MODULE_BEGIN( ShaderGen )
 
 MODULE_END;
 
+String ShaderGen::smCommonShaderPath(Con::getVariable("$Core::CommonShaderPath", "shaders/common"));
 
 ShaderGen::ShaderGen()
 {
@@ -124,6 +125,8 @@ void ShaderGen::initShaderGen()
 
    // Delete the auto-generated conditioner include file.
    Torque::FS::Remove( "shadergen:/" + ConditionerFeature::ConditionerIncludeFileName );
+
+   smCommonShaderPath = String(Con::getVariable("$Core::CommonShaderPath", "shaders/common"));
 }
 
 void ShaderGen::generateShader( const MaterialFeatureData &featureData,

--- a/Engine/source/shaderGen/shaderGen.h
+++ b/Engine/source/shaderGen/shaderGen.h
@@ -47,7 +47,6 @@
 #include "materials/materialFeatureData.h"
 #endif
 
-
 /// Base class used by shaderGen to be API agnostic.  Subclasses implement the various methods
 /// in an API specific way.
 class ShaderGenPrinter
@@ -164,6 +163,8 @@ public:
    void setPrinter(ShaderGenPrinter* printer) { mPrinter = printer; }
    void setComponentFactory(ShaderGenComponentFactory* factory) { mComponentFactory = factory; }
    void setFileEnding(String ending) { mFileEnding = ending; }
+
+   static String smCommonShaderPath;
 
 protected:   
 

--- a/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
+++ b/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
@@ -70,7 +70,7 @@ MODULE_END;
 
 
 TerrainFeatGLSL::TerrainFeatGLSL()
-   : mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/torque.glsl" ))
+   : mTorqueDep(ShaderGen::smCommonShaderPath + String("/gl/torque.glsl" ))
    {      
    addDependency( &mTorqueDep );
    }
@@ -293,8 +293,8 @@ U32 TerrainBaseMapFeatGLSL::getOutputTargets( const MaterialFeatureData &fd ) co
 }
 
 TerrainDetailMapFeatGLSL::TerrainDetailMapFeatGLSL()
-   :  mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/torque.glsl" )),
-      mTerrainDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/terrain/terrain.glsl" ))
+   :  mTorqueDep(ShaderGen::smCommonShaderPath + String("/gl/torque.glsl" )),
+      mTerrainDep(ShaderGen::smCommonShaderPath + String("/terrain/terrain.glsl" ))
       
 {
    addDependency( &mTorqueDep );
@@ -662,8 +662,8 @@ U32 TerrainDetailMapFeatGLSL::getOutputTargets( const MaterialFeatureData &fd ) 
 
 
 TerrainMacroMapFeatGLSL::TerrainMacroMapFeatGLSL()
-   :  mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/gl/torque.glsl" )),
-      mTerrainDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/terrain/terrain.glsl" ))
+   :  mTorqueDep(ShaderGen::smCommonShaderPath + String("/gl/torque.glsl" )),
+      mTerrainDep(ShaderGen::smCommonShaderPath + String("/terrain/terrain.glsl" ))
       
 {
    addDependency( &mTorqueDep );

--- a/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
+++ b/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
@@ -69,7 +69,7 @@ MODULE_END;
 
 
 TerrainFeatHLSL::TerrainFeatHLSL()
-   : mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/torque.hlsl" ))
+   : mTorqueDep(ShaderGen::smCommonShaderPath + String("/torque.hlsl" ))
 {      
    addDependency( &mTorqueDep );
 }
@@ -299,8 +299,8 @@ U32 TerrainBaseMapFeatHLSL::getOutputTargets( const MaterialFeatureData &fd ) co
 }
 
 TerrainDetailMapFeatHLSL::TerrainDetailMapFeatHLSL()
-   :  mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/torque.hlsl" )),
-      mTerrainDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/terrain/terrain.hlsl" ))
+   :  mTorqueDep(ShaderGen::smCommonShaderPath + String("/torque.hlsl" )),
+      mTerrainDep(ShaderGen::smCommonShaderPath + String("/terrain/terrain.hlsl" ))
       
 {
    addDependency( &mTorqueDep );
@@ -629,8 +629,8 @@ U32 TerrainDetailMapFeatHLSL::getOutputTargets( const MaterialFeatureData &fd ) 
 
 
 TerrainMacroMapFeatHLSL::TerrainMacroMapFeatHLSL()
-   :  mTorqueDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/torque.hlsl" )),
-      mTerrainDep(String(Con::getVariable("$Core::CommonShaderPath")) + String("/terrain/terrain.hlsl" ))
+   :  mTorqueDep(ShaderGen::smCommonShaderPath + String("/torque.hlsl" )),
+      mTerrainDep(ShaderGen::smCommonShaderPath + String("/terrain/terrain.hlsl" ))
       
 {
    addDependency( &mTorqueDep );


### PR DESCRIPTION
Reworks the $Core::commonShaderPath variable usage to be a static variable in ShaderGen for efficiency(only one getVariable when shadergen is initialized), as well as implements the ability to set a default value, and ensures that it tries to set a path even if the pref variable is missing which is important for ported projects from older builds.