### PR TITLE
Fills in monitor functions in PlatformWindowManagerSDL

### DIFF
--- a/Engine/source/windowManager/sdl/sdlWindowMgr.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindowMgr.cpp
@@ -61,8 +61,6 @@ PlatformWindowManagerSDL::PlatformWindowManagerSDL()
    mOffscreenRender = false;
 
    mInputState = KeyboardInputState::NONE;
-
-   buildMonitorsList();
 }
 
 PlatformWindowManagerSDL::~PlatformWindowManagerSDL()
@@ -75,9 +73,8 @@ PlatformWindowManagerSDL::~PlatformWindowManagerSDL()
 
 RectI PlatformWindowManagerSDL::getPrimaryDesktopArea()
 {
-   // TODO SDL
-   AssertFatal(0, "");
-   return RectI(0,0,0,0);
+   // Primary is monitor 0
+   return getMonitorRect(0);
 }
 
 Point2I PlatformWindowManagerSDL::getDesktopResolution()
@@ -100,46 +97,60 @@ S32 PlatformWindowManagerSDL::getDesktopBitDepth()
    return bbp;
 }
 
-void PlatformWindowManagerSDL::buildMonitorsList()
-{
-   // TODO SDL
-}
-
 S32 PlatformWindowManagerSDL::findFirstMatchingMonitor(const char* name)
 {
-   /// TODO SDL
-   AssertFatal(0, "");
+   S32 count = SDL_GetNumVideoDisplays();
+   for (U32 index = 0; index < count; ++index)
+   {
+      if (dStrstr(name, SDL_GetDisplayName(index)) == name)
+         return index;
+   }
 
    return 0;
 }
 
 U32 PlatformWindowManagerSDL::getMonitorCount()
 {
-   // TODO SDL
-   AssertFatal(0, "");
-   return 1;
+   S32 monitorCount = SDL_GetNumVideoDisplays();
+   if (monitorCount < 0)
+   {
+      Con::errorf("SDL_GetNumVideoDisplays() failed: %s", SDL_GetError());
+      monitorCount = 0;
+   }
+
+   return (U32)monitorCount;
 }
 
 const char* PlatformWindowManagerSDL::getMonitorName(U32 index)
 {
-   // TODO SDL
-   AssertFatal(0, "");
+   const char* monitorName = SDL_GetDisplayName(index);
+   if (monitorName == NULL)
+      Con::errorf("SDL_GetDisplayName() failed: %s", SDL_GetError());
 
-   return "Monitor";
+   return monitorName;
 }
 
 RectI PlatformWindowManagerSDL::getMonitorRect(U32 index)
 {
-   // TODO SDL
-   AssertFatal(0, "");
+   SDL_Rect sdlRect;
+   if (0 != SDL_GetDisplayBounds(index, &sdlRect))
+   {
+      Con::errorf("SDL_GetDisplayBounds() failed: %s", SDL_GetError());
+      return RectI(0, 0, 0, 0);
+   }
 
-   return RectI(0, 0, 0,0 );
+   return RectI(sdlRect.x, sdlRect.y, sdlRect.w, sdlRect.h);
 }
 
 void PlatformWindowManagerSDL::getMonitorRegions(Vector<RectI> &regions)
 {
-   // TODO SDL
-   AssertFatal(0, "");
+   SDL_Rect sdlRect;
+   S32 monitorCount = SDL_GetNumVideoDisplays();
+   for (S32 index = 0; index < monitorCount; ++index)
+   {
+      if (0 == SDL_GetDisplayBounds(index, &sdlRect))
+         regions.push_back(RectI(sdlRect.x, sdlRect.y, sdlRect.w, sdlRect.h));
+   }
 }
 
 void PlatformWindowManagerSDL::getWindows(VectorPtr<PlatformWindow*> &windows)

--- a/Engine/source/windowManager/sdl/sdlWindowMgr.h
+++ b/Engine/source/windowManager/sdl/sdlWindowMgr.h
@@ -105,9 +105,6 @@ public:
    virtual S32       getDesktopBitDepth();
    virtual Point2I   getDesktopResolution();
 
-   /// Build out the monitors list.
-   virtual void buildMonitorsList();
-
    virtual S32 findFirstMatchingMonitor(const char* name);
    virtual U32 getMonitorCount();
    virtual const char* getMonitorName(U32 index);


### PR DESCRIPTION
Adds the sdl implementation for all used PlatformWindowManager monitor functions. [This unit test](https://github.com/GarageGames/Torque3D/blob/development/Engine/source/windowManager/test/windowManagerTest.cpp#L28) will now pass for the SDL platform. Here is the equivalent in TorqueScript to test the functions via the Canvas object: 
//Canvas.listDisplays();
function Canvas::listDisplays(%this)
{
   %count = %this.getMonitorCount();
   echo(%count SPC "monitor(s) detected.");
   for (%i = 0; %i < %count; %i++)
   {
      echo("Monitor #" @ (%i + 1) SPC %this.getMonitorName(%i) @ ": " @ %this.getMonitorRect(%i));
   }
}
edited to correct formatting.