### PR TITLE
Changes TSStatic::castRayRendered to use passed texcoord argument.

### DIFF
--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -1007,6 +1007,8 @@ bool TSStatic::castRayRendered(const Point3F &start, const Point3F &end, RayInfo
 
    // Cast the ray against the currently visible detail
    RayInfo localInfo;
+   if (info && info->generateTexCoord)
+      localInfo.generateTexCoord = true;
    bool res = mShapeInstance->castRayOpcode( mShapeInstance->getCurrentDetail(), start, end, &localInfo );
 
    if ( res )


### PR DESCRIPTION
This fixes a bug where TSStatic::castRayRendered() ignored the state of generateTexCoord in the passed RayInfo structure and never returned texture coordinates if requested.