### PR TITLE
Improved BitStream writeQuat/readQuat methods.

### DIFF
--- a/Engine/source/core/stream/bitStream.h
+++ b/Engine/source/core/stream/bitStream.h
@@ -207,18 +207,18 @@ public:
    void readAffineTransform(MatrixF*);
 
    /// Writes a quaternion in a lossy compressed format that
-   /// is ( bitCount * 3 ) + 1 bits in size.
+   /// is ( bitCount * 3 ) + 2 bits in size.
    ///
    /// @param quat The normalized quaternion to write.
-   /// @param bitCount The the storage space for the xyz component of
+   /// @param bitCount The the storage space for the packed components of
    ///                 the quaternion.
    ///
    void writeQuat( const QuatF& quat, U32 bitCount = 9 );
 
    /// Reads a quaternion written with writeQuat.
    ///
-   /// @param quat The normalized quaternion to write.
-   /// @param bitCount The the storage space for the xyz component of
+   /// @param quat The quaternion that was read.
+   /// @param bitCount The the storage space for the packed components of
    ///                 the quaternion.  Must match the bitCount at write.
    /// @see writeQuat
    ///


### PR DESCRIPTION
Replaces the writeQuat/readQuat implementations with one that utilizes smallest three compression. I had intended to PR this as two additional methods for the BitStream class as shown [here](https://github.com/OTHGMars/Torque3D/commit/2d334833789d5f2215fe79df7c0ca71f984814ee), but after seeing how the stock methods performed in a [direct comparison](https://github.com/OTHGMars/Torque3D/blob/PairAQuatFuncs/Templates/Full/source/quatWriteData.md), figured this would be a better approach. If anyone would prefer to see it PRed as additional methods, leave a comment below.