### PR TITLE
Fix for bug in GFXVideoMode::parseFromString()

### DIFF
--- a/Engine/source/gfx/gfxStructs.cpp
+++ b/Engine/source/gfx/gfxStructs.cpp
@@ -49,7 +49,9 @@ void GFXVideoMode::parseFromString( const char *str )
 
    PARSE_ELEM(S32, resolution.x, dAtoi, tempBuf, " x\0")
    PARSE_ELEM(S32, resolution.y, dAtoi, NULL,    " x\0")
-   PARSE_ELEM(S32, fullScreen,   dAtob, NULL,    " \0")
+   const char *boolptr = dStrtok(NULL, " \0");
+   if (boolptr)
+      fullScreen = dAtob(boolptr);
    PARSE_ELEM(S32, bitDepth,     dAtoi, NULL,    " \0")
    PARSE_ELEM(S32, refreshRate,  dAtoi, NULL,    " \0")
    PARSE_ELEM(S32, antialiasLevel, dAtoi, NULL,    " \0")


### PR DESCRIPTION
When testing PR #2264 I discovered that GFXVideoMode::parseFromString() will never assign false to the fullScreen value. That value must be initialized to false going in. I found it hard to believe that that could be the case and not have caused a problem before now, so I dropped:
```c++
   GFXVideoMode vmTest = GFXInit::getDesktopResolution();
   vmTest.fullScreen = true;
   vmTest.parseFromString("800 600 false 32 60");
   Con::printf("%s becomes %s", "800 600 false 32 60", vmTest.toString().c_str());
```
into the end of _GFXInitGetInitialRes() and the output string is:
800 600 false 32 60 becomes 800 600 true 32 60 0

None of the values get assigned by the macro [here](https://github.com/GarageGames/Torque3D/blob/development/Engine/source/gfx/gfxStructs.cpp#L46-L48) if their function evaluates to zero or the token is missing from the string. This commit corrects that for the boolean case to only skip the assignment if the string token is not found.