### PR TITLE
fix sdlPlatformGL so we can compile without OpenGL when SDL is enabled

### DIFF
--- a/Engine/source/platformSDL/sdlPlatformGL.cpp
+++ b/Engine/source/platformSDL/sdlPlatformGL.cpp
@@ -1,3 +1,5 @@
+#if defined(TORQUE_OPENGL) && defined(TORQUE_SDL)
+
 #include <SDL.h>
 #include "windowManager/sdl/sdlWindow.h"
 #include "console/console.h"
@@ -88,3 +90,4 @@ namespace PlatformGL
    }
 
 }
+#endif


### PR DESCRIPTION
This just fixes sdlPlatformGL so we can compile t3d with sdl enabled and opengl disabled