### PR TITLE
Remove a now-unneeded fix for offsetof on new versions of Visual Studio.

### DIFF
--- a/Engine/source/console/consoleTypes.h
+++ b/Engine/source/console/consoleTypes.h
@@ -48,13 +48,6 @@ template<typename T> inline const T nullAsType(){ return nullptr; }
 /// @ingroup console_system Console System
 /// @{
 
-#if _MSC_VER >= 1911
-   #ifdef offsetof
-      #undef offsetof
-   #endif // offsetof
-   #define offsetof(s,m) ((size_t)&reinterpret_cast<char const volatile&>((((s*)0)->m)))
-#endif
-
 #ifndef Offset
 #define Offset(x, cls) offsetof(cls, x)
 #endif


### PR DESCRIPTION
Remove a now-unneeded fix for offsetof on new versions of Visual Studio.