### PR TITLE
Hotfix to make VS2017 15.3 play nice.

### DIFF
--- a/Engine/source/console/consoleTypes.h
+++ b/Engine/source/console/consoleTypes.h
@@ -48,6 +48,13 @@ template<typename T> inline const T nullAsType(){ return nullptr; }
 /// @ingroup console_system Console System
 /// @{
 
+#if _MSC_VER >= 1911
+   #ifdef offsetof
+      #undef offsetof
+   #endif // offsetof
+   #define offsetof(s,m) ((size_t)&reinterpret_cast<char const volatile&>((((s*)0)->m)))
+#endif
+
 #ifndef Offset
 #define Offset(x, cls) offsetof(cls, x)
 #endif


### PR DESCRIPTION
Hotfix to make VS2017 15.3 play nice. Offsetof behavior - specifically builtin - is unreliable in release(and broken in debug), so explicitly defining it to use a reliable method for now.