### PR TITLE
5 Button mouse support

### DIFF
--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -474,6 +474,12 @@ void PlatformWindowSDL::_triggerMouseButtonNotify(const SDL_Event& event)
       case SDL_BUTTON_MIDDLE:
          button = 2;
          break;
+      case SDL_BUTTON_X1:
+         button = 3;
+         break;
+      case SDL_BUTTON_X2:
+         button = 4;
+         break;
       default:
          return;
    }


### PR DESCRIPTION
SDL supports up to 5 buttons per mouse, T3D currently only supports 3. This commit adds event mappings for the additional buttons.