### PR TITLE
Fix potential crash with D3D11

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
@@ -824,7 +824,9 @@ void GFXD3D11Device::reset(DXGI_SWAP_CHAIN_DESC &d3dpp)
 
    // Now re aquire all the resources we trashed earlier
    reacquireDefaultPoolResources();
-
+   //set last bound shaders
+   mD3DDeviceContext->PSSetShader(mLastPixShader, NULL, 0);
+   mD3DDeviceContext->VSSetShader(mLastVertShader, NULL, 0);
    // Mark everything dirty and flush to card, for sanity.
    updateStates(true);
 }

--- a/Engine/source/gfx/D3D11/gfxD3D11Device.h
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.h
@@ -134,7 +134,6 @@ protected:
    ID3D11DeviceContext1* mD3DDeviceContext1;
    ID3DUserDefinedAnnotation* mUserAnnotation;
 
-   GFXShader* mCurrentShader;
    GFXShaderRef mGenericShader[GS_COUNT];
    GFXShaderConstBufferRef mGenericShaderBuffer[GS_COUNT];
    GFXShaderConstHandle *mModelViewProjSC[GS_COUNT];


### PR DESCRIPTION
This fixes a potential crash with D3D11 that usually happens when playing a video or displaying a splash screen and resizing the window