### PR TITLE
Sets the default grid snap size to 1 rather than 10.

### DIFF
--- a/Engine/source/gui/worldEditor/gizmo.cpp
+++ b/Engine/source/gui/worldEditor/gizmo.cpp
@@ -182,7 +182,7 @@ GizmoProfile::GizmoProfile()
    gridColor.set(255,255,255,20);
    planeDim = 500.0f;   
 
-   gridSize.set(10,10,10);
+   gridSize.set(1,1,1);
    snapToGrid = false;
    allowSnapRotations = true;
    rotationSnap = 15.0f;

--- a/Templates/Full/game/tools/worldEditor/scripts/editorPrefs.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editorPrefs.ed.cs
@@ -128,7 +128,7 @@ EditorSettings.setDefaultValue(  "renderInfoText",          "1"               );
 
 EditorSettings.beginGroup( "Grid" );
 EditorSettings.setDefaultValue(  "gridColor",               "255 255 255 20"  );
-EditorSettings.setDefaultValue(  "gridSize",                "10 10 10"        );
+EditorSettings.setDefaultValue(  "gridSize",                "1 1 1"        );
 EditorSettings.setDefaultValue(  "snapToGrid",              "0"               ); //<-- Not currently used
 EditorSettings.setDefaultValue(  "renderPlane",             "0"               );
 EditorSettings.setDefaultValue(  "renderPlaneHashes",       "0"               );


### PR DESCRIPTION
Sets the default grid snap size to 1 rather than 10. 1 Seems like a more neutral default value, and also makes it match the displayed '1' in the UI interface as the default as well.