### PR TITLE
Corrects a problem with the D3D11 texture lock/unlock mechanism

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11TextureObject.h
+++ b/Engine/source/gfx/D3D11/gfxD3D11TextureObject.h
@@ -31,8 +31,9 @@ class GFXD3D11TextureObject : public GFXTextureObject
 {
 protected:
    static U32 mTexCount;
-   GFXTexHandle mLockTex;
+   GFXTexHandle mStagingTex;
    DXGI_MAPPED_RECT mLockRect;
+   D3D11_BOX mLockBox;
    bool mLocked;
 
    U32 mLockedSubresource;


### PR DESCRIPTION
As per the title. If you need some quick code to test this with see [here](https://hastebin.com/fexocuzudu.php) . This will produce a green texture 1024x1024 that will have a 512x512 blue box in the dead center of it.