### PR TITLE
changes find, swap, for_each, and delete_pointer from global to t3d namespace

### DIFF
--- a/Engine/source/T3D/decal/decalDataFile.cpp
+++ b/Engine/source/T3D/decal/decalDataFile.cpp
@@ -131,7 +131,7 @@ bool DecalDataFile::write( Stream& stream )
    {
       DecalInstance *inst = allDecals[i];
 
-      dataIter = find( allDatablocks.begin(), allDatablocks.end(), inst->mDataBlock );
+      dataIter = T3D::find( allDatablocks.begin(), allDatablocks.end(), inst->mDataBlock );
       U8 dataIndex = dataIter - allDatablocks.begin();
       
       stream.write( dataIndex );

--- a/Engine/source/T3D/fx/windEmitter.cpp
+++ b/Engine/source/T3D/fx/windEmitter.cpp
@@ -47,7 +47,7 @@ WindEmitter::WindEmitter()
 
 WindEmitter::~WindEmitter()
 {
-   WindEmitterList::iterator iter = find( smAllEmitters.begin(), smAllEmitters.end(), this );
+   WindEmitterList::iterator iter = T3D::find( smAllEmitters.begin(), smAllEmitters.end(), this );
    smAllEmitters.erase( iter );
 }
 

--- a/Engine/source/collision/clippedPolyList.cpp
+++ b/Engine/source/collision/clippedPolyList.cpp
@@ -330,7 +330,7 @@ void ClippedPolyList::cullUnusedVerts()
    for ( vIter = mVertexList.begin(); vIter != mVertexList.end(); vIter++, i++ )
    {
       // Is this vertex used?
-      iNextIter = find( mIndexList.begin(), mIndexList.end(), i );
+      iNextIter = T3D::find( mIndexList.begin(), mIndexList.end(), i );
       if ( iNextIter != mIndexList.end() )
          continue;
 
@@ -346,7 +346,7 @@ void ClippedPolyList::cullUnusedVerts()
 
       for ( nextVIter = vIter + 1; nextVIter != mVertexList.end(); nextVIter++, n++ )
       {
-         iNextIter = find( mIndexList.begin(), mIndexList.end(), n );
+         iNextIter = T3D::find( mIndexList.begin(), mIndexList.end(), n );
          
          // If we found a used vertex
          // grab its index for later use

--- a/Engine/source/console/simObjectList.cpp
+++ b/Engine/source/console/simObjectList.cpp
@@ -33,7 +33,7 @@ String SimObjectList::smSortScriptCallbackFn;
 
 bool SimObjectList::pushBack(SimObject* obj)
 {
-   if (find(begin(),end(),obj) == end())
+   if (T3D::find(begin(),end(),obj) == end())
    {
       push_back(obj);
       return true;
@@ -44,7 +44,7 @@ bool SimObjectList::pushBack(SimObject* obj)
 
 bool SimObjectList::pushBackForce(SimObject* obj)
 {
-   iterator itr = find(begin(),end(),obj);
+   iterator itr = T3D::find(begin(),end(),obj);
    if (itr == end())
    {
       push_back(obj);
@@ -64,7 +64,7 @@ bool SimObjectList::pushBackForce(SimObject* obj)
 
 bool SimObjectList::pushFront(SimObject* obj)
 {
-   if (find(begin(),end(),obj) == end())
+   if (T3D::find(begin(),end(),obj) == end())
    {
       push_front(obj);
       return true;
@@ -75,7 +75,7 @@ bool SimObjectList::pushFront(SimObject* obj)
 
 bool SimObjectList::remove(SimObject* obj)
 {
-   iterator ptr = find(begin(),end(),obj);
+   iterator ptr = T3D::find(begin(),end(),obj);
    if (ptr != end())
    {
       erase(ptr);
@@ -87,7 +87,7 @@ bool SimObjectList::remove(SimObject* obj)
 
 bool SimObjectList::removeStable(SimObject* obj)
 {
-   iterator ptr = find(begin(),end(),obj);
+   iterator ptr = T3D::find(begin(),end(),obj);
    if (ptr != end())
    {
       erase(ptr);

--- a/Engine/source/console/simSet.h
+++ b/Engine/source/console/simSet.h
@@ -154,9 +154,9 @@ class SimSet : public SimObject, public TamlChildren
       value operator[] (S32 index) { return objectList[U32(index)]; }
 
       inline iterator find( iterator first, iterator last, SimObject *obj)
-      { return ::find(first, last, obj); }
+      { return T3D::find(first, last, obj); }
       inline iterator find(SimObject *obj) 
-      { return ::find(begin(), end(), obj); }
+      { return T3D::find(begin(), end(), obj); }
 
       /// Reorder the position of "obj" to either be the last object in the list or, if
       /// "target" is given, to come before "target" in the list of children.

--- a/Engine/source/core/tAlgorithm.h
+++ b/Engine/source/core/tAlgorithm.h
@@ -23,40 +23,41 @@
 #ifndef _TALGORITHM_H_
 #define _TALGORITHM_H_
 
-
-/// Finds the first matching value within the container
-/// returning the the element or last if its not found.
-template <class Iterator, class Value>
-Iterator find(Iterator first, Iterator last, Value value)
+namespace T3D
 {
-   while (first != last && *first != value)
-      ++first;
-   return first;
+	/// Finds the first matching value within the container
+	/// returning the the element or last if its not found.
+	template <class Iterator, class Value>
+	Iterator find(Iterator first, Iterator last, Value value)
+	{
+		while (first != last && *first != value)
+			++first;
+		return first;
+	}
+
+	/// Exchanges the values of the two elements.
+	template <typename T>
+	inline void swap(T &left, T &right)
+	{
+		T temp = right;
+		right = left;
+		left = temp;
+	}
+
+	/// Steps thru the elements of an array calling detete for each.
+	template <class Iterator, class Functor>
+	void for_each(Iterator first, Iterator last, Functor func)
+	{
+		for (; first != last; first++)
+			func(*first);
+	}
+
+	/// Functor for deleting a pointer.
+	/// @see for_each
+	struct delete_pointer
+	{
+		template <typename T>
+		void operator()(T *ptr) { delete ptr; }
+	};
 }
-
-/// Exchanges the values of the two elements.
-template <typename T> 
-inline void swap( T &left, T &right )
-{
-   T temp = right;
-   right = left;
-   left = temp;
-}
-
-/// Steps thru the elements of an array calling detete for each.
-template <class Iterator, class Functor>
-void for_each( Iterator first, Iterator last, Functor func )
-{
-   for ( ; first != last; first++ )
-      func( *first );
-}
-
-/// Functor for deleting a pointer.
-/// @see for_each
-struct delete_pointer
-{
-  template <typename T>
-  void operator()(T *ptr){ delete ptr;}
-};
-
 #endif //_TALGORITHM_H_

--- a/Engine/source/forest/forestDataFile.cpp
+++ b/Engine/source/forest/forestDataFile.cpp
@@ -213,7 +213,7 @@ bool ForestData::write( const char *path )
    Vector<ForestItem>::const_iterator iter = items.begin();
    for ( ; iter != items.end(); iter++ )
    {
-      U8 dataIndex = find( allDatablocks.begin(), allDatablocks.end(), iter->getData() ) - allDatablocks.begin();
+      U8 dataIndex = T3D::find( allDatablocks.begin(), allDatablocks.end(), iter->getData() ) - allDatablocks.begin();
 
       stream.write( dataIndex );
 
@@ -770,7 +770,7 @@ U32 ForestData::getDatablocks( Vector<ForestItemData*> *outVector ) const
       {
          ForestItemData *data = item->getData();
 
-         if ( find( outVector->begin(), outVector->end(), data ) != outVector->end() )
+         if (T3D::find( outVector->begin(), outVector->end(), data ) != outVector->end() )
             continue;
 
          count++;

--- a/Engine/source/forest/forestWindMgr.cpp
+++ b/Engine/source/forest/forestWindMgr.cpp
@@ -85,7 +85,7 @@ void ForestWindMgr::addEmitter( ForestWindEmitter *emitter )
 
 void ForestWindMgr::removeEmitter( ForestWindEmitter *emitter )
 {
-   ForestWindEmitterList::iterator iter = find( mEmitters.begin(), 
+   ForestWindEmitterList::iterator iter = T3D::find( mEmitters.begin(),
                                                 mEmitters.end(), 
                                                 emitter );
 
@@ -161,7 +161,7 @@ void ForestWindMgr::processTick()
       PROFILE_SCOPE( ForestWindMgr_AdvanceTime_SwapSources );
       AssertFatal( mPrevSources->isEmpty(), "prev sources not empty!" );
       
-      swap( mSources, mPrevSources );      
+	  T3D::swap( mSources, mPrevSources );
 
       AssertFatal( mSources->isEmpty(), "swap failed!" );
    }

--- a/Engine/source/gui/editor/guiEditCtrl.cpp
+++ b/Engine/source/gui/editor/guiEditCtrl.cpp
@@ -1015,7 +1015,7 @@ void GuiEditCtrl::removeSelection( GuiControl* ctrl )
 {
    if( selectionContains( ctrl ) )
    {
-      Vector< GuiControl* >::iterator i = ::find( mSelectedControls.begin(), mSelectedControls.end(), ctrl );
+      Vector< GuiControl* >::iterator i = T3D::find( mSelectedControls.begin(), mSelectedControls.end(), ctrl );
       if ( i != mSelectedControls.end() )
          mSelectedControls.erase( i );
 

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -103,7 +103,7 @@ ProcessedMaterial::ProcessedMaterial()
 
 ProcessedMaterial::~ProcessedMaterial()
 {
-   for_each( mPasses.begin(), mPasses.end(), delete_pointer() );
+	T3D::for_each( mPasses.begin(), mPasses.end(), T3D::delete_pointer() );
 }
 
 void ProcessedMaterial::_setBlendState(Material::BlendOp blendOp, GFXStateBlockDesc& desc )

--- a/Engine/source/math/mIntersector.h
+++ b/Engine/source/math/mIntersector.h
@@ -228,7 +228,7 @@ void PolyhedronBoxIntersector< Polyhedron >::_preprocess( const MatrixF& objToWo
          Point2F p = _project( i, v2 ); // Second point on line.
 
          if( frontFace != 0 )
-            swap( p, q );
+			 T3D::swap( p, q );
 
          Point2F normal( - ( p.y - q.y ), p.x - q.x );
          normal.normalize();

--- a/Engine/source/math/mPlaneSet.h
+++ b/Engine/source/math/mPlaneSet.h
@@ -441,7 +441,7 @@ U32 PlaneSet< T >::clipPolygon( const Point3F* inVertices, U32 inNumVertices, Po
       // Make the output of the last iteration the
       // input of this iteration.
 
-      swap( tempPolygon, clippedPolygon );
+	  T3D::swap( tempPolygon, clippedPolygon );
       numTempPolygonVertices = numClippedPolygonVertices;
 
       if( maxOutVertices < numTempPolygonVertices + 1 )

--- a/Engine/source/math/mathUtils.cpp
+++ b/Engine/source/math/mathUtils.cpp
@@ -1706,7 +1706,7 @@ bool clipFrustumByPolygon( const Point3F* points, U32 numPoints, const RectI& vi
       // Make the output of the last iteration the
       // input of this iteration.
 
-      swap( tempPolygon, clippedPolygon );
+	  T3D::swap( tempPolygon, clippedPolygon );
       numTempPolygonVertices = numClippedPolygonVertices;
 
       // Clip our current remainder of the original polygon

--- a/Engine/source/postFx/postEffectManager.cpp
+++ b/Engine/source/postFx/postEffectManager.cpp
@@ -198,7 +198,7 @@ bool PostEffectManager::_addEffect( PostEffect *effect )
 bool PostEffectManager::_removeEffect( PostEffect *effect )
 {
    // Check the end of frame list.
-   EffectVector::iterator iter = find( mEndOfFrameList.begin(), mEndOfFrameList.end(), effect );
+   EffectVector::iterator iter = T3D::find( mEndOfFrameList.begin(), mEndOfFrameList.end(), effect );
    if ( iter != mEndOfFrameList.end() )
    {
       mEndOfFrameList.erase( iter );
@@ -206,7 +206,7 @@ bool PostEffectManager::_removeEffect( PostEffect *effect )
    }
 
    // Check the diffuse list.
-   iter = find( mAfterDiffuseList.begin(), mAfterDiffuseList.end(), effect );
+   iter = T3D::find( mAfterDiffuseList.begin(), mAfterDiffuseList.end(), effect );
    if ( iter != mAfterDiffuseList.end() )
    {
       mAfterDiffuseList.erase( iter );
@@ -218,7 +218,7 @@ bool PostEffectManager::_removeEffect( PostEffect *effect )
    for( ; mapIter != mAfterBinMap.end(); mapIter++ )
    {
       EffectVector &effects = mapIter->value;
-      iter = find( effects.begin(), effects.end(), effect );
+      iter = T3D::find( effects.begin(), effects.end(), effect );
       if ( iter != effects.end() )
       {
          effects.erase( iter );
@@ -230,7 +230,7 @@ bool PostEffectManager::_removeEffect( PostEffect *effect )
    for( ; mapIter != mBeforeBinMap.end(); mapIter++ )
    {
       EffectVector &effects = mapIter->value;
-      iter = find( effects.begin(), effects.end(), effect );
+      iter = T3D::find( effects.begin(), effects.end(), effect );
       if ( iter != effects.end() )
       {
          effects.erase( iter );

--- a/Engine/source/scene/sceneContainer.cpp
+++ b/Engine/source/scene/sceneContainer.cpp
@@ -183,7 +183,7 @@ bool SceneContainer::removeObject(SceneObject* obj)
    // Remove water and physical zone types from the special vector.
    if ( obj->getTypeMask() & ( WaterObjectType | PhysicalZoneObjectType ) )
    {
-      Vector<SceneObject*>::iterator iter = find( mWaterAndZones.begin(), mWaterAndZones.end(), obj );
+      Vector<SceneObject*>::iterator iter = T3D::find( mWaterAndZones.begin(), mWaterAndZones.end(), obj );
       if( iter != mTerrains.end() )
          mWaterAndZones.erase_fast(iter);
    }
@@ -191,7 +191,7 @@ bool SceneContainer::removeObject(SceneObject* obj)
    // Remove terrain objects from special vector.
    if( obj->getTypeMask() & TerrainObjectType )
    {
-      Vector< SceneObject* >::iterator iter = find( mTerrains.begin(), mTerrains.end(), obj );
+      Vector< SceneObject* >::iterator iter = T3D::find( mTerrains.begin(), mTerrains.end(), obj );
       if( iter != mTerrains.end() )
          mTerrains.erase_fast(iter);
    }

--- a/Engine/source/sfx/sfxController.cpp
+++ b/Engine/source/sfx/sfxController.cpp
@@ -142,7 +142,7 @@ void SFXController::_compileList( SFXPlayList* playList )
          {
             // Randomly exchange slots in the list.
             for( U32 i = 0; i < SFXPlayList::NUM_SLOTS; ++ i )
-               swap( slotList[ gRandGen.randI( 0, SFXPlayList::NUM_SLOTS - 1 ) ], slotList[ i ] );
+				T3D::swap( slotList[ gRandGen.randI( 0, SFXPlayList::NUM_SLOTS - 1 ) ], slotList[ i ] );
          }
          break;
          

--- a/Engine/source/sfx/sfxDevice.cpp
+++ b/Engine/source/sfx/sfxDevice.cpp
@@ -165,7 +165,7 @@ void SFXDevice::_removeBuffer( SFXBuffer* buffer )
 {
    AssertFatal( buffer, "SFXDevice::_removeBuffer() - Got a null buffer!" );
 
-   BufferIterator iter = find( mBuffers.begin(), mBuffers.end(), buffer );
+   BufferIterator iter = T3D::find( mBuffers.begin(), mBuffers.end(), buffer );
    if( iter != mBuffers.end() )
    {
       SFXBuffer* buffer = *iter;
@@ -201,7 +201,7 @@ void SFXDevice::_removeVoice( SFXVoice* voice )
 {
    AssertFatal( voice, "SFXDevice::_removeVoice() - Got null voice!" );
 
-   VoiceIterator iter = find( mVoices.begin(), mVoices.end(), voice );
+   VoiceIterator iter = T3D::find( mVoices.begin(), mVoices.end(), voice );
    if( iter != mVoices.end() )
    {
       mStatNumVoices --;

--- a/Engine/source/sfx/sfxSystem.cpp
+++ b/Engine/source/sfx/sfxSystem.cpp
@@ -647,7 +647,7 @@ void SFXSystem::deleteWhenStopped( SFXSource* source )
    // If the source isn't already on the play-once source list,
    // put it there now.
    
-   Vector< SFXSource* >::iterator iter = find( mPlayOnceSources.begin(), mPlayOnceSources.end(), source );
+   Vector< SFXSource* >::iterator iter = T3D::find( mPlayOnceSources.begin(), mPlayOnceSources.end(), source );
    if( iter == mPlayOnceSources.end() )
       mPlayOnceSources.push_back( source );
 }
@@ -674,7 +674,7 @@ void SFXSystem::_onRemoveSource( SFXSource* source )
 {
    // Check if it was a play once source.
    
-   Vector< SFXSource* >::iterator iter = find( mPlayOnceSources.begin(), mPlayOnceSources.end(), source );
+   Vector< SFXSource* >::iterator iter = T3D::find( mPlayOnceSources.begin(), mPlayOnceSources.end(), source );
    if ( iter != mPlayOnceSources.end() )
       mPlayOnceSources.erase_fast( iter );
 
@@ -684,7 +684,7 @@ void SFXSystem::_onRemoveSource( SFXSource* source )
    
    if( dynamic_cast< SFXSound* >( source ) )
    {
-      SFXSoundVector::iterator iter = find( mSounds.begin(), mSounds.end(), static_cast< SFXSound* >( source ) );
+      SFXSoundVector::iterator iter = T3D::find( mSounds.begin(), mSounds.end(), static_cast< SFXSound* >( source ) );
       if( iter != mSounds.end() )
          mSounds.erase_fast( iter );
          

--- a/Engine/source/terrain/terrCellMaterial.cpp
+++ b/Engine/source/terrain/terrCellMaterial.cpp
@@ -289,7 +289,7 @@ void TerrainCellMaterial::init(  TerrainBlock *block,
          // The pass failed to be generated... give up.
          mPasses.last().materials.clear();
          mPasses.clear();
-         for_each( materials.begin(), materials.end(), delete_pointer() );
+		 T3D::for_each( materials.begin(), materials.end(), T3D::delete_pointer() );
          return;
       }
 
@@ -298,7 +298,7 @@ void TerrainCellMaterial::init(  TerrainBlock *block,
    }
 
    // Cleanup any remaining matinfo.
-   for_each( materials.begin(), materials.end(), delete_pointer() );
+   T3D::for_each( materials.begin(), materials.end(), T3D::delete_pointer() );
 
    // If we have attached mats then update them too.
    if ( mDeferredMat )

--- a/Engine/source/ts/tsLastDetail.cpp
+++ b/Engine/source/ts/tsLastDetail.cpp
@@ -101,7 +101,7 @@ TSLastDetail::~TSLastDetail()
       mMaterial->deleteObject();
 
    // Remove ourselves from the list.
-   Vector<TSLastDetail*>::iterator iter = find( smLastDetails.begin(), smLastDetails.end(), this );
+   Vector<TSLastDetail*>::iterator iter = T3D::find( smLastDetails.begin(), smLastDetails.end(), this );
    smLastDetails.erase( iter );
 }
 


### PR DESCRIPTION
tAlgorythm fed namespace T3D for better library interoperability. resulted in the need to specify usage in... a few places. (short version: it was blowing up being able to incorporate bits of std::*)