### PR TITLE
Removes the GameObject folder insert for the scripted object creator grid

### DIFF
--- a/Templates/BaseGame/game/tools/worldEditor/scripts/editorPrefs.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/editorPrefs.ed.cs
@@ -34,7 +34,6 @@ EditorSettings.setDefaultValue(  "orthoFOV",                "50" );
 EditorSettings.setDefaultValue(  "orthoShowGrid",           "1" );
 EditorSettings.setDefaultValue(  "currentEditor",           "WorldEditorInspectorPlugin" );
 EditorSettings.setDefaultValue(  "newLevelFile",            "tools/levels/BlankRoom.mis" );
-EditorSettings.setDefaultValue(  "newGameObjectDir",        "scripts/server/gameObjects" );
 
 if( isFile( "C:/Program Files/Torsion/Torsion.exe" ) )
    EditorSettings.setDefaultValue(  "torsionPath",          "C:/Program Files/Torsion/Torsion.exe" );
@@ -128,7 +127,7 @@ EditorSettings.setDefaultValue(  "renderInfoText",          "1"               );
 
 EditorSettings.beginGroup( "Grid" );
 EditorSettings.setDefaultValue(  "gridColor",               "255 255 255 20"  );
-EditorSettings.setDefaultValue(  "gridSize",                "10 10 10"        );
+EditorSettings.setDefaultValue(  "gridSize",                "1 1 1"        );
 EditorSettings.setDefaultValue(  "snapToGrid",              "0"               ); //<-- Not currently used
 EditorSettings.setDefaultValue(  "renderPlane",             "0"               );
 EditorSettings.setDefaultValue(  "renderPlaneHashes",       "0"               );

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/editors/creator.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/editors/creator.ed.cs
@@ -304,36 +304,6 @@ function EWCreatorWindow::navigate( %this, %address )
                %this.addShapeIcon( %obj );
          }
       }
-      
-      //Add a separate folder for Game Objects
-      if(isClass("Entity"))
-      {
-          if(%address $= "")
-          {
-              %this.addFolderIcon("GameObjects");
-          }
-          else
-          {
-              //find all GameObjectAssets
-              %assetQuery = new AssetQuery();
-              if(!AssetDatabase.findAssetType(%assetQuery, "GameObjectAsset"))
-                 return 0; //if we didn't find ANY, just exit
-
-              %count = %assetQuery.getCount();
-
-              for(%i=0; %i < %count; %i++)
-              {
-                 %assetId = %assetQuery.getAsset(%i);
-
-                 %gameObjectAsset = AssetDatabase.acquireAsset(%assetId);
-
-                 if(isFile(%gameObjectAsset.TAMLFilePath))
-                 {
-                    %this.addGameObjectIcon( %gameObjectAsset.gameObjectName );
-                 }
-              }
-          }
-      }
    }
    
    if ( %this.tab $= "Meshes" )
@@ -761,22 +731,6 @@ function EWCreatorWindow::addPrefabIcon( %this, %fullPath )
    %ctrl.text = %file;
    %ctrl.class = "CreatorPrefabIconBtn";
    %ctrl.tooltip = %tip;
-   
-   %ctrl.buttonType = "radioButton";
-   %ctrl.groupNum = "-1";   
-   
-   %this.contentCtrl.addGuiControl( %ctrl );   
-}
-
-function EWCreatorWindow::addGameObjectIcon( %this, %gameObjectName )
-{
-   %ctrl = %this.createIcon();
-
-   %ctrl.altCommand = "spawnGameObject( \"" @ %gameObjectName @ "\", true );";
-   %ctrl.iconBitmap = EditorIconRegistry::findIconByClassName( "Prefab" );
-   %ctrl.text = %gameObjectName;
-   %ctrl.class = "CreatorGameObjectIconBtn";
-   %ctrl.tooltip = "Spawn the " @ %gameObjectName @ " GameObject";
    
    %ctrl.buttonType = "radioButton";
    %ctrl.groupNum = "-1";   

--- a/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -1302,6 +1302,7 @@ function VisibilityDropdownToggle()
    {
       EVisibility.setVisible(true);
       visibilityToggleBtn.setStateOn(1);
+      EVisibility.setExtent("200 540");
    }
 }
 
@@ -1569,6 +1570,27 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
    %haveObjectEntries = false;
    %haveLockAndHideEntries = true;
    
+   //Set up the generic pop-up pre-emptively if we haven't already
+   if( !isObject( ETContextPopup ) )
+   {
+      %popup = new PopupMenu( ETContextPopup )
+      {
+         superClass = "MenuBuilder";
+         isPopup = "1";
+
+         item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId( %this.object ) );";
+         item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject( %this.object );";
+         item[ 2 ] = "Inspect" TAB "" TAB "inspectObject( %this.object );";
+         item[ 3 ] = "-";
+         item[ 4 ] = "Locked" TAB "" TAB "%this.object.setLocked( !%this.object.locked ); EWorldEditor.syncGui();";
+         item[ 5 ] = "Hidden" TAB "" TAB "EWorldEditor.hideObject( %this.object, !%this.object.hidden ); EWorldEditor.syncGui();";
+         item[ 6 ] = "-";
+         item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
+
+         object = -1;
+      };
+   }
+   
    // Handle multi-selection.
    if( %this.getSelectedItemsCount() > 1 )
    {
@@ -1615,12 +1637,67 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
             item[ 0 ] = "Add Camera Bookmark" TAB "" TAB "EditorGui.addCameraBookmarkByGui();";
          };
    }
+   
+   else if(%obj.isMemberOfClass("Entity"))
+   {
+      %popup = EntityObjectPopup;
+      if(!isObject(EntityObjectPopup))
+      {
+         %popup = new PopupMenu( EntityObjectPopup )
+         {
+            superClass = "MenuBuilder";
+            isPopup = "1";
+
+            item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId( %this.object ) );";
+            item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject( %this.object );";
+            item[ 2 ] = "Inspect" TAB "" TAB "inspectObject( %this.object );";
+            item[ 3 ] = "-";
+            item[ 4 ] = "Toggle Lock Children" TAB "" TAB "EWorldEditor.toggleLockChildren( %this.object );";
+            item[ 5 ] = "Toggle Hide Children" TAB "" TAB "EWorldEditor.toggleHideChildren( %this.object );";
+            item[ 6 ] = "-";
+            item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
+            item[ 8 ] = "-";
+            item[ 9 ] = "Add New Objects Here" TAB "" TAB "EWCreatorWindow.setNewObjectGroup( %this.object );";
+            item[ 10 ] = "Add Children to Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( %this.object, false );";
+            item[ 11 ] = "Remove Children from Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( %this.object, true );";
+            item[ 12 ] = "-";
+            item[ 13 ] = "Convert to Game Object" TAB "" TAB "EWorldEditor.createGameObject( %this.object );";
+            item[ 14 ] = "Duplicate Game Object" TAB "" TAB "EWorldEditor.duplicateGameObject( %this.object );";
+            item[ 15 ] = "Show in Asset Browser" TAB "" TAB "EWorldEditor.showGameObjectInAssetBrowser( %this.object );";
+            
+            object = -1;
+         };
+      }
+         
+      if(!isObject(AssetDatabase.acquireAsset(%obj.gameObjectAsset)))
+      {
+         EntityObjectPopup.enableItem(13, true);
+         EntityObjectPopup.enableItem(14, false);
+         EntityObjectPopup.enableItem(15, false);
+      }
+      else
+      {
+         EntityObjectPopup.enableItem(13, false);
+         EntityObjectPopup.enableItem(14, true);
+         EntityObjectPopup.enableItem(15, true);
+      }
+      
+      %popup.object = %obj;
+      
+      %hasChildren = %obj.getCount() > 0;
+      %popup.enableItem( 10, %hasChildren );
+      %popup.enableItem( 11, %hasChildren );
+      
+      %haveObjectEntries = true;
+      %haveLockAndHideEntries = false;
+   }
 
    // Open context menu if this is a SimGroup
    else if( !%obj.isMemberOfClass( "SceneObject" ) )
    {
       %popup = ETSimGroupContextPopup;
       if( !isObject( %popup ) )
+      {
          %popup = new PopupMenu( ETSimGroupContextPopup )
          {
             superClass = "MenuBuilder";
@@ -1641,6 +1718,7 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
 
             object = -1;
          };
+      }
 
       %popup.object = %obj;
       
@@ -1652,77 +1730,56 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
       %haveLockAndHideEntries = false;
    }
    
-   // Open generic context menu.
-   else
+   // Specialized version for ConvexShapes. 
+   else if( %obj.isMemberOfClass( "ConvexShape" ) )
    {
-      %popup = ETContextPopup;      
+      %popup = ETConvexShapeContextPopup;      
       if( !isObject( %popup ) )
-         %popup = new PopupMenu( ETContextPopup )
+      {
+         %popup = new PopupMenu( ETConvexShapeContextPopup : ETContextPopup )
          {
             superClass = "MenuBuilder";
             isPopup = "1";
 
-            item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId( %this.object ) );";
-            item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject( %this.object );";
-            item[ 2 ] = "Inspect" TAB "" TAB "inspectObject( %this.object );";
-            item[ 3 ] = "-";
-            item[ 4 ] = "Locked" TAB "" TAB "%this.object.setLocked( !%this.object.locked ); EWorldEditor.syncGui();";
-            item[ 5 ] = "Hidden" TAB "" TAB "EWorldEditor.hideObject( %this.object, !%this.object.hidden ); EWorldEditor.syncGui();";
-            item[ 6 ] = "-";
-            item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
-
-            object = -1;
+            item[ 8 ] = "-";
+            item[ 9 ] = "Convert to Zone" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Zone\" );";
+            item[ 10 ] = "Convert to Portal" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Portal\" );";
+            item[ 11 ] = "Convert to Occluder" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"OcclusionVolume\" );";
+            item[ 12 ] = "Convert to Sound Space" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"SFXSpace\" );";
          };
-         
-      if(%obj.isMemberOfClass("Entity"))
-      {
-         %popup = ETEntityContextPopup;      
-         if( !isObject( %popup ) )
-            %popup = new PopupMenu( ETEntityContextPopup : ETSimGroupContextPopup )
-            {
-               superClass = "MenuBuilder";
-               isPopup = "1";
-
-               item[ 12 ] = "-";
-               item[ 13 ] = "Convert to Game Object" TAB "" TAB "EWorldEditor.createGameObject( %this.object );";
-            };
-      }
-     
-      // Specialized version for ConvexShapes. 
-      else if( %obj.isMemberOfClass( "ConvexShape" ) )
-      {
-         %popup = ETConvexShapeContextPopup;      
-         if( !isObject( %popup ) )
-            %popup = new PopupMenu( ETConvexShapeContextPopup : ETContextPopup )
-            {
-               superClass = "MenuBuilder";
-               isPopup = "1";
-
-               item[ 8 ] = "-";
-               item[ 9 ] = "Convert to Zone" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Zone\" );";
-               item[ 10 ] = "Convert to Portal" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Portal\" );";
-               item[ 11 ] = "Convert to Occluder" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"OcclusionVolume\" );";
-               item[ 12 ] = "Convert to Sound Space" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"SFXSpace\" );";
-            };
       }
       
-      // Specialized version for polyhedral objects.
-      else if( %obj.isMemberOfClass( "Zone" ) ||
-               %obj.isMemberOfClass( "Portal" ) ||
-               %obj.isMemberOfClass( "OcclusionVolume" ) ||
-               %obj.isMemberOfClass( "SFXSpace" ) )
+      %popup.object = %obj;
+      %haveObjectEntries = true;
+   }
+   
+   // Specialized version for polyhedral objects.
+   else if( %obj.isMemberOfClass( "Zone" ) ||
+            %obj.isMemberOfClass( "Portal" ) ||
+            %obj.isMemberOfClass( "OcclusionVolume" ) ||
+            %obj.isMemberOfClass( "SFXSpace" ) )
+   {
+      %popup = ETPolyObjectContextPopup;      
+      if( !isObject( %popup ) )
       {
-         %popup = ETPolyObjectContextPopup;      
-         if( !isObject( %popup ) )
-            %popup = new PopupMenu( ETPolyObjectContextPopup : ETContextPopup )
-            {
-               superClass = "MenuBuilder";
-               isPopup = "1";
+         %popup = new PopupMenu( ETPolyObjectContextPopup : ETContextPopup )
+         {
+            superClass = "MenuBuilder";
+            isPopup = "1";
 
-               item[ 8 ] = "-";
-               item[ 9 ] = "Convert to ConvexShape" TAB "" TAB "EWorldEditor.convertSelectionToConvexShape();";
-            };
+            item[ 8 ] = "-";
+            item[ 9 ] = "Convert to ConvexShape" TAB "" TAB "EWorldEditor.convertSelectionToConvexShape();";
+         };
       }
+      
+      %popup.object = %obj;
+      %haveObjectEntries = true;
+   }
+   
+   // Open generic context menu.
+   else
+   {
+      %popup = ETContextPopup;      
 
       %popup.object = %obj;
       %haveObjectEntries = true;
@@ -2251,155 +2308,6 @@ function EWorldEditor::deleteMissionObject( %this, %object )
    MEDeleteUndoAction::submit( %object );
    EWorldEditor.isDirty = true;
    EditorTree.buildVisibleTree( true );
-}
-
-function EWorldEditor::createGameObject( %this, %entity )
-{
-   if(!isObject(GameObjectBuilder))
-   {
-      new GuiControl(GameObjectBuilder, EditorGuiGroup) {
-         profile = "ToolsGuiDefaultProfile";
-         horizSizing = "right";
-         vertSizing = "bottom";
-         position = "0 0";
-         extent = "800 600";
-         minExtent = "8 8";
-         visible = "1";
-         setFirstResponder = "0";
-         modal = "1";
-         helpTag = "0";
-      
-         new GuiWindowCtrl(GameObjectBuilderTargetWindow) {
-            profile = "ToolsGuiWindowProfile";
-            horizSizing = "center";
-            vertSizing = "center";
-            position = "384 205";
-            extent = "256 102";
-            minExtent = "256 8";
-            visible = "1";
-            setFirstResponder = "0";
-            modal = "1";
-            helpTag = "0";
-            resizeWidth = "1";
-            resizeHeight = "1";
-            canMove = "1";
-            canClose = "0";
-            canMinimize = "0";
-            canMaximize = "0";
-            minSize = "50 50";
-            text = "Create Object";
-      
-            new GuiTextCtrl() {
-               profile = "GuiCenterTextProfile";
-               horizSizing = "right";
-               vertSizing = "bottom";
-               position = "9 26";
-               extent = "84 16";
-               minExtent = "8 8";
-               visible = "1";
-               setFirstResponder = "0";
-               modal = "1";
-               helpTag = "0";
-               text = "Object Name:";
-            };
-            new GuiTextEditCtrl(GameObjectBuilderObjectName) {
-                class = ObjectBuilderGuiTextEditCtrl;
-               profile = "ToolsGuiTextEditProfile";
-               horizSizing = "width";
-               vertSizing = "bottom";
-               position = "78 26";
-               extent = "172 18";
-               minExtent = "8 8";
-               visible = "1";
-               setFirstResponder = "0";
-               modal = "1";
-               helpTag = "0";
-               historySize = "0";
-            };
-            new GuiButtonCtrl(GameObjectBuilderOKButton) {
-               profile = "ToolsGuiButtonProfile";
-               horizSizing = "width";
-               vertSizing = "bottom";
-               position = "7 250";
-               extent = "156 24";
-               minExtent = "8 8";
-               visible = "1";
-               setFirstResponder = "0";
-               modal = "1";
-               command = "EWorldEditor.buildGameObject();";
-               helpTag = "0";
-               text = "Create New";
-               Accelerator = "return";
-            };
-            new GuiButtonCtrl(GameObjectBuilderCancelButton) {
-               profile = "ToolsGuiButtonProfile";
-               horizSizing = "left";
-               vertSizing = "bottom";
-               position = "170 250";
-               extent = "80 24";
-               minExtent = "8 8";
-               visible = "1";
-               setFirstResponder = "0";
-               modal = "1";
-               command = "Canvas.popDialog(GameObjectBuilder);";
-               helpTag = "0";
-               text = "Cancel";
-               Accelerator = "escape";
-            };
-         };
-      };
-      
-      GameObjectBuilderTargetWindow.extent = getWord(GameObjectBuilderTargetWindow.extent, 0) SPC 88;
-      GameObjectBuilderOKButton.position = getWord(GameObjectBuilderOKButton.position, 0) SPC 57;
-      GameObjectBuilderCancelButton.position = getWord(GameObjectBuilderCancelButton.position, 0) SPC 57;
-   }
-
-   GameObjectBuilderObjectName.text = "";
-   GameObjectBuilder.selectedEntity = %entity;
-
-   Canvas.pushDialog(GameObjectBuilder);
-}
-
-function EWorldEditor::buildGameObject(%this)
-{
-	if(GameObjectBuilderObjectName.getText() $= "")
-	{
-		error("Attempted to make a new Game Object with no name!");
-		Canvas.popDialog(GameObjectBuilder);
-		return;
-	}
-
-	%path = EditorSettings.value( "WorldEditor/newGameObjectDir" );
-	%className = GameObjectBuilderObjectName.getText();
-	GameObjectBuilder.selectedEntity.class = %className;
-	Inspector.inspect(GameObjectBuilder.selectedEntity);
-	
-	%file = new FileObject();
-	
-	if(%file.openForWrite(%path @ "\\" @ %className @ ".cs"))
-	{
-		%file.writeline("function " @ %className @ "::onAdd(%this)\n{\n\n}\n");
-		%file.writeline("function " @ %className @ "::onRemove(%this)\n{\n\n}\n");
-		
-		//todo, pre-write any event functions of interest
-		
-		%file.close();
-	}
-	
-	//set up the paths
-	%tamlPath = %path @ "/" @ %className @ ".taml";
-	%scriptPath = %path @ "/" @ %className @ ".cs";
-	saveGameObject(%className, %tamlPath, %scriptPath);
-	
-	//reload it
-	execGameObjects();
-	
-	//now, add the script file and a ref to the taml into our SGO manifest so we can readily spawn it later.
-	TamlWrite(GameObjectBuilder.selectedEntity, %tamlpath);
-
-   GameObjectBuilder.selectedEntity = "";
-	
-	Canvas.popDialog(GameObjectBuilder);
 }
 
 function EWorldEditor::selectAllObjectsInSet( %this, %set, %deselect )

--- a/Templates/Full/game/tools/worldEditor/scripts/editorPrefs.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editorPrefs.ed.cs
@@ -34,7 +34,6 @@ EditorSettings.setDefaultValue(  "orthoFOV",                "50" );
 EditorSettings.setDefaultValue(  "orthoShowGrid",           "1" );
 EditorSettings.setDefaultValue(  "currentEditor",           "WorldEditorInspectorPlugin" );
 EditorSettings.setDefaultValue(  "newLevelFile",            "tools/levels/BlankRoom.mis" );
-EditorSettings.setDefaultValue(  "newGameObjectDir",        "scripts/server/gameObjects" );
 
 if( isFile( "C:/Program Files/Torsion/Torsion.exe" ) )
    EditorSettings.setDefaultValue(  "torsionPath",          "C:/Program Files/Torsion/Torsion.exe" );

--- a/Templates/Full/game/tools/worldEditor/scripts/editors/creator.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editors/creator.ed.cs
@@ -304,36 +304,6 @@ function EWCreatorWindow::navigate( %this, %address )
                %this.addShapeIcon( %obj );
          }
       }
-      
-      //Add a separate folder for Game Objects
-      if(isClass("Entity"))
-      {
-          if(%address $= "")
-          {
-              %this.addFolderIcon("GameObjects");
-          }
-          else
-          {
-              //find all GameObjectAssets
-              %assetQuery = new AssetQuery();
-              if(!AssetDatabase.findAssetType(%assetQuery, "GameObjectAsset"))
-                 return 0; //if we didn't find ANY, just exit
-
-              %count = %assetQuery.getCount();
-
-              for(%i=0; %i < %count; %i++)
-              {
-                 %assetId = %assetQuery.getAsset(%i);
-
-                 %gameObjectAsset = AssetDatabase.acquireAsset(%assetId);
-
-                 if(isFile(%gameObjectAsset.TAMLFilePath))
-                 {
-                    %this.addGameObjectIcon( %gameObjectAsset.gameObjectName );
-                 }
-              }
-          }
-      }
    }
    
    if ( %this.tab $= "Meshes" )
@@ -761,22 +731,6 @@ function EWCreatorWindow::addPrefabIcon( %this, %fullPath )
    %ctrl.text = %file;
    %ctrl.class = "CreatorPrefabIconBtn";
    %ctrl.tooltip = %tip;
-   
-   %ctrl.buttonType = "radioButton";
-   %ctrl.groupNum = "-1";   
-   
-   %this.contentCtrl.addGuiControl( %ctrl );   
-}
-
-function EWCreatorWindow::addGameObjectIcon( %this, %gameObjectName )
-{
-   %ctrl = %this.createIcon();
-
-   %ctrl.altCommand = "spawnGameObject( \"" @ %gameObjectName @ "\", true );";
-   %ctrl.iconBitmap = EditorIconRegistry::findIconByClassName( "Prefab" );
-   %ctrl.text = %gameObjectName;
-   %ctrl.class = "CreatorGameObjectIconBtn";
-   %ctrl.tooltip = "Spawn the " @ %gameObjectName @ " GameObject";
    
    %ctrl.buttonType = "radioButton";
    %ctrl.groupNum = "-1";   


### PR DESCRIPTION
Removes the GameObject  folder insert for the scripted object creator grid, which was causing a UI screwup making the scripted objects overlap and jumble up.

Also reorgs the popup controls to match what's in the BaseGame template's setup, which should fix editor popups.