### PR TITLE
Adds missing GFX Texture format strings

### DIFF
--- a/Engine/source/gfx/gfxStringEnumTranslate.cpp
+++ b/Engine/source/gfx/gfxStringEnumTranslate.cpp
@@ -164,6 +164,12 @@ void GFXStringEnumTranslate::init()
    GFX_STRING_ASSIGN_MACRO( GFXStringTextureFormat, GFXFormatR16F );
    GFX_STRING_ASSIGN_MACRO( GFXStringTextureFormat, GFXFormatR16G16F );
    GFX_STRING_ASSIGN_MACRO( GFXStringTextureFormat, GFXFormatR10G10B10A2 );
+
+   GFX_STRING_ASSIGN_MACRO( GFXStringTextureFormat, GFXFormatR8G8B8_SRGB );
+   GFX_STRING_ASSIGN_MACRO( GFXStringTextureFormat, GFXFormatR8G8B8A8_LINEAR_FORCE );
+   GFX_STRING_ASSIGN_MACRO( GFXStringTextureFormat, GFXFormatBC1_SRGB );
+   GFX_STRING_ASSIGN_MACRO( GFXStringTextureFormat, GFXFormatBC2_SRGB );
+   GFX_STRING_ASSIGN_MACRO( GFXStringTextureFormat, GFXFormatBC3_SRGB );
    VALIDATE_LOOKUPTABLE( GFXStringTextureFormat, GFXFormat);
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This commit eliminates 5 warnings output from VALIDATE_LOOKUPTABLE here: https://github.com/GarageGames/Torque3D/blob/development/Engine/source/gfx/gfxStringEnumTranslate.cpp#L167
And prevents a fatal error here: https://github.com/GarageGames/Torque3D/blob/development/Engine/source/gfx/gfxTextureManager.cpp#L1371
that occurs when called from GuiOffscreenCanvas::_setupTargets() for an OpenVROverlay because GFXFormatR8G8B8A8_LINEAR_FORCE  is used.