### PR TITLE
textureProfile conflict reporting

### DIFF
--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -254,6 +254,8 @@ GFXTextureObject *GFXTextureManager::_lookupTexture( const char *hashName, const
    //compare just the profile flags and not the entire profile, names could be different but otherwise identical flags
    if (ret && (ret->mProfile->compareFlags(*profile)))
       return ret;
+   else if (ret)
+      Con::warnf("GFXTextureManager::_lookupTexture: Cached texture %s has a different profile flag", hashName);
 
    return NULL;
 }


### PR DESCRIPTION
from@rextimmy: reports the same texture used with 2 conflicting textureProfiles (flipping back and forth causes duplicates)