### PR TITLE
Fixed a typo where the value of outBytesWritten was being clamped incorrectly.

### DIFF
--- a/Engine/source/platform/platformNet.cpp
+++ b/Engine/source/platform/platformNet.cpp
@@ -1672,7 +1672,7 @@ Net::Error Net::send(NetSocket handleFd, const U8 *buffer, S32 bufferSize, S32 *
 
    if (outBytesWritten)
    {
-      *outBytesWritten = outBytesWritten < 0 ? 0 : bytesWritten;
+      *outBytesWritten = *outBytesWritten < 0 ? 0 : bytesWritten;
    }
 
    return PlatformNetState::getLastError();


### PR DESCRIPTION
There was a small typo in `platformNet.cpp` where the `outBytesWritten` was being checked as a pointer, rather than a value, leading to the code not compiling under the latest xcode, but also this would've potentially allowed negative `outBytesWritten` values since the value being checked was a pointer, rather than the value of the pointer.