### PR TITLE
adds a slider for the HDR color shift

### DIFF
--- a/Templates/Full/game/core/scripts/client/postFx/postFXManager.gui
+++ b/Templates/Full/game/core/scripts/client/postFx/postFXManager.gui
@@ -1533,22 +1533,21 @@
                   canSave = "1";
                   canSaveDynamicFields = "0";
 
-                  new GuiCheckBoxCtrl(ppOptionsHDREffectsBlueShift) {
-                     useInactiveState = "0";
-                     text = " Enable Color Shift";
-                     groupNum = "-1";
-                     buttonType = "ToggleButton";
-                     useMouseEvents = "0";
-                     position = "11 4";
-                     extent = "117 24";
+                  new GuiSliderCtrl(ppOptionsHDREffectsBlueShift) {
+                     range = "0 2";
+                     ticks = "0";
+                     snap = "0";
+                     value = "0.376238";
+                     position = "158 4";
+                     extent = "200 21";
                      minExtent = "8 2";
                      horizSizing = "right";
                      vertSizing = "bottom";
-                     profile = "GuiCheckBoxProfile";
+                     profile = "GuiSliderBoxProfile";
                      visible = "1";
                      active = "1";
                      tooltipProfile = "GuiToolTipProfile";
-                     tooltip = "Enables a scene tinting/Blue shift based on the color selected below.";
+                     tooltip = "Value : 1.60526";
                      hovertime = "1000";
                      isContainer = "0";
                      canSave = "1";
@@ -1595,6 +1594,29 @@
                      tooltip = "Select a color";
                      hovertime = "1000";
                      isContainer = "0";
+                     canSave = "1";
+                     canSaveDynamicFields = "0";
+                  };
+                  new GuiTextCtrl() {
+                     text = "Color Shift Intensity";
+                     maxLength = "1024";
+                     margin = "0 0 0 0";
+                     padding = "0 0 0 0";
+                     anchorTop = "1";
+                     anchorBottom = "0";
+                     anchorLeft = "1";
+                     anchorRight = "0";
+                     position = "10 4";
+                     extent = "129 20";
+                     minExtent = "8 2";
+                     horizSizing = "right";
+                     vertSizing = "bottom";
+                     profile = "GuiTextProfile";
+                     visible = "1";
+                     active = "1";
+                     tooltipProfile = "GuiToolTipProfile";
+                     hovertime = "1000";
+                     isContainer = "1";
                      canSave = "1";
                      canSaveDynamicFields = "0";
                   };

--- a/Templates/Full/game/core/scripts/client/postFx/postFxManager.gui.cs
+++ b/Templates/Full/game/core/scripts/client/postFx/postFxManager.gui.cs
@@ -279,9 +279,10 @@ function ppOptionsHDRToneMapping::onAction(%this)
    //$HDRPostFX::enableToneMapping =  %this.getValue();
 }
 
-function ppOptionsHDREffectsBlueShift::onAction(%this)
+function ppOptionsHDREffectsBlueShift::onMouseDragged(%this)
 {
    $HDRPostFX::enableBlueShift = %this.getValue();
+   %this.ToolTip = "Value : " @ %this.value;
 }
 
 


### PR DESCRIPTION
This changes to on/off toggle button for HDR colorshift effect into a slider that can gradually activate the colorshift from 0 to 100%, previously it was just on and off which was too strong in most cases.
I also increased the max value from 1 to 2 since that is the highest value possible, maybe someone wants to have extreme settings, just in case.