### PR TITLE
allows for arbitrary reskinning

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -1953,6 +1953,7 @@ void Player::reSkin()
 {
    if ( isGhost() && mShapeInstance && mSkinNameHandle.isValidString() )
    {
+	  mShapeInstance->resetMaterialList();
       Vector<String> skins;
       String(mSkinNameHandle.getString()).split( ";", skins );
 

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -3689,6 +3689,7 @@ void ShapeBase::reSkin()
 {
    if ( isGhost() && mShapeInstance && mSkinNameHandle.isValidString() )
    {
+	  mShapeInstance->resetMaterialList();
       Vector<String> skins;
       String(mSkinNameHandle.getString()).split( ";", skins );
 

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -534,6 +534,7 @@ void TSStatic::reSkin()
 {
    if ( isGhost() && mShapeInstance && mSkinNameHandle.isValidString() )
    {
+	  mShapeInstance->resetMaterialList();
       Vector<String> skins;
       String(mSkinNameHandle.getString()).split( ";", skins );
 

--- a/Engine/source/ts/tsShapeInstance.cpp
+++ b/Engine/source/ts/tsShapeInstance.cpp
@@ -307,13 +307,19 @@ void TSShapeInstance::reSkin( String newBaseName, String oldBaseName )
    {
       // Try changing base
       const String &pName = materialNames[i];
-	  String newName( pName );
-	  newName.replace( oldBaseName, newBaseName );
+	  String newName( String::ToLower(pName) );
+	  newName.replace( String::ToLower(oldBaseName), String::ToLower(newBaseName) );
 	  pMatList->renameMaterial( i, newName );
    }
 
    // Initialize the material instances
    initMaterialList();
+}
+
+void TSShapeInstance::resetMaterialList()
+{
+	TSMaterialList* oMatlist = mShape->materialList;
+	setMaterialList(oMatlist);
 }
 
 //-------------------------------------------------------------------------------------

--- a/Engine/source/ts/tsShapeInstance.cpp
+++ b/Engine/source/ts/tsShapeInstance.cpp
@@ -307,12 +307,9 @@ void TSShapeInstance::reSkin( String newBaseName, String oldBaseName )
    {
       // Try changing base
       const String &pName = materialNames[i];
-      if ( pName.compare( oldBaseName, oldBaseNameLength, String::NoCase ) == 0 )
-      {
-         String newName( pName );
-         newName.replace( 0, oldBaseNameLength, newBaseName );
-         pMatList->renameMaterial( i, newName );
-      }
+	  String newName( pName );
+	  newName.replace( oldBaseName, newBaseName );
+	  pMatList->renameMaterial( i, newName );
    }
 
    // Initialize the material instances

--- a/Engine/source/ts/tsShapeInstance.h
+++ b/Engine/source/ts/tsShapeInstance.h
@@ -377,7 +377,7 @@ protected:
    }
 
    void reSkin( String newBaseName, String oldBaseName = String::EmptyString );
-
+   void resetMaterialList();
    enum
    {
       MaskNodeRotation       = 0x01,


### PR DESCRIPTION
allows arbitrary material name string replacement, rather than forcing folks to start with base. ie: an entry of skin = "blue; area=fire";  would replace base_area_grid with blue_fire_grid as the used material