### PR TITLE
Fixes CanvasSizeChangeSignal and Canvas::onResize()  under SDL

### DIFF
--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -594,6 +594,7 @@ void PlatformWindowSDL::_processSDLEvent(SDL_Event &evt)
                SDL_GetWindowSize( mWindowHandle, &width, &height );
                mVideoMode.resolution.set( width, height );
                getGFXTarget()->resetMode();
+               resizeEvent.trigger(getWindowId(), width, height);
                break;
             }
 


### PR DESCRIPTION
The  CanvasSizeChangeSignal is never triggered and Canvas::onResize() is never called when resizing the platform window under SDL. To verify, place a breakpoint at https://github.com/GarageGames/Torque3D/blob/development/Engine/source/gui/core/guiCanvas.cpp#L356, run the game and maximize/restore or resize the platform window. The breakpoint should be hitting, but it is not. This one line commit fixes that to match the legacy windows win32 platform behavior.