### PR TITLE
micro patch to the nativefiledialogues library to mirror file type name

### DIFF
--- a/Engine/lib/nativeFileDialogs/nfd_win.cpp
+++ b/Engine/lib/nativeFileDialogs/nfd_win.cpp
@@ -183,7 +183,7 @@ static nfdresult_t AddFiltersToDialog( ::IFileDialog *fileOpenDialog, const char
             /* end of filter -- add it to specList */
 
             // Empty filter name -- Windows describes them by extension.            
-            specList[specIdx].pszName = EMPTY_WSTR;
+            CopyNFDCharToWChar(specbuf, (wchar_t**)&specList[specIdx].pszName);
             CopyNFDCharToWChar( specbuf, (wchar_t**)&specList[specIdx].pszSpec );
                         
             memset( specbuf, 0, sizeof(char)*NFD_MAX_STRLEN );
@@ -203,7 +203,7 @@ static nfdresult_t AddFiltersToDialog( ::IFileDialog *fileOpenDialog, const char
 
     /* Add wildcard */
     specList[specIdx].pszSpec = WILDCARD;
-    specList[specIdx].pszName = EMPTY_WSTR;
+    specList[specIdx].pszName = WILDCARD;
     
     fileOpenDialog->SetFileTypes( filterCount+1, specList );
 


### PR DESCRIPTION
folks with 'hide extensions for known file types' on windows weren't seeing any entries in thier drop-down lists for file types.