### PR TITLE
Typo in afxParticlePool_T3D.cpp

### DIFF
--- a/Engine/source/afx/util/afxParticlePool_T3D.cpp
+++ b/Engine/source/afx/util/afxParticlePool_T3D.cpp
@@ -28,7 +28,7 @@
 #include "scene/sceneRenderState.h"
 #include "T3D/fx/particleEmitter.h"
 #include "renderInstance/renderPassManager.h"
-#include "lighting/lightinfo.h"
+#include "lighting/lightInfo.h"
 #include "lighting/lightManager.h"
 
 #include "afx/util/afxParticlePool.h"


### PR DESCRIPTION
There was a typo in afxParticlePool_T3D.cpp that was including lightinfo.h instead of light**I**nfo.h