### PR TITLE
Fixes various incorrect popup menu behaviors.

### DIFF
--- a/Engine/source/gui/editor/popupMenu.cpp
+++ b/Engine/source/gui/editor/popupMenu.cpp
@@ -199,7 +199,7 @@ bool PopupMenu::setItem(S32 pos, const char *title, const char* accelerator, con
 
 void PopupMenu::removeItem(S32 itemPos)
 {
-   if (mMenuItems.size() < itemPos || itemPos < 0)
+   if (mMenuItems.empty() || mMenuItems.size() < itemPos || itemPos < 0)
       return;
 
    mMenuItems.erase(itemPos);
@@ -208,7 +208,7 @@ void PopupMenu::removeItem(S32 itemPos)
 //////////////////////////////////////////////////////////////////////////
 void PopupMenu::enableItem(S32 pos, bool enable)
 {
-   if (mMenuItems.size() < pos || pos < 0)
+   if (mMenuItems.empty() || mMenuItems.size() < pos || pos < 0)
       return;
 
    mMenuItems[pos].enabled = enable;
@@ -216,7 +216,7 @@ void PopupMenu::enableItem(S32 pos, bool enable)
 
 void PopupMenu::checkItem(S32 pos, bool checked)
 {
-   if (mMenuItems.size() < pos || pos < 0)
+   if (mMenuItems.empty() || mMenuItems.size() < pos || pos < 0)
       return;
 
    if (checked && mMenuItems[pos].checkGroup != -1)
@@ -243,7 +243,7 @@ void PopupMenu::checkRadioItem(S32 firstPos, S32 lastPos, S32 checkPos)
 
 bool PopupMenu::isItemChecked(S32 pos)
 {
-   if (mMenuItems.size() < pos || pos < 0)
+   if (mMenuItems.empty() || mMenuItems.size() < pos || pos < 0)
       return false;
 
    return mMenuItems[pos].isChecked;
@@ -252,6 +252,11 @@ bool PopupMenu::isItemChecked(S32 pos)
 U32 PopupMenu::getItemCount()
 {
    return mMenuItems.size();
+}
+
+void PopupMenu::clearItems()
+{
+	mMenuItems.clear();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -496,6 +501,11 @@ DefineConsoleMethod(PopupMenu, isItemChecked, bool, (S32 pos), , "(pos)")
 DefineConsoleMethod(PopupMenu, getItemCount, S32, (), , "()")
 {
    return object->getItemCount();
+}
+
+DefineConsoleMethod(PopupMenu, clearItems, void, (), , "()")
+{
+	return object->clearItems();
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/gui/editor/popupMenu.h
+++ b/Engine/source/gui/editor/popupMenu.h
@@ -137,6 +137,9 @@ public:
    /// Returns the number of items in the menu.
    U32 getItemCount();
 
+   ///Clears all items
+   void clearItems();
+
    //-----------------------------------------------------------------------------
    /// Displays this menu as a popup menu and blocks until the user has selected
    /// an item.

--- a/Templates/BaseGame/game/tools/base/menuBar/menuBuilder.ed.cs
+++ b/Templates/BaseGame/game/tools/base/menuBar/menuBuilder.ed.cs
@@ -152,9 +152,20 @@ function MenuBuilder::onAdd(%this)
    }
 }
 
+function MenuBuilder::reloadItems(%this)
+{
+   %this.clearItems();
+   
+   for(%i = 0;%this.item[%i] !$= "";%i++)
+   {
+      %this.addItem(%i);
+   }
+}
+
 function MenuBuilder::onRemove(%this)
 {
-   %this.removeFromMenuBar();
+   if(%this.isMethod("removeFromMenuBar"))
+      %this.removeFromMenuBar();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Templates/BaseGame/game/tools/guiEditor/scripts/guiEditorTreeView.ed.cs
+++ b/Templates/BaseGame/game/tools/guiEditor/scripts/guiEditorTreeView.ed.cs
@@ -28,33 +28,6 @@
 
 function GuiEditorTreeView::init(%this)
 {
-   if( !isObject( %this.contextMenu ) )
-      %this.contextMenu = new PopupMenu()
-      {
-         superClass = "MenuBuilder";
-         isPopup = true;
-         
-         item[ 0 ] = "Rename" TAB "" TAB "GuiEditorTreeView.showItemRenameCtrl( GuiEditorTreeView.findItemByObjectId( %this.object ) );";
-         item[ 1 ] = "Delete" TAB "" TAB "GuiEditor.deleteControl( %this.object );";
-         item[ 2 ] = "-";
-         item[ 3 ] = "Locked" TAB "" TAB "%this.object.setLocked( !%this.object.locked ); GuiEditorTreeView.update();";
-         item[ 4 ] = "Hidden" TAB "" TAB "%this.object.setVisible( !%this.object.isVisible() ); GuiEditorTreeView.update();";
-         item[ 5 ] = "-";
-         item[ 6 ] = "Add New Controls Here" TAB "" TAB "GuiEditor.setCurrentAddSet( %this.object );";
-         item[ 7 ] = "Add Child Controls to Selection" TAB "" TAB "GuiEditor.selectAllControlsInSet( %this.object, false );";
-         item[ 8 ] = "Remove Child Controls from Selection" TAB "" TAB "GuiEditor.selectAllControlsInSet( %this.object, true );";
-         
-         object = -1;
-      };
-      
-   if( !isObject( %this.contextMenuMultiSel ) )
-      %this.contextMenuMultiSel = new PopupMenu()
-      {
-         superClass = "MenuBuilder";
-         isPopup = true;
-         
-         item[ 0 ] = "Delete" TAB "" TAB "GuiEditor.deleteSelection();";
-      };
 }
 
 //---------------------------------------------------------------------------------------------
@@ -113,12 +86,36 @@ function GuiEditorTreeView::onRightMouseDown( %this, %item, %pts, %obj )
 {
    if( %this.getSelectedItemsCount() > 1 )
    {
-      %popup = %this.contextMenuMultiSel;
+      %popup = new PopupMenu()
+      {
+         superClass = "MenuBuilder";
+         isPopup = true;
+         object = -1;
+      };
+      
+      %popup.item[ 0 ] = "Delete" TAB "" TAB "GuiEditor.deleteSelection();";
+         
+      %popup.reloadItems();
       %popup.showPopup( Canvas );
    }
    else if( %obj )
    {
-      %popup = %this.contextMenu;
+     %popup = new PopupMenu()
+      {
+         superClass = "MenuBuilder";
+         isPopup = true;
+         object = %obj;
+      };
+      
+      %popup.item[ 0 ] = "Rename" TAB "" TAB "GuiEditorTreeView.showItemRenameCtrl( GuiEditorTreeView.findItemByObjectId(" @ %popup.object @ ") );";
+      %popup.item[ 1 ] = "Delete" TAB "" TAB "GuiEditor.deleteControl(" @ %popup.object @ ");";
+      %popup.item[ 2 ] = "-";
+      %popup.item[ 3 ] = "Locked" TAB "" TAB "%this.object.setLocked( !" @ %popup.object @ ".locked); GuiEditorTreeView.update();";
+      %popup.item[ 4 ] = "Hidden" TAB "" TAB "%this.object.setVisible( !" @ %popup.object @ ".isVisible() ); GuiEditorTreeView.update();";
+      %popup.item[ 5 ] = "-";
+      %popup.item[ 6 ] = "Add New Controls Here" TAB "" TAB "GuiEditor.setCurrentAddSet( " @ %popup.object @ ");";
+      %popup.item[ 7 ] = "Add Child Controls to Selection" TAB "" TAB "GuiEditor.selectAllControlsInSet( " @ %popup.object @ ", false );";
+      %popup.item[ 8 ] = "Remove Child Controls from Selection" TAB "" TAB "GuiEditor.selectAllControlsInSet( " @ %popup.object @ ", true );";
       
       %popup.checkItem( 3, %obj.locked );
       %popup.checkItem( 4, !%obj.isVisible() );
@@ -127,7 +124,8 @@ function GuiEditorTreeView::onRightMouseDown( %this, %item, %pts, %obj )
       %popup.enableItem( 7, %obj.getCount() > 0 );
       %popup.enableItem( 8, %obj.getCount() > 0 );
       
-      %popup.object = %obj;      
+      %popup.reloadItems();
+      
       %popup.showPopup( Canvas );
    }
 }

--- a/Templates/BaseGame/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
+++ b/Templates/BaseGame/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
@@ -2733,7 +2733,7 @@ function ShapeEdDetailTree::onRightMouseUp( %this, %itemId, %mouse )
             superClass = "MenuBuilder";
             isPopup = "1";
 
-            item[ 0 ] = "Hidden" TAB "" TAB "ShapeEdDetailTree.onHideMeshItem( %this._objName, !%this._itemHidden );";
+            item[ 0 ] = "Hidden" TAB "" TAB "ShapeEdDetailTree.onHideMeshItem(" @ ShapeEdMeshPopup._objName @ ", !" @ ShapeEdMeshPopup @ "._itemHidden );";
             item[ 1 ] = "-";
             item[ 2 ] = "Hide all" TAB "" TAB "ShapeEdDetailTree.onHideMeshItem( \"\", true );";
             item[ 3 ] = "Show all" TAB "" TAB "ShapeEdDetailTree.onHideMeshItem( \"\", false );";

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -1571,224 +1571,111 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
    %haveLockAndHideEntries = true;
    
    //Set up the generic pop-up pre-emptively if we haven't already
-   if( !isObject( ETContextPopup ) )
+   %popup = new PopupMenu()
    {
-      %popup = new PopupMenu( ETContextPopup )
-      {
-         superClass = "MenuBuilder";
-         isPopup = "1";
-
-         item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId( %this.object ) );";
-         item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject( %this.object );";
-         item[ 2 ] = "Inspect" TAB "" TAB "inspectObject( %this.object );";
-         item[ 3 ] = "-";
-         item[ 4 ] = "Locked" TAB "" TAB "%this.object.setLocked( !%this.object.locked ); EWorldEditor.syncGui();";
-         item[ 5 ] = "Hidden" TAB "" TAB "EWorldEditor.hideObject( %this.object, !%this.object.hidden ); EWorldEditor.syncGui();";
-         item[ 6 ] = "-";
-         item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
-
-         object = -1;
-      };
-   }
+      superClass = "MenuBuilder";
+      isPopup = "1";
+      object = -1;
+      bookmark = -1;
+   };
    
-   // Handle multi-selection.
    if( %this.getSelectedItemsCount() > 1 )
    {
-      %popup = ETMultiSelectionContextPopup;
-      if( !isObject( %popup ) )
-         %popup = new PopupMenu( ETMultiSelectionContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 0 ] = "Delete" TAB "" TAB "EditorMenuEditDelete();";
-            item[ 1 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
-         };
+      %popup.item[ 0 ] = "Delete" TAB "" TAB "EditorMenuEditDelete();";
+      %popup.item[ 1 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
    }
-
-   // Open context menu if this is a CameraBookmark
-   else if( %obj.isMemberOfClass( "CameraBookmark" ) )
-   {
-      %popup = ETCameraBookmarkContextPopup;
-      if( !isObject( %popup ) )
-         %popup = new PopupMenu( ETCameraBookmarkContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 0 ] = "Go To Bookmark" TAB "" TAB "EditorGui.jumpToBookmark( %this.bookmark.getInternalName() );";
-
-            bookmark = -1;
-         };
-
-      ETCameraBookmarkContextPopup.bookmark = %obj;
-   }
-   
-   // Open context menu if this is set CameraBookmarks group.
-   else if( %obj.name $= "CameraBookmarks" )
-   {
-      %popup = ETCameraBookmarksGroupContextPopup;
-      if( !isObject( %popup ) )
-         %popup = new PopupMenu( ETCameraBookmarksGroupContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 0 ] = "Add Camera Bookmark" TAB "" TAB "EditorGui.addCameraBookmarkByGui();";
-         };
-   }
-   
-   else if(%obj.isMemberOfClass("Entity"))
-   {
-      %popup = EntityObjectPopup;
-      if(!isObject(EntityObjectPopup))
-      {
-         %popup = new PopupMenu( EntityObjectPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId( %this.object ) );";
-            item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject( %this.object );";
-            item[ 2 ] = "Inspect" TAB "" TAB "inspectObject( %this.object );";
-            item[ 3 ] = "-";
-            item[ 4 ] = "Toggle Lock Children" TAB "" TAB "EWorldEditor.toggleLockChildren( %this.object );";
-            item[ 5 ] = "Toggle Hide Children" TAB "" TAB "EWorldEditor.toggleHideChildren( %this.object );";
-            item[ 6 ] = "-";
-            item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
-            item[ 8 ] = "-";
-            item[ 9 ] = "Add New Objects Here" TAB "" TAB "EWCreatorWindow.setNewObjectGroup( %this.object );";
-            item[ 10 ] = "Add Children to Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( %this.object, false );";
-            item[ 11 ] = "Remove Children from Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( %this.object, true );";
-            item[ 12 ] = "-";
-            item[ 13 ] = "Convert to Game Object" TAB "" TAB "EWorldEditor.createGameObject( %this.object );";
-            item[ 14 ] = "Duplicate Game Object" TAB "" TAB "EWorldEditor.duplicateGameObject( %this.object );";
-            item[ 15 ] = "Show in Asset Browser" TAB "" TAB "EWorldEditor.showGameObjectInAssetBrowser( %this.object );";
-            
-            object = -1;
-         };
-      }
-         
-      if(!isObject(AssetDatabase.acquireAsset(%obj.gameObjectAsset)))
-      {
-         EntityObjectPopup.enableItem(13, true);
-         EntityObjectPopup.enableItem(14, false);
-         EntityObjectPopup.enableItem(15, false);
-      }
-      else
-      {
-         EntityObjectPopup.enableItem(13, false);
-         EntityObjectPopup.enableItem(14, true);
-         EntityObjectPopup.enableItem(15, true);
-      }
-      
-      %popup.object = %obj;
-      
-      %hasChildren = %obj.getCount() > 0;
-      %popup.enableItem( 10, %hasChildren );
-      %popup.enableItem( 11, %hasChildren );
-      
-      %haveObjectEntries = true;
-      %haveLockAndHideEntries = false;
-   }
-
-   // Open context menu if this is a SimGroup
-   else if( !%obj.isMemberOfClass( "SceneObject" ) )
-   {
-      %popup = ETSimGroupContextPopup;
-      if( !isObject( %popup ) )
-      {
-         %popup = new PopupMenu( ETSimGroupContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId( %this.object ) );";
-            item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject( %this.object );";
-            item[ 2 ] = "Inspect" TAB "" TAB "inspectObject( %this.object );";
-            item[ 3 ] = "-";
-            item[ 4 ] = "Toggle Lock Children" TAB "" TAB "EWorldEditor.toggleLockChildren( %this.object );";
-            item[ 5 ] = "Toggle Hide Children" TAB "" TAB "EWorldEditor.toggleHideChildren( %this.object );";
-            item[ 6 ] = "-";
-            item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
-            item[ 8 ] = "-";
-            item[ 9 ] = "Add New Objects Here" TAB "" TAB "EWCreatorWindow.setNewObjectGroup( %this.object );";
-            item[ 10 ] = "Add Children to Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( %this.object, false );";
-            item[ 11 ] = "Remove Children from Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( %this.object, true );";
-
-            object = -1;
-         };
-      }
-
-      %popup.object = %obj;
-      
-      %hasChildren = %obj.getCount() > 0;
-      %popup.enableItem( 10, %hasChildren );
-      %popup.enableItem( 11, %hasChildren );
-      
-      %haveObjectEntries = true;
-      %haveLockAndHideEntries = false;
-   }
-   
-   // Specialized version for ConvexShapes. 
-   else if( %obj.isMemberOfClass( "ConvexShape" ) )
-   {
-      %popup = ETConvexShapeContextPopup;      
-      if( !isObject( %popup ) )
-      {
-         %popup = new PopupMenu( ETConvexShapeContextPopup : ETContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 8 ] = "-";
-            item[ 9 ] = "Convert to Zone" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Zone\" );";
-            item[ 10 ] = "Convert to Portal" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Portal\" );";
-            item[ 11 ] = "Convert to Occluder" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"OcclusionVolume\" );";
-            item[ 12 ] = "Convert to Sound Space" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"SFXSpace\" );";
-         };
-      }
-      
-      %popup.object = %obj;
-      %haveObjectEntries = true;
-   }
-   
-   // Specialized version for polyhedral objects.
-   else if( %obj.isMemberOfClass( "Zone" ) ||
-            %obj.isMemberOfClass( "Portal" ) ||
-            %obj.isMemberOfClass( "OcclusionVolume" ) ||
-            %obj.isMemberOfClass( "SFXSpace" ) )
-   {
-      %popup = ETPolyObjectContextPopup;      
-      if( !isObject( %popup ) )
-      {
-         %popup = new PopupMenu( ETPolyObjectContextPopup : ETContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 8 ] = "-";
-            item[ 9 ] = "Convert to ConvexShape" TAB "" TAB "EWorldEditor.convertSelectionToConvexShape();";
-         };
-      }
-      
-      %popup.object = %obj;
-      %haveObjectEntries = true;
-   }
-   
-   // Open generic context menu.
    else
    {
-      %popup = ETContextPopup;      
-
-      %popup.object = %obj;
-      %haveObjectEntries = true;
+      if( %obj.isMemberOfClass( "CameraBookmark" ) )
+      {
+         %popup.bookmark = %obj;
+         
+         %popup.item[ 0 ] = "Go To Bookmark" TAB "" TAB "EditorGui.jumpToBookmark( " @ %popup.bookmark.getInternalName() @ " );";
+      }
+      else if( %obj.name $= "CameraBookmarks" )
+      {
+         %popup.item[ 0 ] = "Add Camera Bookmark" TAB "" TAB "EditorGui.addCameraBookmarkByGui();";
+      }
+      else 
+      {
+         %popup.object = %obj;
+         %haveObjectEntries = true;
+         
+         %popup.item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId(" @ %popup.object @ ") );";
+         %popup.item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject(" @ %popup.object @ ");";
+         %popup.item[ 2 ] = "Inspect" TAB "" TAB "inspectObject(" @ %popup.object @ ");";
+         %popup.item[ 3 ] = "-";
+         %popup.item[ 4 ] = "Locked" TAB "" TAB "%this.object.setLocked( !" @ %popup.object @ ".locked ); EWorldEditor.syncGui();";
+         %popup.item[ 5 ] = "Hidden" TAB "" TAB "EWorldEditor.hideObject( " @ %popup.object @ ", !" @ %popup.object @ ".hidden ); EWorldEditor.syncGui();";
+         %popup.item[ 6 ] = "-";
+         %popup.item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
+   
+         if( %obj.isMemberOfClass( "ConvexShape" ) )
+         {
+            %popup.item[ 8 ] = "-";
+            %popup.item[ 9 ] = "Convert to Zone" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Zone\" );";
+            %popup.item[ 10 ] = "Convert to Portal" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Portal\" );";
+            %popup.item[ 11 ] = "Convert to Occluder" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"OcclusionVolume\" );";
+            %popup.item[ 12 ] = "Convert to Sound Space" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"SFXSpace\" );";
+         }
+         else if( %obj.isMemberOfClass( "Zone" ) ||
+               %obj.isMemberOfClass( "Portal" ) ||
+               %obj.isMemberOfClass( "OcclusionVolume" ) ||
+               %obj.isMemberOfClass( "SFXSpace" ) )
+         {
+            %popup.item[ 8 ] = "-";
+            %popup.item[ 9 ] = "Convert to ConvexShape" TAB "" TAB "EWorldEditor.convertSelectionToConvexShape();";
+         }
+         else if(%obj.getClassName() $= "SimGroup" || 
+               %obj.isMemberOfClass( "Path" ) ||
+               %obj.isMemberOfClass("Entity") )
+         {
+            //If it's not any special-handle classes above, then it'll be group-based stuff here
+            %popup.item[ 4 ] = "Toggle Lock Children" TAB "" TAB "EWorldEditor.toggleLockChildren( " @ %popup.object @ " );";
+            %popup.item[ 5 ] = "Toggle Hide Children" TAB "" TAB "EWorldEditor.toggleHideChildren( " @ %popup.object @ " );";
+            
+            %popup.item[ 8 ] = "-";
+            %popup.item[ 9 ] = "Add New Objects Here" TAB "" TAB "EWCreatorWindow.setNewObjectGroup( " @ %popup.object @ " );";
+            %popup.item[ 10 ] = "Add Children to Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( " @ %popup.object @ ", false );";
+            %popup.item[ 11 ] = "Remove Children from Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( " @ %popup.object @ ", true );";
+            
+            %hasChildren = %obj.getCount() > 0;
+            %popup.enableItem( 10, %hasChildren );
+            %popup.enableItem( 11, %hasChildren );
+            
+            %haveObjectEntries = true;
+            %haveLockAndHideEntries = false;
+            
+            //Special case for Entities, which is special-case AND does group stuff with chld objects
+            if(%obj.isMemberOfClass("Entity"))
+            {
+               %popup.item[ 12 ] = "-";
+               %popup.item[ 13 ] = "Convert to Game Object" TAB "" TAB "EWorldEditor.createGameObject( " @ %popup.object @ " );";
+               %popup.item[ 14 ] = "Duplicate Game Object" TAB "" TAB "EWorldEditor.duplicateGameObject( " @ %popup.object @ " );";
+               %popup.item[ 15 ] = "Show in Asset Browser" TAB "" TAB "EWorldEditor.showGameObjectInAssetBrowser( " @ %popup.object @ " );";
+               
+               if(!isObject(AssetDatabase.acquireAsset(%obj.gameObjectAsset)))
+               {
+                  %popup.enableItem(13, true);
+                  %popup.enableItem(14, false);
+                  %popup.enableItem(15, false);
+               }
+               else
+               {
+                  %popup.enableItem(13, false);
+                  %popup.enableItem(14, true);
+                  %popup.enableItem(15, true);
+               }
+            }
+         }  
+      }
    }
 
    if( %haveObjectEntries )
    {         
       %popup.enableItem( 0, %obj.isNameChangeAllowed() && %obj.getName() !$= "MissionGroup" );
       %popup.enableItem( 1, %obj.getName() !$= "MissionGroup" );
+      
       if( %haveLockAndHideEntries )
       {
          %popup.checkItem( 4, %obj.locked );
@@ -1797,6 +1684,7 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
       %popup.enableItem( 7, %this.isItemSelected( %itemId ) );
    }
    
+   %popup.reloadItems();
    %popup.showPopup( Canvas );
 }
 

--- a/Templates/Full/game/tools/base/menuBar/menuBuilder.ed.cs
+++ b/Templates/Full/game/tools/base/menuBar/menuBuilder.ed.cs
@@ -152,9 +152,20 @@ function MenuBuilder::onAdd(%this)
    }
 }
 
+function MenuBuilder::reloadItems(%this)
+{
+   %this.clearItems();
+   
+   for(%i = 0;%this.item[%i] !$= "";%i++)
+   {
+      %this.addItem(%i);
+   }
+}
+
 function MenuBuilder::onRemove(%this)
 {
-   %this.removeFromMenuBar();
+   if(%this.isMethod("removeFromMenuBar"))
+      %this.removeFromMenuBar();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Templates/Full/game/tools/guiEditor/scripts/guiEditor.ed.cs
+++ b/Templates/Full/game/tools/guiEditor/scripts/guiEditor.ed.cs
@@ -223,7 +223,7 @@ function GuiEditor::switchToWorldEditor( %this )
 
 function GuiEditor::enableMenuItems(%this, %val)
 {
-   %menu = GuiEditCanvas.menuBar->EditMenu.getID();
+   %menu = GuiEditCanvas.menuBar.findMenu("Edit").getID();
    
    %menu.enableItem( 3, %val ); // cut
    %menu.enableItem( 4, %val ); // copy
@@ -239,8 +239,8 @@ function GuiEditor::enableMenuItems(%this, %val)
    %menu.enableItem( 18, %val ); // group
    %menu.enableItem( 19, %val ); // ungroup
    
-   GuiEditCanvas.menuBar->LayoutMenu.enableAllItems( %val );
-   GuiEditCanvas.menuBar->MoveMenu.enableAllItems( %val );
+   GuiEditCanvas.menuBar.findMenu("Layout").enableAllItems( %val );
+   GuiEditCanvas.menuBar.findMenu("Move").enableAllItems( %val );
 }
 
 //---------------------------------------------------------------------------------------------
@@ -294,7 +294,7 @@ function GuiEditor::updateUndoMenu(%this)
    %nextUndo = %uman.getNextUndoName();
    %nextRedo = %uman.getNextRedoName();
    
-   %editMenu = GuiEditCanvas.menuBar->editMenu;
+   %editMenu = GuiEditCanvas.menuBar.findMenu("Edit");
    
    %editMenu.setItemName( 0, "Undo " @ %nextUndo );
    %editMenu.setItemName( 1, "Redo " @ %nextRedo );
@@ -443,7 +443,7 @@ function GuiEditor::setPreviewResolution( %this, %width, %height )
 function GuiEditor::toggleEdgeSnap( %this )
 {
    %this.snapToEdges = !%this.snapToEdges;
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_EDGESNAP_INDEX, %this.snapToEdges );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_EDGESNAP_INDEX, %this.snapToEdges );
    GuiEditorEdgeSnapping_btn.setStateOn( %this.snapToEdges );
 }
 
@@ -452,7 +452,7 @@ function GuiEditor::toggleEdgeSnap( %this )
 function GuiEditor::toggleCenterSnap( %this )
 {
    %this.snapToCenters = !%this.snapToCenters;
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_CENTERSNAP_INDEX, %this.snapToCenters );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_CENTERSNAP_INDEX, %this.snapToCenters );
    GuiEditorCenterSnapping_btn.setStateOn( %this.snapToCenters );
 }
 
@@ -461,7 +461,7 @@ function GuiEditor::toggleCenterSnap( %this )
 function GuiEditor::toggleFullBoxSelection( %this )
 {
    %this.fullBoxSelection = !%this.fullBoxSelection;
-   GuiEditCanvas.menuBar->EditMenu.checkItem( $GUI_EDITOR_MENU_FULLBOXSELECT_INDEX, %this.fullBoxSelection );
+   GuiEditCanvas.menuBar.findMenu("Edit").checkItem( $GUI_EDITOR_MENU_FULLBOXSELECT_INDEX, %this.fullBoxSelection );
 }
 
 //---------------------------------------------------------------------------------------------
@@ -469,7 +469,7 @@ function GuiEditor::toggleFullBoxSelection( %this )
 function GuiEditor::toggleDrawGuides( %this )
 {
    %this.drawGuides= !%this.drawGuides;
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_DRAWGUIDES_INDEX, %this.drawGuides );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_DRAWGUIDES_INDEX, %this.drawGuides );
 }
 
 //---------------------------------------------------------------------------------------------
@@ -477,7 +477,7 @@ function GuiEditor::toggleDrawGuides( %this )
 function GuiEditor::toggleGuideSnap( %this )
 {
    %this.snapToGuides = !%this.snapToGuides;
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_GUIDESNAP_INDEX, %this.snapToGuides );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_GUIDESNAP_INDEX, %this.snapToGuides );
 }
 
 //---------------------------------------------------------------------------------------------
@@ -485,7 +485,7 @@ function GuiEditor::toggleGuideSnap( %this )
 function GuiEditor::toggleControlSnap( %this )
 {
    %this.snapToControls = !%this.snapToControls;
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_CONTROLSNAP_INDEX, %this.snapToControls );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_CONTROLSNAP_INDEX, %this.snapToControls );
 }
 
 //---------------------------------------------------------------------------------------------
@@ -493,7 +493,7 @@ function GuiEditor::toggleControlSnap( %this )
 function GuiEditor::toggleCanvasSnap( %this )
 {
    %this.snapToCanvas = !%this.snapToCanvas;
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_CANVASSNAP_INDEX, %this.snapToCanvas );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_CANVASSNAP_INDEX, %this.snapToCanvas );
 }
 
 //---------------------------------------------------------------------------------------------
@@ -506,7 +506,7 @@ function GuiEditor::toggleGridSnap( %this )
    else
       %this.setSnapToGrid( %this.snap2GridSize );
 
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_GRIDSNAP_INDEX, %this.snap2Grid );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_GRIDSNAP_INDEX, %this.snap2Grid );
    GuiEditorSnapCheckBox.setStateOn( %this.snap2Grid );
 }
 
@@ -993,14 +993,14 @@ function GuiEditorGui::onWake( %this )
 
    // Set up initial menu toggle states.
    
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_EDGESNAP_INDEX, GuiEditor.snapToEdges );
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_CENTERSNAP_INDEX, GuiEditor.snapToCenters );
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_GUIDESNAP_INDEX, GuiEditor.snapToGuides );
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_CONTROLSNAP_INDEX, GuiEditor.snapToControls );
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_CANVASSNAP_INDEX, GuiEditor.snapToCanvas );
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_GRIDSNAP_INDEX, GuiEditor.snap2Grid );
-   GuiEditCanvas.menuBar->SnapMenu.checkItem( $GUI_EDITOR_MENU_DRAWGUIDES_INDEX, GuiEditor.drawGuides );
-   GuiEditCanvas.menuBar->EditMenu.checkItem( $GUI_EDITOR_MENU_FULLBOXSELECT_INDEX, GuiEditor.fullBoxSelection );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_EDGESNAP_INDEX, GuiEditor.snapToEdges );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_CENTERSNAP_INDEX, GuiEditor.snapToCenters );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_GUIDESNAP_INDEX, GuiEditor.snapToGuides );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_CONTROLSNAP_INDEX, GuiEditor.snapToControls );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_CANVASSNAP_INDEX, GuiEditor.snapToCanvas );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_GRIDSNAP_INDEX, GuiEditor.snap2Grid );
+   GuiEditCanvas.menuBar.findMenu("Snap").checkItem( $GUI_EDITOR_MENU_DRAWGUIDES_INDEX, GuiEditor.drawGuides );
+   GuiEditCanvas.menuBar.findMenu("Edit").checkItem( $GUI_EDITOR_MENU_FULLBOXSELECT_INDEX, GuiEditor.fullBoxSelection );
 
    // Sync toolbar buttons.
    

--- a/Templates/Full/game/tools/guiEditor/scripts/guiEditorTreeView.ed.cs
+++ b/Templates/Full/game/tools/guiEditor/scripts/guiEditorTreeView.ed.cs
@@ -28,33 +28,6 @@
 
 function GuiEditorTreeView::init(%this)
 {
-   if( !isObject( %this.contextMenu ) )
-      %this.contextMenu = new PopupMenu()
-      {
-         superClass = "MenuBuilder";
-         isPopup = true;
-         
-         item[ 0 ] = "Rename" TAB "" TAB "GuiEditorTreeView.showItemRenameCtrl( GuiEditorTreeView.findItemByObjectId( %this.object ) );";
-         item[ 1 ] = "Delete" TAB "" TAB "GuiEditor.deleteControl( %this.object );";
-         item[ 2 ] = "-";
-         item[ 3 ] = "Locked" TAB "" TAB "%this.object.setLocked( !%this.object.locked ); GuiEditorTreeView.update();";
-         item[ 4 ] = "Hidden" TAB "" TAB "%this.object.setVisible( !%this.object.isVisible() ); GuiEditorTreeView.update();";
-         item[ 5 ] = "-";
-         item[ 6 ] = "Add New Controls Here" TAB "" TAB "GuiEditor.setCurrentAddSet( %this.object );";
-         item[ 7 ] = "Add Child Controls to Selection" TAB "" TAB "GuiEditor.selectAllControlsInSet( %this.object, false );";
-         item[ 8 ] = "Remove Child Controls from Selection" TAB "" TAB "GuiEditor.selectAllControlsInSet( %this.object, true );";
-         
-         object = -1;
-      };
-      
-   if( !isObject( %this.contextMenuMultiSel ) )
-      %this.contextMenuMultiSel = new PopupMenu()
-      {
-         superClass = "MenuBuilder";
-         isPopup = true;
-         
-         item[ 0 ] = "Delete" TAB "" TAB "GuiEditor.deleteSelection();";
-      };
 }
 
 //---------------------------------------------------------------------------------------------
@@ -113,12 +86,36 @@ function GuiEditorTreeView::onRightMouseDown( %this, %item, %pts, %obj )
 {
    if( %this.getSelectedItemsCount() > 1 )
    {
-      %popup = %this.contextMenuMultiSel;
+      %popup = new PopupMenu()
+      {
+         superClass = "MenuBuilder";
+         isPopup = true;
+         object = -1;
+      };
+      
+      %popup.item[ 0 ] = "Delete" TAB "" TAB "GuiEditor.deleteSelection();";
+         
+      %popup.reloadItems();
       %popup.showPopup( Canvas );
    }
    else if( %obj )
    {
-      %popup = %this.contextMenu;
+     %popup = new PopupMenu()
+      {
+         superClass = "MenuBuilder";
+         isPopup = true;
+         object = %obj;
+      };
+      
+      %popup.item[ 0 ] = "Rename" TAB "" TAB "GuiEditorTreeView.showItemRenameCtrl( GuiEditorTreeView.findItemByObjectId(" @ %popup.object @ ") );";
+      %popup.item[ 1 ] = "Delete" TAB "" TAB "GuiEditor.deleteControl(" @ %popup.object @ ");";
+      %popup.item[ 2 ] = "-";
+      %popup.item[ 3 ] = "Locked" TAB "" TAB "%this.object.setLocked( !" @ %popup.object @ ".locked); GuiEditorTreeView.update();";
+      %popup.item[ 4 ] = "Hidden" TAB "" TAB "%this.object.setVisible( !" @ %popup.object @ ".isVisible() ); GuiEditorTreeView.update();";
+      %popup.item[ 5 ] = "-";
+      %popup.item[ 6 ] = "Add New Controls Here" TAB "" TAB "GuiEditor.setCurrentAddSet( " @ %popup.object @ ");";
+      %popup.item[ 7 ] = "Add Child Controls to Selection" TAB "" TAB "GuiEditor.selectAllControlsInSet( " @ %popup.object @ ", false );";
+      %popup.item[ 8 ] = "Remove Child Controls from Selection" TAB "" TAB "GuiEditor.selectAllControlsInSet( " @ %popup.object @ ", true );";
       
       %popup.checkItem( 3, %obj.locked );
       %popup.checkItem( 4, !%obj.isVisible() );
@@ -127,7 +124,8 @@ function GuiEditorTreeView::onRightMouseDown( %this, %item, %pts, %obj )
       %popup.enableItem( 7, %obj.getCount() > 0 );
       %popup.enableItem( 8, %obj.getCount() > 0 );
       
-      %popup.object = %obj;      
+      %popup.reloadItems();
+      
       %popup.showPopup( Canvas );
    }
 }

--- a/Templates/Full/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
+++ b/Templates/Full/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
@@ -2719,7 +2719,7 @@ function ShapeEdDetailTree::onRightMouseUp( %this, %itemId, %mouse )
             superClass = "MenuBuilder";
             isPopup = "1";
 
-            item[ 0 ] = "Hidden" TAB "" TAB "ShapeEdDetailTree.onHideMeshItem( %this._objName, !%this._itemHidden );";
+            item[ 0 ] = "Hidden" TAB "" TAB "ShapeEdDetailTree.onHideMeshItem(" @ ShapeEdMeshPopup._objName @ ", !" @ ShapeEdMeshPopup @ "._itemHidden );";
             item[ 1 ] = "-";
             item[ 2 ] = "Hide all" TAB "" TAB "ShapeEdDetailTree.onHideMeshItem( \"\", true );";
             item[ 3 ] = "Show all" TAB "" TAB "ShapeEdDetailTree.onHideMeshItem( \"\", false );";

--- a/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -1571,224 +1571,111 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
    %haveLockAndHideEntries = true;
    
    //Set up the generic pop-up pre-emptively if we haven't already
-   if( !isObject( ETContextPopup ) )
+   %popup = new PopupMenu()
    {
-      %popup = new PopupMenu( ETContextPopup )
-      {
-         superClass = "MenuBuilder";
-         isPopup = "1";
-
-         item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId( %this.object ) );";
-         item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject( %this.object );";
-         item[ 2 ] = "Inspect" TAB "" TAB "inspectObject( %this.object );";
-         item[ 3 ] = "-";
-         item[ 4 ] = "Locked" TAB "" TAB "%this.object.setLocked( !%this.object.locked ); EWorldEditor.syncGui();";
-         item[ 5 ] = "Hidden" TAB "" TAB "EWorldEditor.hideObject( %this.object, !%this.object.hidden ); EWorldEditor.syncGui();";
-         item[ 6 ] = "-";
-         item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
-
-         object = -1;
-      };
-   }
+      superClass = "MenuBuilder";
+      isPopup = "1";
+      object = -1;
+      bookmark = -1;
+   };
    
-   // Handle multi-selection.
    if( %this.getSelectedItemsCount() > 1 )
    {
-      %popup = ETMultiSelectionContextPopup;
-      if( !isObject( %popup ) )
-         %popup = new PopupMenu( ETMultiSelectionContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 0 ] = "Delete" TAB "" TAB "EditorMenuEditDelete();";
-            item[ 1 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
-         };
+      %popup.item[ 0 ] = "Delete" TAB "" TAB "EditorMenuEditDelete();";
+      %popup.item[ 1 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
    }
-
-   // Open context menu if this is a CameraBookmark
-   else if( %obj.isMemberOfClass( "CameraBookmark" ) )
-   {
-      %popup = ETCameraBookmarkContextPopup;
-      if( !isObject( %popup ) )
-         %popup = new PopupMenu( ETCameraBookmarkContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 0 ] = "Go To Bookmark" TAB "" TAB "EditorGui.jumpToBookmark( %this.bookmark.getInternalName() );";
-
-            bookmark = -1;
-         };
-
-      ETCameraBookmarkContextPopup.bookmark = %obj;
-   }
-   
-   // Open context menu if this is set CameraBookmarks group.
-   else if( %obj.name $= "CameraBookmarks" )
-   {
-      %popup = ETCameraBookmarksGroupContextPopup;
-      if( !isObject( %popup ) )
-         %popup = new PopupMenu( ETCameraBookmarksGroupContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 0 ] = "Add Camera Bookmark" TAB "" TAB "EditorGui.addCameraBookmarkByGui();";
-         };
-   }
-   
-   else if(%obj.isMemberOfClass("Entity"))
-   {
-      %popup = EntityObjectPopup;
-      if(!isObject(EntityObjectPopup))
-      {
-         %popup = new PopupMenu( EntityObjectPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId( %this.object ) );";
-            item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject( %this.object );";
-            item[ 2 ] = "Inspect" TAB "" TAB "inspectObject( %this.object );";
-            item[ 3 ] = "-";
-            item[ 4 ] = "Toggle Lock Children" TAB "" TAB "EWorldEditor.toggleLockChildren( %this.object );";
-            item[ 5 ] = "Toggle Hide Children" TAB "" TAB "EWorldEditor.toggleHideChildren( %this.object );";
-            item[ 6 ] = "-";
-            item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
-            item[ 8 ] = "-";
-            item[ 9 ] = "Add New Objects Here" TAB "" TAB "EWCreatorWindow.setNewObjectGroup( %this.object );";
-            item[ 10 ] = "Add Children to Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( %this.object, false );";
-            item[ 11 ] = "Remove Children from Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( %this.object, true );";
-            item[ 12 ] = "-";
-            item[ 13 ] = "Convert to Game Object" TAB "" TAB "EWorldEditor.createGameObject( %this.object );";
-            item[ 14 ] = "Duplicate Game Object" TAB "" TAB "EWorldEditor.duplicateGameObject( %this.object );";
-            item[ 15 ] = "Show in Asset Browser" TAB "" TAB "EWorldEditor.showGameObjectInAssetBrowser( %this.object );";
-            
-            object = -1;
-         };
-      }
-         
-      if(!isObject(AssetDatabase.acquireAsset(%obj.gameObjectAsset)))
-      {
-         EntityObjectPopup.enableItem(13, true);
-         EntityObjectPopup.enableItem(14, false);
-         EntityObjectPopup.enableItem(15, false);
-      }
-      else
-      {
-         EntityObjectPopup.enableItem(13, false);
-         EntityObjectPopup.enableItem(14, true);
-         EntityObjectPopup.enableItem(15, true);
-      }
-      
-      %popup.object = %obj;
-      
-      %hasChildren = %obj.getCount() > 0;
-      %popup.enableItem( 10, %hasChildren );
-      %popup.enableItem( 11, %hasChildren );
-      
-      %haveObjectEntries = true;
-      %haveLockAndHideEntries = false;
-   }
-
-   // Open context menu if this is a SimGroup
-   else if( !%obj.isMemberOfClass( "SceneObject" ) )
-   {
-      %popup = ETSimGroupContextPopup;
-      if( !isObject( %popup ) )
-      {
-         %popup = new PopupMenu( ETSimGroupContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId( %this.object ) );";
-            item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject( %this.object );";
-            item[ 2 ] = "Inspect" TAB "" TAB "inspectObject( %this.object );";
-            item[ 3 ] = "-";
-            item[ 4 ] = "Toggle Lock Children" TAB "" TAB "EWorldEditor.toggleLockChildren( %this.object );";
-            item[ 5 ] = "Toggle Hide Children" TAB "" TAB "EWorldEditor.toggleHideChildren( %this.object );";
-            item[ 6 ] = "-";
-            item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
-            item[ 8 ] = "-";
-            item[ 9 ] = "Add New Objects Here" TAB "" TAB "EWCreatorWindow.setNewObjectGroup( %this.object );";
-            item[ 10 ] = "Add Children to Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( %this.object, false );";
-            item[ 11 ] = "Remove Children from Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( %this.object, true );";
-
-            object = -1;
-         };
-      }
-
-      %popup.object = %obj;
-      
-      %hasChildren = %obj.getCount() > 0;
-      %popup.enableItem( 10, %hasChildren );
-      %popup.enableItem( 11, %hasChildren );
-      
-      %haveObjectEntries = true;
-      %haveLockAndHideEntries = false;
-   }
-   
-   // Specialized version for ConvexShapes. 
-   else if( %obj.isMemberOfClass( "ConvexShape" ) )
-   {
-      %popup = ETConvexShapeContextPopup;      
-      if( !isObject( %popup ) )
-      {
-         %popup = new PopupMenu( ETConvexShapeContextPopup : ETContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 8 ] = "-";
-            item[ 9 ] = "Convert to Zone" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Zone\" );";
-            item[ 10 ] = "Convert to Portal" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Portal\" );";
-            item[ 11 ] = "Convert to Occluder" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"OcclusionVolume\" );";
-            item[ 12 ] = "Convert to Sound Space" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"SFXSpace\" );";
-         };
-      }
-      
-      %popup.object = %obj;
-      %haveObjectEntries = true;
-   }
-   
-   // Specialized version for polyhedral objects.
-   else if( %obj.isMemberOfClass( "Zone" ) ||
-            %obj.isMemberOfClass( "Portal" ) ||
-            %obj.isMemberOfClass( "OcclusionVolume" ) ||
-            %obj.isMemberOfClass( "SFXSpace" ) )
-   {
-      %popup = ETPolyObjectContextPopup;      
-      if( !isObject( %popup ) )
-      {
-         %popup = new PopupMenu( ETPolyObjectContextPopup : ETContextPopup )
-         {
-            superClass = "MenuBuilder";
-            isPopup = "1";
-
-            item[ 8 ] = "-";
-            item[ 9 ] = "Convert to ConvexShape" TAB "" TAB "EWorldEditor.convertSelectionToConvexShape();";
-         };
-      }
-      
-      %popup.object = %obj;
-      %haveObjectEntries = true;
-   }
-   
-   // Open generic context menu.
    else
    {
-      %popup = ETContextPopup;      
-
-      %popup.object = %obj;
-      %haveObjectEntries = true;
+      if( %obj.isMemberOfClass( "CameraBookmark" ) )
+      {
+         %popup.bookmark = %obj;
+         
+         %popup.item[ 0 ] = "Go To Bookmark" TAB "" TAB "EditorGui.jumpToBookmark( " @ %popup.bookmark.getInternalName() @ " );";
+      }
+      else if( %obj.name $= "CameraBookmarks" )
+      {
+         %popup.item[ 0 ] = "Add Camera Bookmark" TAB "" TAB "EditorGui.addCameraBookmarkByGui();";
+      }
+      else 
+      {
+         %popup.object = %obj;
+         %haveObjectEntries = true;
+         
+         %popup.item[ 0 ] = "Rename" TAB "" TAB "EditorTree.showItemRenameCtrl( EditorTree.findItemByObjectId(" @ %popup.object @ ") );";
+         %popup.item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject(" @ %popup.object @ ");";
+         %popup.item[ 2 ] = "Inspect" TAB "" TAB "inspectObject(" @ %popup.object @ ");";
+         %popup.item[ 3 ] = "-";
+         %popup.item[ 4 ] = "Locked" TAB "" TAB "%this.object.setLocked( !" @ %popup.object @ ".locked ); EWorldEditor.syncGui();";
+         %popup.item[ 5 ] = "Hidden" TAB "" TAB "EWorldEditor.hideObject( " @ %popup.object @ ", !" @ %popup.object @ ".hidden ); EWorldEditor.syncGui();";
+         %popup.item[ 6 ] = "-";
+         %popup.item[ 7 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
+   
+         if( %obj.isMemberOfClass( "ConvexShape" ) )
+         {
+            %popup.item[ 8 ] = "-";
+            %popup.item[ 9 ] = "Convert to Zone" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Zone\" );";
+            %popup.item[ 10 ] = "Convert to Portal" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"Portal\" );";
+            %popup.item[ 11 ] = "Convert to Occluder" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"OcclusionVolume\" );";
+            %popup.item[ 12 ] = "Convert to Sound Space" TAB "" TAB "EWorldEditor.convertSelectionToPolyhedralObjects( \"SFXSpace\" );";
+         }
+         else if( %obj.isMemberOfClass( "Zone" ) ||
+               %obj.isMemberOfClass( "Portal" ) ||
+               %obj.isMemberOfClass( "OcclusionVolume" ) ||
+               %obj.isMemberOfClass( "SFXSpace" ) )
+         {
+            %popup.item[ 8 ] = "-";
+            %popup.item[ 9 ] = "Convert to ConvexShape" TAB "" TAB "EWorldEditor.convertSelectionToConvexShape();";
+         }
+         else if(%obj.getClassName() $= "SimGroup" || 
+               %obj.isMemberOfClass( "Path" ) ||
+               %obj.isMemberOfClass("Entity") )
+         {
+            //If it's not any special-handle classes above, then it'll be group-based stuff here
+            %popup.item[ 4 ] = "Toggle Lock Children" TAB "" TAB "EWorldEditor.toggleLockChildren( " @ %popup.object @ " );";
+            %popup.item[ 5 ] = "Toggle Hide Children" TAB "" TAB "EWorldEditor.toggleHideChildren( " @ %popup.object @ " );";
+            
+            %popup.item[ 8 ] = "-";
+            %popup.item[ 9 ] = "Add New Objects Here" TAB "" TAB "EWCreatorWindow.setNewObjectGroup( " @ %popup.object @ " );";
+            %popup.item[ 10 ] = "Add Children to Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( " @ %popup.object @ ", false );";
+            %popup.item[ 11 ] = "Remove Children from Selection" TAB "" TAB "EWorldEditor.selectAllObjectsInSet( " @ %popup.object @ ", true );";
+            
+            %hasChildren = %obj.getCount() > 0;
+            %popup.enableItem( 10, %hasChildren );
+            %popup.enableItem( 11, %hasChildren );
+            
+            %haveObjectEntries = true;
+            %haveLockAndHideEntries = false;
+            
+            //Special case for Entities, which is special-case AND does group stuff with chld objects
+            if(%obj.isMemberOfClass("Entity"))
+            {
+               %popup.item[ 12 ] = "-";
+               %popup.item[ 13 ] = "Convert to Game Object" TAB "" TAB "EWorldEditor.createGameObject( " @ %popup.object @ " );";
+               %popup.item[ 14 ] = "Duplicate Game Object" TAB "" TAB "EWorldEditor.duplicateGameObject( " @ %popup.object @ " );";
+               %popup.item[ 15 ] = "Show in Asset Browser" TAB "" TAB "EWorldEditor.showGameObjectInAssetBrowser( " @ %popup.object @ " );";
+               
+               if(!isObject(AssetDatabase.acquireAsset(%obj.gameObjectAsset)))
+               {
+                  %popup.enableItem(13, true);
+                  %popup.enableItem(14, false);
+                  %popup.enableItem(15, false);
+               }
+               else
+               {
+                  %popup.enableItem(13, false);
+                  %popup.enableItem(14, true);
+                  %popup.enableItem(15, true);
+               }
+            }
+         }  
+      }
    }
 
    if( %haveObjectEntries )
    {         
       %popup.enableItem( 0, %obj.isNameChangeAllowed() && %obj.getName() !$= "MissionGroup" );
       %popup.enableItem( 1, %obj.getName() !$= "MissionGroup" );
+      
       if( %haveLockAndHideEntries )
       {
          %popup.checkItem( 4, %obj.locked );
@@ -1797,6 +1684,7 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
       %popup.enableItem( 7, %this.isItemSelected( %itemId ) );
    }
    
+   %popup.reloadItems();
    %popup.showPopup( Canvas );
 }
 


### PR DESCRIPTION
Rearranges the right-mouse click popup menus for the world editor and gui editors to a) be organized more logically and b) be more flexible.

This also fixes some insecure behavior relying on %this value eval'ing, which has also been modified to be better.

Also fixes up some old calls for getting menubar menus by internal name, which is no longer supported, instead using the findMenu function call.