### PR TITLE
Fix forest editor failing to load forest

### DIFF
--- a/Templates/BaseGame/game/tools/forestEditor/forestEditorGui.cs
+++ b/Templates/BaseGame/game/tools/forestEditor/forestEditorGui.cs
@@ -50,7 +50,7 @@ function ForestEditorGui::onActiveForestUpdated( %this, %forest, %createNew )
 /// Called from a message box when a forest is not found.
 function ForestEditorGui::createForest( %this )
 {
-   %forestObject = parseMissionGroupForIds("Forest", "");
+   %forestObject = trim(parseMissionGroupForIds("Forest", ""));
  
    if ( isObject( %forestObject ) )
    {

--- a/Templates/BaseGame/game/tools/forestEditor/main.cs
+++ b/Templates/BaseGame/game/tools/forestEditor/main.cs
@@ -144,7 +144,7 @@ function ForestEditorPlugin::onActivated( %this )
    //ForestEditToolbar.setVisible( true );
 
    //Get our existing forest object in our current mission if we have one
-   %forestObject = parseMissionGroupForIds("Forest", "");
+   %forestObject = trim(parseMissionGroupForIds("Forest", ""));
    if(isObject(%forestObject))
    {
       ForestEditorGui.setActiveForest(%forestObject.getName());
@@ -242,7 +242,7 @@ function ForestEditorPlugin::onSaveMission( %this, %missionFile )
    ForestDataManager.saveDirty();
 
    //First, find out if we have an existing forest object
-   %forestObject = parseMissionGroupForIds("Forest", "");
+   %forestObject = trim(parseMissionGroupForIds("Forest", ""));
  
    if ( isObject( %forestObject ) )
    {

--- a/Templates/Full/game/tools/forestEditor/forestEditorGui.cs
+++ b/Templates/Full/game/tools/forestEditor/forestEditorGui.cs
@@ -50,7 +50,7 @@ function ForestEditorGui::onActiveForestUpdated( %this, %forest, %createNew )
 /// Called from a message box when a forest is not found.
 function ForestEditorGui::createForest( %this )
 {
-   %forestObject = parseMissionGroupForIds("Forest", "");
+   %forestObject = trim(parseMissionGroupForIds("Forest", ""));
  
    if ( isObject( %forestObject ) )
    {

--- a/Templates/Full/game/tools/forestEditor/main.cs
+++ b/Templates/Full/game/tools/forestEditor/main.cs
@@ -143,7 +143,7 @@ function ForestEditorPlugin::onActivated( %this )
    //ForestEditToolbar.setVisible( true );
 
    //Get our existing forest object in our current mission if we have one
-   %forestObject = parseMissionGroupForIds("Forest", "");
+   %forestObject = trim(parseMissionGroupForIds("Forest", ""));
    if(isObject(%forestObject))
    {
       ForestEditorGui.setActiveForest(%forestObject.getName());
@@ -241,7 +241,7 @@ function ForestEditorPlugin::onSaveMission( %this, %missionFile )
    ForestDataManager.saveDirty();
 
    //First, find out if we have an existing forest object
-   %forestObject = parseMissionGroupForIds("Forest", "");
+   %forestObject = trim(parseMissionGroupForIds("Forest", ""));
  
    if ( isObject( %forestObject ) )
    {


### PR DESCRIPTION
Caused by space after objectID returned by parseMissionGroupForIds().  The meant that `isObject(%forestObject)` was returning false.