### PR TITLE
ExtendedMove packet cleanup

### DIFF
--- a/Engine/source/T3D/gameBase/extended/extendedMove.cpp
+++ b/Engine/source/T3D/gameBase/extended/extendedMove.cpp
@@ -27,6 +27,8 @@ F32 ExtendedMoveManager::mRotAA[ExtendedMove::MaxPositionsRotations] = { 1, };
 
 F32 ExtendedMoveManager::mPosScale = 2.0f;
 
+static ExtendedMove ClampedNullExtendedMove;
+
 void ExtendedMoveManager::init()
 {
    for(U32 i = 0; i < ExtendedMove::MaxPositionsRotations; ++i)
@@ -82,6 +84,8 @@ void ExtendedMoveManager::init()
       "@brief Indicates the scale to be given to mvPos values.\n\n"
       ""
       "@ingroup Game");
+
+   ClampedNullExtendedMove.clamp();
 }
 
 const ExtendedMove NullExtendedMove;
@@ -115,7 +119,7 @@ void ExtendedMove::pack(BitStream *stream, const Move * basemove)
 {
    bool alwaysWriteAll = basemove!=NULL;
    if (!basemove)
-      basemove = &NullExtendedMove;
+      basemove = &ClampedNullExtendedMove;
 
    // Write the standard Move stuff
    packMove(stream, basemove, alwaysWriteAll);

--- a/Engine/source/T3D/gameBase/extended/extendedMove.cpp
+++ b/Engine/source/T3D/gameBase/extended/extendedMove.cpp
@@ -22,8 +22,8 @@ F32 ExtendedMoveManager::mPosZ[ExtendedMove::MaxPositionsRotations] = { 0, };
 bool ExtendedMoveManager::mRotIsEuler[ExtendedMove::MaxPositionsRotations] = { 0, };
 F32 ExtendedMoveManager::mRotAX[ExtendedMove::MaxPositionsRotations] = { 0, };
 F32 ExtendedMoveManager::mRotAY[ExtendedMove::MaxPositionsRotations] = { 0, };
-F32 ExtendedMoveManager::mRotAZ[ExtendedMove::MaxPositionsRotations] = { 0, };
-F32 ExtendedMoveManager::mRotAA[ExtendedMove::MaxPositionsRotations] = { 1, };
+F32 ExtendedMoveManager::mRotAZ[ExtendedMove::MaxPositionsRotations] = { 1, 1, 1 };
+F32 ExtendedMoveManager::mRotAA[ExtendedMove::MaxPositionsRotations] = { 0, };
 
 F32 ExtendedMoveManager::mPosScale = 2.0f;
 
@@ -104,8 +104,8 @@ ExtendedMove::ExtendedMove() : Move()
       posZ[i] = 0;
       rotX[i] = 0;
       rotY[i] = 0;
-      rotZ[i] = 0;
-      rotW[i] = 1;
+      rotZ[i] = 1;
+      rotW[i] = 0;
 
       cposX[i] = 0;
       cposY[i] = 0;

--- a/Engine/source/T3D/gameBase/extended/extendedMoveList.cpp
+++ b/Engine/source/T3D/gameBase/extended/extendedMoveList.cpp
@@ -74,7 +74,7 @@ bool ExtendedMoveList::getNextExtMove( ExtendedMove &curMove )
       }
       else
       {
-         //Rotation is passed in as an Angle Axis in degrees.  We need to convert this into a Quat.
+         //Rotation is passed in as an Angle Axis in degrees.
          AngAxisF q(Point3F(ExtendedMoveManager::mRotAX[i], ExtendedMoveManager::mRotAY[i], ExtendedMoveManager::mRotAZ[i]), mDegToRad(ExtendedMoveManager::mRotAA[i]));
          curMove.rotX[i] = q.axis.x;
          curMove.rotY[i] = q.axis.y;


### PR DESCRIPTION
The `ExtendedMove::pack()` function will write 360 bits of data into every move packet even if no tracked devices are present. This can be verified by building a project with the TORQUE_EXTENDED_MOVE flag set, placing a breakpoint at https://github.com/GarageGames/Torque3D/blob/development/Engine/source/T3D/gameBase/extended/extendedMove.cpp#L148, launching the game with no tracked devices connected and stepping through to see every value get sent in full. All of the values being compared from the current move have already been clamped/unclamped and because of floating-point errors `0.0f != UNCLAMPPOS(CLAMPPOS( 0.0f ))`. This PR creates a clamped copy of the NullExtendedMove to use for comparisons in the pack function so the full extended tracking data is only sent for devices that are connected and tracking. The initial rotation values have been changed to reflect the change from QuatF to AngAxisF and prevent the `mDegToRad()` call [here](https://github.com/GarageGames/Torque3D/blob/development/Engine/source/T3D/gameBase/extended/extendedMoveList.cpp#L78) from causing an empty move to differ from the default.