### PR TITLE
Allow correct display of widescreen resolutions (16:9 and 16:10 ratio) on a 4:3 ratio display

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
@@ -238,7 +238,7 @@ DXGI_SWAP_CHAIN_DESC GFXD3D11Device::setupPresentParams(const GFXVideoMode &mode
 
    if (mode.fullScreen)
    {
-      d3dpp.BufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
+      d3dpp.BufferDesc.Scaling = DXGI_MODE_SCALING_CENTERED;
       d3dpp.BufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
       d3dpp.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
    }


### PR DESCRIPTION
Using DXGI_MODE_SCALING_UNSPECIFIED will result in a scaling of widescreen resolutions with a width:height ratio of 16:9 or 16:10 on 4:3 ratio displays, changing the resolution to the next available 4:3 resolution, causing distortion of the view. Changing DXGI_MODE_SCALING_UNSPECIFIED to DXGI_MODE_SCALING_CENTERED will prevent this behavior, resulting in a correct display of these widescreen resolutions.
