### PR TITLE
fix turret lod lookup

### DIFF
--- a/Templates/Full/game/art/shapes/weapons/Turret/TP_Turret.cs
+++ b/Templates/Full/game/art/shapes/weapons/Turret/TP_Turret.cs
@@ -23,6 +23,6 @@
 singleton TSShapeConstructor(TP_TurretDAE)
 {
    baseShape = "./TP_Turret.DAE";
-   lodType = "TrailingNumber";
+   lodType = "SingleSize";
    loadLights = "0";
 };

--- a/Templates/Modules/FPSGameplay/art/shapes/weapons/Turret/TP_Turret.cs
+++ b/Templates/Modules/FPSGameplay/art/shapes/weapons/Turret/TP_Turret.cs
@@ -23,6 +23,6 @@
 singleton TSShapeConstructor(TP_TurretDAE)
 {
    baseShape = "./TP_Turret.DAE";
-   lodType = "TrailingNumber";
+   lodType = "SingleSize";
    loadLights = "0";
 };


### PR DESCRIPTION
the turret sample was built with varying trailing nubers. now that we default to that being the specifier, need to specify SingleSize (alternatively DetectDTS) instead for the very rare case when that isn't the intent.