### PR TITLE
Remove legacy_stdio_definitions.lib

### DIFF
--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -643,13 +643,6 @@ if(WIN32)
    if(TORQUE_OPENGL)
       addLib(OpenGL32.lib)
    endif()
-
-   # JTH: DXSDK is compiled with older runtime, and MSVC 2015+ is when __vsnprintf is undefined.
-   # This is a workaround by linking with the older legacy library functions.
-   # See this for more info: http://stackoverflow.com/a/34230122
-   if (MSVC14)
-      addLib(legacy_stdio_definitions.lib)
-   endif()
 endif()
 
 if (APPLE)


### PR DESCRIPTION
Fix for #2164 

Dependency was added by PR #1566. No longer needed now that DX SDK has
been replaced.