### PR TITLE
SceneObject::isRenderEnabled() cleanup

### DIFF
--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -763,8 +763,7 @@ void SceneObject::onCameraScopeQuery( NetConnection* connection, CameraScopeQuer
 
 bool SceneObject::isRenderEnabled() const
 {
-   AbstractClassRep *classRep = getClassRep();
-   return ( mObjectFlags.test( RenderEnabledFlag ) && classRep->isRenderEnabled() );
+   return mObjectFlags.test( RenderEnabledFlag );
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
no need for an AbstractClassRep *classRep = getClassRep(); check for every object-instance every frame.