### PR TITLE
Changes for SFXSound::setPosition(time)

### DIFF
--- a/Engine/source/platform/async/asyncPacketStream.h
+++ b/Engine/source/platform/async/asyncPacketStream.h
@@ -281,9 +281,22 @@ void AsyncPacketBufferedInputStream< Stream, Packet >::_requestNext()
       IResettable* resettable = dynamic_cast< IResettable* >( s );
       if( resettable )
       {
+         IPositionable< U32 >* positionable = dynamic_cast< IPositionable< U32 >* >( &Deref( stream ) );
+         U32 pos;
+         if(positionable)
+            pos = positionable->getPosition();
+         
          resettable->reset();
          isEOS = false;
          this->mNumRemainingSourceElements = mNumTotalSourceElements;
+         
+         if( positionable )
+         {
+            positionable->setPosition(pos);
+            U32 dur = stream->getDuration();
+            if(dur != 0) //avoiding division by zero? not needed, probably
+               this->mNumRemainingSourceElements -= (U32)(mNumTotalSourceElements*(F32)pos/dur);
+         }
       }
    }
    else if( isEOS )

--- a/Engine/source/sfx/sfxSound.cpp
+++ b/Engine/source/sfx/sfxSound.cpp
@@ -81,6 +81,7 @@ SFXSound::SFXSound( SFXProfile *profile, SFXDescription* desc )
    :  Parent( profile, desc ),
       mVoice( NULL )
 {
+   mSetPositionValue = 0;
 }
 
 //-----------------------------------------------------------------------------
@@ -411,6 +412,9 @@ void SFXSound::_play()
          Platform::outputDebugString( "[SFXSound] virtualizing playback of source '%i'", getId() );
       #endif
    }
+   if(getPosition() != mSetPositionValue)
+      setPosition(mSetPositionValue);
+   mSetPositionValue = 0; //Non looping sounds need this to reset.
 }
 
 //-----------------------------------------------------------------------------
@@ -421,6 +425,7 @@ void SFXSound::_stop()
    
    if( mVoice )
       mVoice->stop();
+   mSetPositionValue = 0;
 }
 
 //-----------------------------------------------------------------------------
@@ -431,6 +436,7 @@ void SFXSound::_pause()
    
    if( mVoice )
       mVoice->pause();
+   mSetPositionValue = getPosition();
 }
 
 //-----------------------------------------------------------------------------
@@ -511,6 +517,8 @@ void SFXSound::_updatePriority()
 
 U32 SFXSound::getPosition() const
 {
+   if( getLastStatus() == SFXStatusStopped)
+      return mSetPositionValue;
    if( mVoice )
       return mVoice->getFormat().getDuration( mVoice->getPosition() );
    else
@@ -522,6 +530,8 @@ U32 SFXSound::getPosition() const
 void SFXSound::setPosition( U32 ms )
 {
    AssertFatal( ms < getDuration(), "SFXSound::setPosition() - position out of range" );
+   mSetPositionValue = ms;
+
    if( mVoice )
       mVoice->setPosition( mVoice->getFormat().getSampleCount( ms ) );
    else

--- a/Engine/source/sfx/sfxSound.cpp
+++ b/Engine/source/sfx/sfxSound.cpp
@@ -693,8 +693,9 @@ DefineEngineMethod( SFXSound, setPosition, void, ( F32 position ),,
    "playback will resume at the given position when play() is called.\n\n"
    "@param position The new position of the play cursor (in seconds).\n" )
 {
-   if( position >= 0 && position <= object->getDuration() )
-      object->setPosition( position * 1000.0f );
+   position *= 1000.0f;
+   if( position >= 0 && position < object->getDuration() )
+      object->setPosition( position );
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/sfx/sfxSound.h
+++ b/Engine/source/sfx/sfxSound.h
@@ -81,6 +81,9 @@ class SFXSound : public SFXSource,
       /// _initBuffer() used for managing virtual sources.
       U32 mDuration;
 
+      ///Used for setPosition (time in miliseconds)
+      U32 mSetPositionValue;
+
       /// Create a new voice for this source.
       bool _allocVoice( SFXDevice* device );
 


### PR DESCRIPTION
Note: Only tested with OpenAL.

The method sfxSound.setPosition(time) has some issues:
-The engine method has a miscalculation in some values.
-It doesn't work when the sound is stopped (so you can't modify the time before play).
-It doesn't work at all for files longer than 24 seconds that are streaming and looping (if they're shorter than 24 s, internally they're changed to not-streaming -sfxSystem.cpp: ~line 714-).

To check that you need a datablock SFXProfile with looping and streaming like:

datablock SFXProfile(SoundLength31sLS)
{
   filename = "data/sfxSetPosTest/scripts/atime_31s";
   description = AudioMusicLoop2D;
};

With that datablock loaded you create the sound with:
$sound_object = sfxCreateSource(SoundLength31sLS);

Then you can test various things like:

$sound_object.play();
$sound_object.setPosition(24);
$sound_object.stop()
$sound_object.getPosition();
$sound_object.setPosition(10);
$sound_object.play();


This pull request _tries_ to fix those issues.
I'm not 100% sure if all it is alright.
Specially the changes to asyncPacketStream.h. But I don't see anywhere else where it is used.
Also not sure the effect with internet streaming sounds.
The SFXSound::_play() part is a bit "hack" but I don't know how to easily add the option for setPosition to work before playing.


Finally let me warn about a possible issue:
source\sfx\openal\sfxALBuffer.cpp(156,0): {Fatal} - SFXALBuffer::write() - buffer invalid

That may happen when setting the position immediatly after sfxCreateSource all in one line very fast like:

$sound_object = sfxCreateSource(SoundLength31sLS); $sound_object.play(); $sound_object.setPosition(28);

But it's very hard for it to appear, as:
-It seems to appear only the first time a datablock is used.
-It seems to be affected by buffer load so you have to force continuous loads of sound.

I have no idea how to fix it. I'd love any help on that. Probably a while(true){ -check if buffer is ready then break the while;- } is needed somewhere.

To try to replicate it you can use the module I include at the end.
With that loaded start any level and just call
stop_create_play_setpos(500)

If it doesn't explode then you need to restart the game to try again (for the datablocks to be again 1st time). You can change that 500 to change how fast the files are reload, too.
And actually it is troublesome because the sound plays but the setPosition fails.

Ah, that error appears too before these pull request changes. But only in the cases where setPosition worked.

Example with some files you can use in this module:
[sfxSetPosTest.zip](https://github.com/GarageGames/Torque3D/files/1800620/sfxSetPosTest.zip)
