### PR TITLE
Adds Clamp to QuatF::dot()

### DIFF
--- a/Engine/source/math/mQuat.h
+++ b/Engine/source/math/mQuat.h
@@ -222,7 +222,7 @@ inline QuatF& QuatF::neg()
 
 inline F32 QuatF::dot( const QuatF &q ) const
 {
-   return (w*q.w + x*q.x + y*q.y + z*q.z);
+   return mClampF(w*q.w + x*q.x + y*q.y + z*q.z, -1.0f, 1.0f);
 }
 
 inline F32 QuatF::angleBetween( const QuatF & q )


### PR DESCRIPTION
As shown in the image below, the QuatF::dot() function can return values outside the [-1, 1] range due to floating point precision. This causes the QuatF::angleBetween() function to reurn NAN when it should be returning Zero or Pi (and explains why there are no references to either function in the codebase). This PR clamps the output of QuatF::dot() to the [-1, 1] range so both functions become usable.
![quaterror](https://user-images.githubusercontent.com/5728394/45983901-ad192380-c02c-11e8-808a-e8b8ddf10121.jpg)
Edited to fix image link.