### PR TITLE
Fix dumpConsoleClasses / dumpConsoleFunctions

### DIFF
--- a/Engine/source/console/codeBlock.cpp
+++ b/Engine/source/console/codeBlock.cpp
@@ -698,10 +698,10 @@ String CodeBlock::getFunctionArgs(U32 ip)
 {
    StringBuilder str;
 
-   U32 fnArgc = code[ip + 5];
+   U32 fnArgc = code[ip + 8];
    for (U32 i = 0; i < fnArgc; ++i)
    {
-      StringTableEntry var = CodeToSTE(code, ip + (i * 2) + 6);
+      StringTableEntry var = CodeToSTE(code, ip + (i * 2) + 9);
 
       if (i != 0)
          str.append(", ");

--- a/Engine/source/console/consoleDoc.cpp
+++ b/Engine/source/console/consoleDoc.cpp
@@ -88,7 +88,7 @@ void printClassHeader(const char* usage, const char * className, const char * su
    if((usage != NULL) && strlen(usage))
    {
       // Copy Usage Document
-      S32 usageLen = dStrlen( usage );
+      S32 usageLen = dStrlen( usage ) + 1;
       FrameTemp<char> usageStr( usageLen );
       dStrcpy( usageStr, usage, usageLen );
 


### PR DESCRIPTION
Both have small errors that cause crashing:

* `dumpConsoleClasses` has an off-by-1 error with a string buffer in `printClassHeader`
* `dumpConsoleFunctions` uses the wrong offset into the function code in `CodeBlock::getFunctionArgs`