### PR TITLE
Fixes smCommonShaderPath init order

### DIFF
--- a/Engine/source/shaderGen/shaderGen.cpp
+++ b/Engine/source/shaderGen/shaderGen.cpp
@@ -96,6 +96,8 @@ void ShaderGen::initShaderGen()
    if (!mInitDelegates[adapterType])
       return;
 
+   smCommonShaderPath = String(Con::getVariable("$Core::CommonShaderPath", "shaders/common"));
+
    mInitDelegates[adapterType](this);
    mFeatureInitSignal.trigger( adapterType );
    mInit = true;
@@ -125,8 +127,6 @@ void ShaderGen::initShaderGen()
 
    // Delete the auto-generated conditioner include file.
    Torque::FS::Remove( "shadergen:/" + ConditionerFeature::ConditionerIncludeFileName );
-
-   smCommonShaderPath = String(Con::getVariable("$Core::CommonShaderPath", "shaders/common"));
 }
 
 void ShaderGen::generateShader( const MaterialFeatureData &featureData,


### PR DESCRIPTION
Moves the initialization of the shader common path const var so it is set before we do an initial setup of some shadergen fields.

Resolves #2079