### PR TITLE
exposes getters for typevalidators.

### DIFF
--- a/Engine/source/console/typeValidators.h
+++ b/Engine/source/console/typeValidators.h
@@ -53,6 +53,8 @@ public:
       maxV = maxValue;
    }
    void validateType(SimObject *object, void *typePtr);
+   F32 getMin() { return minV; };
+   F32 getMax() { return maxV; };
 };
 
 /// Signed integer min/max range validator
@@ -66,6 +68,8 @@ public:
       maxV = maxValue;
    }
    void validateType(SimObject *object, void *typePtr);
+   F32 getMin() { return minV; };
+   F32 getMax() { return maxV; };
 };
 
 /// Scaled integer field validator
@@ -93,6 +97,7 @@ class Point3NormalizeValidator : public TypeValidator
 public:
    Point3NormalizeValidator(F32 normalizeLength = 1.0f) : length(normalizeLength) { }
    void validateType(SimObject *object, void *typePtr);
+   F32 getLength() { return length; };
 };
 
 namespace CommonValidators


### PR DESCRIPTION
example usage

FRangeValidator gravCoefFValidator(-10.f, 10.f);
   addFieldV( "gravityCoefficient", TYPEID< F32 >(), Offset(gravityCoefficient, ParticleData), &gravCoefFValidator,
      "Strength of gravity on the particles." ); <- clamps gravity within a -10 to 10 range when evaluating scriptt-set changes

mClamp(gravityCoefficient,gravCoefFValidator.getMin(),gravCoefFValidator.getMax()) for any calculations done on the source side would do the same at the point that is called, with a singularl lookup spot for the range.