### PR TITLE
Fixes the inspector/component editor to display components

### DIFF
--- a/Engine/source/gui/editor/guiInspector.h
+++ b/Engine/source/gui/editor/guiInspector.h
@@ -89,6 +89,9 @@ public:
       else
          return nullptr;
    }
+
+   S32 getComponentGroupTargetId() { return mComponentGroupTargetId; }
+   void setComponentGroupTargetId(S32 compId) { mComponentGroupTargetId = compId; }
    
    /// Return the number of objects being inspected by this GuiInspector.
    U32 getNumInspectObjects() const { return mTargets.size(); }
@@ -146,6 +149,8 @@ protected:
 
    /// Objects being inspected by this GuiInspector.
    TargetVector mTargets;
+
+   S32 mComponentGroupTargetId;
    
    F32 mDividerPos;   
    S32 mDividerMargin;

--- a/Engine/source/gui/editor/inspector/componentGroup.cpp
+++ b/Engine/source/gui/editor/inspector/componentGroup.cpp
@@ -38,10 +38,11 @@ ConsoleDocClass(GuiInspectorComponentGroup,
    "@internal"
    );
 
-GuiInspectorComponentGroup::GuiInspectorComponentGroup(StringTableEntry groupName, SimObjectPtr<GuiInspector> parent)
+GuiInspectorComponentGroup::GuiInspectorComponentGroup(StringTableEntry groupName, SimObjectPtr<GuiInspector> parent, Component* targetComponent)
 : GuiInspectorGroup(groupName, parent) 
 { 
    /*mNeedScroll=false;*/
+   mTargetComponent = targetComponent;
 };
 
 bool GuiInspectorComponentGroup::onAdd()
@@ -89,15 +90,277 @@ bool GuiInspectorComponentGroup::inspectGroup()
    GuiRolloutCtrl *pArrayRollout = NULL;
    bool bGrabItems = false;
 
-   Component* comp = dynamic_cast<Component*>(getInspector()->getInspectObject(0));
-
    //if this isn't a component, what are we even doing here?
-   if (!comp)
+   if (!mTargetComponent)
       return false;
 
-   for (U32 i = 0; i < comp->getComponentFieldCount(); i++)
+   mParent->setComponentGroupTargetId(mTargetComponent->getId());
+
+   //first, relevent static fields
+   AbstractClassRep::FieldList& fieldList = mTargetComponent->getClassRep()->mFieldList;
+   for (AbstractClassRep::FieldList::iterator itr = fieldList.begin();
+      itr != fieldList.end(); ++itr)
    {
-      ComponentField* field = comp->getComponentField(i);
+      AbstractClassRep::Field* field = &(*itr);
+      if (field->type == AbstractClassRep::StartGroupFieldType)
+      {
+         // If we're dealing with general fields, always set grabItems to true (to skip them)
+         if (bNoGroup == true)
+            bGrabItems = true;
+         else if (dStricmp(field->pGroupname, mCaption) == 0)
+            bGrabItems = true;
+         continue;
+      }
+      else if (field->type == AbstractClassRep::EndGroupFieldType)
+      {
+         // If we're dealing with general fields, always set grabItems to false (to grab them)
+         if (bNoGroup == true)
+            bGrabItems = false;
+         else if (dStricmp(field->pGroupname, mCaption) == 0)
+            bGrabItems = false;
+         continue;
+      }
+
+      // Skip field if it has the HideInInspectors flag set.
+      if (field->flag.test(AbstractClassRep::FIELD_HideInInspectors))
+         continue;
+
+      if (field->pFieldname == StringTable->insert("locked") || field->pFieldname == StringTable->insert("class")
+         || field->pFieldname == StringTable->insert("internalName"))
+         continue;
+
+      if (/*(bGrabItems == true || (bNoGroup == true && bGrabItems == false)) &&*/ itr->type != AbstractClassRep::DeprecatedFieldType)
+      {
+         if (bNoGroup == true && bGrabItems == true)
+            continue;
+
+         if (field->type == AbstractClassRep::StartArrayFieldType)
+         {
+#ifdef DEBUG_SPEW
+            Platform::outputDebugString("[GuiInspectorGroup] Beginning array '%s'",
+               field->pFieldname);
+#endif
+
+            // Starting an array...
+            // Create a rollout for the Array, give it the array's name.
+            GuiRolloutCtrl *arrayRollout = new GuiRolloutCtrl();
+            GuiControlProfile *arrayRolloutProfile = dynamic_cast<GuiControlProfile*>(Sim::findObject("GuiInspectorRolloutProfile0"));
+
+            arrayRollout->setControlProfile(arrayRolloutProfile);
+            //arrayRollout->mCaption = StringTable->insert( String::ToString( "%s (%i)", field->pGroupname, field->elementCount ) );
+            arrayRollout->setCaption(field->pGroupname);
+            //arrayRollout->setMargin( 14, 0, 0, 0 );
+            arrayRollout->registerObject();
+
+            GuiStackControl *arrayStack = new GuiStackControl();
+            arrayStack->registerObject();
+            arrayStack->freeze(true);
+            arrayRollout->addObject(arrayStack);
+
+            // Allocate a rollout for each element-count in the array
+            // Give it the element count name.
+            for (U32 i = 0; i < field->elementCount; i++)
+            {
+               GuiRolloutCtrl *elementRollout = new GuiRolloutCtrl();
+               GuiControlProfile *elementRolloutProfile = dynamic_cast<GuiControlProfile*>(Sim::findObject("GuiInspectorRolloutProfile0"));
+
+               char buf[256];
+               dSprintf(buf, 256, "  [%i]", i);
+
+               elementRollout->setControlProfile(elementRolloutProfile);
+               elementRollout->setCaption(buf);
+               //elementRollout->setMargin( 14, 0, 0, 0 );
+               elementRollout->registerObject();
+
+               GuiStackControl *elementStack = new GuiStackControl();
+               elementStack->registerObject();
+               elementRollout->addObject(elementStack);
+               elementRollout->instantCollapse();
+
+               arrayStack->addObject(elementRollout);
+            }
+
+            pArrayRollout = arrayRollout;
+            pArrayStack = arrayStack;
+            arrayStack->freeze(false);
+            pArrayRollout->instantCollapse();
+            mStack->addObject(arrayRollout);
+
+            bMakingArray = true;
+            continue;
+         }
+         else if (field->type == AbstractClassRep::EndArrayFieldType)
+         {
+#ifdef DEBUG_SPEW
+            Platform::outputDebugString("[GuiInspectorGroup] Ending array '%s'",
+               field->pFieldname);
+#endif
+
+            bMakingArray = false;
+            continue;
+         }
+
+         if (bMakingArray)
+         {
+            // Add a GuiInspectorField for this field, 
+            // for every element in the array...
+            for (U32 i = 0; i < pArrayStack->size(); i++)
+            {
+               FrameTemp<char> intToStr(64);
+               dSprintf(intToStr, 64, "%d", i);
+
+               // The array stack should have a rollout for each element
+               // as children...
+               GuiRolloutCtrl *pRollout = dynamic_cast<GuiRolloutCtrl*>(pArrayStack->at(i));
+               // And the each of those rollouts should have a stack for 
+               // fields...
+               GuiStackControl *pStack = dynamic_cast<GuiStackControl*>(pRollout->at(0));
+
+               // And we add a new GuiInspectorField to each of those stacks...            
+               GuiInspectorField *fieldGui = constructField(field->type);
+               if (fieldGui == NULL)
+                  fieldGui = new GuiInspectorField();
+
+               fieldGui->init(mParent, this);
+               StringTableEntry caption = field->pFieldname;
+               fieldGui->setInspectorField(field, caption, intToStr);
+
+               if (fieldGui->registerObject())
+               {
+#ifdef DEBUG_SPEW
+                  Platform::outputDebugString("[GuiInspectorGroup] Adding array element '%s[%i]'",
+                     field->pFieldname, i);
+#endif
+
+                  mChildren.push_back(fieldGui);
+                  pStack->addObject(fieldGui);
+               }
+               else
+                  delete fieldGui;
+            }
+
+            continue;
+         }
+
+         // This is weird, but it should work for now. - JDD
+         // We are going to check to see if this item is an array
+         // if so, we're going to construct a field for each array element
+         if (field->elementCount > 1)
+         {
+            // Make a rollout control for this array
+            //
+            GuiRolloutCtrl *rollout = new GuiRolloutCtrl();
+            rollout->setDataField(StringTable->insert("profile"), NULL, "GuiInspectorRolloutProfile0");
+            rollout->setCaption(String::ToString("%s (%i)", field->pFieldname, field->elementCount));
+            rollout->setMargin(14, 0, 0, 0);
+            rollout->registerObject();
+            mArrayCtrls.push_back(rollout);
+
+            // Put a stack control within the rollout
+            //
+            GuiStackControl *stack = new GuiStackControl();
+            stack->setDataField(StringTable->insert("profile"), NULL, "GuiInspectorStackProfile");
+            stack->registerObject();
+            stack->freeze(true);
+            rollout->addObject(stack);
+
+            mStack->addObject(rollout);
+
+            // Create each field and add it to the stack.
+            //
+            for (S32 nI = 0; nI < field->elementCount; nI++)
+            {
+               FrameTemp<char> intToStr(64);
+               dSprintf(intToStr, 64, "%d", nI);
+
+               // Construct proper ValueName[nI] format which is "ValueName0" for index 0, etc.
+
+               String fieldName = String::ToString("%s%d", field->pFieldname, nI);
+
+               // If the field already exists, just update it
+               GuiInspectorField *fieldGui = findField(fieldName);
+               if (fieldGui != NULL)
+               {
+                  fieldGui->updateValue();
+                  continue;
+               }
+
+               bNewItems = true;
+
+               fieldGui = constructField(field->type);
+               if (fieldGui == NULL)
+                  fieldGui = new GuiInspectorField();
+
+               fieldGui->init(mParent, this);
+               StringTableEntry caption = StringTable->insert(String::ToString("   [%i]", nI));
+               fieldGui->setInspectorField(field, caption, intToStr);
+
+               fieldGui->setTargetObject(mTargetComponent);
+
+               if (fieldGui->registerObject())
+               {
+                  mChildren.push_back(fieldGui);
+                  stack->addObject(fieldGui);
+               }
+               else
+                  delete fieldGui;
+            }
+
+            stack->freeze(false);
+            stack->updatePanes();
+            rollout->instantCollapse();
+         }
+         else
+         {
+            // If the field already exists, just update it
+            GuiInspectorField *fieldGui = findField(field->pFieldname);
+            if (fieldGui != NULL)
+            {
+               fieldGui->updateValue();
+               continue;
+            }
+
+            bNewItems = true;
+
+            fieldGui = constructField(field->type);
+            if (fieldGui == NULL)
+               fieldGui = new GuiInspectorField();
+
+            fieldGui->init(mParent, this);
+            fieldGui->setInspectorField(field);
+
+            fieldGui->setTargetObject(mTargetComponent);
+
+            if (fieldGui->registerObject())
+            {
+#ifdef DEBUG_SPEW
+               Platform::outputDebugString("[GuiInspectorGroup] Adding field '%s'",
+                  field->pFieldname);
+#endif
+               fieldGui->setValue(mTargetComponent->getDataField(field->pFieldname, NULL));
+
+               mChildren.push_back(fieldGui);
+               mStack->addObject(fieldGui);
+            }
+            else
+            {
+               SAFE_DELETE(fieldGui);
+            }
+         }
+      }
+   }
+
+   for (U32 i = 0; i < mTargetComponent->getComponentFieldCount(); i++)
+   {
+      ComponentField* field = mTargetComponent->getComponentField(i);
+
+      //first and foremost, nab the field type and check if it's a custom field or not.
+      //If it's not a custom field, proceed below, if it is, hand it off to script to be handled by the component
+      if (field->mFieldType == -1)
+      {
+         Con::executef(this, "onConstructComponentField", mTargetComponent, field->mFieldName);
+         continue;
+      }
 
       bNewItems = true;
 
@@ -107,10 +370,12 @@ bool GuiInspectorComponentGroup::inspectGroup()
 
       fieldGui->init(mParent, this);
 
-      AbstractClassRep::Field *refField;
+      fieldGui->setTargetObject(mTargetComponent);
+
+      AbstractClassRep::Field *refField = NULL;
 
       //check dynamics
-      SimFieldDictionary* fieldDictionary = comp->getFieldDictionary();
+      SimFieldDictionary* fieldDictionary = mTargetComponent->getFieldDictionary();
       SimFieldDictionaryIterator itr(fieldDictionary);
 
       while (*itr)
@@ -196,6 +461,14 @@ void GuiInspectorComponentGroup::onMouseMove(const GuiEvent &event)
 {
    //mParent->mOverDivider = false;
 }
+
+void GuiInspectorComponentGroup::onRightMouseUp(const GuiEvent &event)
+{
+   //mParent->mOverDivider = false;
+   if (isMethod("onRightMouseUp"))
+      Con::executef(this, "onRightMouseUp", event.mousePoint);
+}
+
 ConsoleMethod(GuiInspectorComponentGroup, inspectGroup, bool, 2, 2, "Refreshes the dynamic fields in the inspector.")
 {
    return object->inspectGroup();
@@ -249,4 +522,9 @@ ConsoleMethod(GuiInspectorComponentGroup, addDynamicField, void, 2, 2, "obj.addD
 
 ConsoleMethod(GuiInspectorComponentGroup, removeDynamicField, void, 3, 3, "")
 {
+}
+
+DefineConsoleMethod(GuiInspectorComponentGroup, getComponent, S32, (), ,"")
+{
+   return object->getComponent()->getId();
 }

--- a/Engine/source/gui/editor/inspector/componentGroup.h
+++ b/Engine/source/gui/editor/inspector/componentGroup.h
@@ -34,12 +34,14 @@ private:
    typedef GuiInspectorGroup Parent;
    GuiControl* mAddCtrl;
 
+   Component* mTargetComponent;
+
    Vector<AbstractClassRep::Field> tempFields;
 
 public:
    DECLARE_CONOBJECT(GuiInspectorComponentGroup);
    GuiInspectorComponentGroup() { /*mNeedScroll=false;*/ };
-   GuiInspectorComponentGroup(StringTableEntry groupName, SimObjectPtr<GuiInspector> parent);
+   GuiInspectorComponentGroup(StringTableEntry groupName, SimObjectPtr<GuiInspector> parent, Component* targetComponent);
 
    //-----------------------------------------------------------------------------
    // inspectGroup is overridden in GuiInspectorComponentGroup to inspect an 
@@ -50,6 +52,7 @@ public:
    virtual void updateAllFields();
 
    void onMouseMove(const GuiEvent &event);
+   virtual void onRightMouseUp(const GuiEvent &event);
 
    // For scriptable dynamic field additions
    void addDynamicField();
@@ -61,6 +64,9 @@ public:
    virtual SimFieldDictionary::Entry* findDynamicFieldInDictionary(StringTableEntry fieldName);
 
    AbstractClassRep::Field* findObjectBehaviorField(Component* target, String fieldName);
+
+   Component* getComponent() { return mTargetComponent; }
+
 protected:
    // create our inner controls when we add
    virtual bool createContent();

--- a/Engine/source/gui/worldEditor/worldEditorSelection.cpp
+++ b/Engine/source/gui/worldEditor/worldEditorSelection.cpp
@@ -23,7 +23,7 @@
 #include "gui/worldEditor/worldEditorSelection.h"
 #include "gui/worldEditor/worldEditor.h"
 #include "scene/sceneObject.h"
-
+#include "T3D/entity.h"
 
 IMPLEMENT_CONOBJECT( WorldEditorSelection );
 
@@ -410,26 +410,34 @@ void WorldEditorSelection::rotate(const EulerF & rot, const Point3F & center)
    // single selections will rotate around own axis, multiple about world
    if(size() == 1)
    {
-      SceneObject* object = dynamic_cast< SceneObject* >( at( 0 ) );
-      if( object )
+      Entity* eO = dynamic_cast< Entity* >(at(0));
+      if (eO)
       {
-         MatrixF mat = object->getTransform();
+         eO->setTransform(eO->getPosition(), eO->getRotation() + RotationF(rot));
+      }
+      else
+      {
+         SceneObject* object = dynamic_cast<SceneObject*>(at(0));
+         if (object)
+         {
+            MatrixF mat = object->getTransform();
 
-         Point3F pos;
-         mat.getColumn(3, &pos);
+            Point3F pos;
+            mat.getColumn(3, &pos);
 
-         // get offset in obj space
-         Point3F offset = pos - center;
-         MatrixF wMat = object->getWorldTransform();
-         wMat.mulV(offset);
+            // get offset in obj space
+            Point3F offset = pos - center;
+            MatrixF wMat = object->getWorldTransform();
+            wMat.mulV(offset);
 
-         //
-         MatrixF transform(EulerF(0,0,0), -offset);
-         transform.mul(MatrixF(rot));
-         transform.mul(MatrixF(EulerF(0,0,0), offset));
-         mat.mul(transform);
+            //
+            MatrixF transform(EulerF(0, 0, 0), -offset);
+            transform.mul(MatrixF(rot));
+            transform.mul(MatrixF(EulerF(0, 0, 0), offset));
+            mat.mul(transform);
 
-         object->setTransform(mat);
+            object->setTransform(mat);
+         }
       }
    }
    else

--- a/Templates/BaseGame/game/core/main.cs
+++ b/Templates/BaseGame/game/core/main.cs
@@ -41,6 +41,12 @@ $Core::UnAvailableTexturePath = "core/images/unavailable";
 $Core::WarningTexturePath = "core/images/warnMat";
 $Core::CommonShaderPath = "core/shaders";
 
+ModuleDatabase.setModuleExtension("module");
+
+//Core components
+ModuleDatabase.scanModules( "core", false );
+ModuleDatabase.LoadExplicit( "CoreComponentsModule" );
+
 exec("./helperFunctions.cs");
 
 // We need some of the default GUI profiles in order to get the canvas and

--- a/Templates/BaseGame/game/data/clientServer/scripts/server/connectionToClient.cs
+++ b/Templates/BaseGame/game/data/clientServer/scripts/server/connectionToClient.cs
@@ -132,6 +132,23 @@ function isNameUnique(%name)
 //
 function GameConnection::onDrop(%client, %reason)
 {
+   %entityIds = parseMissionGroupForIds("Entity", "");
+   %entityCount = getWordCount(%entityIds);
+   
+   for(%i=0; %i < %entityCount; %i++)
+   {
+      %entity = getWord(%entityIds, %i);
+      
+      for(%e=0; %e < %entity.getCount(); %e++)
+      {
+         %child = %entity.getObject(%e);
+         if(%child.getClassName() $= "Entity")
+            %entityIds = %entityIds SPC %child.getID();  
+      }
+      
+      %entity.notify("onClientDisconnect", %client);
+   }
+   
    if($missionRunning)
       theLevelInfo.onClientLeaveGame();
    

--- a/Templates/BaseGame/game/data/clientServer/scripts/server/levelDownload.cs
+++ b/Templates/BaseGame/game/data/clientServer/scripts/server/levelDownload.cs
@@ -131,6 +131,22 @@ function serverCmdMissionStartPhase3Ack(%client, %seq)
    %client.currentPhase = 3;
    
    // Server is ready to drop into the game
+   %entityIds = parseMissionGroupForIds("Entity", "");
+   %entityCount = getWordCount(%entityIds);
+   
+   for(%i=0; %i < %entityCount; %i++)
+   {
+      %entity = getWord(%entityIds, %i);
+      
+      for(%e=0; %e < %entity.getCount(); %e++)
+      {
+         %child = %entity.getObject(%e);
+         if(%child.getCLassName() $= "Entity")
+            %entityIds = %entityIds SPC %child.getID();  
+      }
+      
+      %entity.notify("onClientConnect", %client);
+   }
    
    //Have any special game-play handling here
    if(theLevelInfo.isMethod("onClientEnterGame"))
@@ -151,7 +167,7 @@ function serverCmdMissionStartPhase3Ack(%client, %seq)
             };  
          }
          
-         if (isDefined("$Game::DefaultCameraClass"))
+         //if (isDefined("$Game::DefaultCameraClass"))
             %client.camera = spawnObject("Camera", Observer);
       }
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -1302,6 +1302,7 @@ function VisibilityDropdownToggle()
    {
       EVisibility.setVisible(true);
       visibilityToggleBtn.setStateOn(1);
+      EVisibility.setExtent("200 540");
    }
 }
 
@@ -1641,6 +1642,31 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
 
             object = -1;
          };
+         
+      if(%obj.isMemberOfClass("Entity"))
+      {
+         if( !isObject( GameObjectPopup ) )
+            %popup = new PopupMenu( GameObjectPopup : ETSimGroupContextPopup )
+            {
+               //item[ 12 ] = "-";
+               item[ 12 ] = "Convert to Game Object" TAB "" TAB "EWorldEditor.createGameObject( %this.object );";
+               item[ 13 ] = "Duplicate Game Object" TAB "" TAB "EWorldEditor.duplicateGameObject( %this.object );";
+               item[ 14 ] = "Show in Asset Browser" TAB "" TAB "EWorldEditor.showGameObjectInAssetBrowser( %this.object );";
+            };
+            
+         if(!isObject(AssetDatabase.acquireAsset(%obj.gameObjectAsset)))
+         {
+            GameObjectPopup.enableItem(12, true);
+            GameObjectPopup.enableItem(13, false);
+            GameObjectPopup.enableItem(14, false);
+         }
+         else
+         {
+            GameObjectPopup.enableItem(12, false);
+            GameObjectPopup.enableItem(13, true);
+            GameObjectPopup.enableItem(14, true);
+         }
+      }
 
       %popup.object = %obj;
       


### PR DESCRIPTION
Fixes the inspector/component editor to display the components attached to an entity correctly in the inspector. Missed these bits of code with some of the prior e/c-related PR's.