### PR TITLE
Adds features to GuiInputCtrl

### DIFF
--- a/Engine/source/gui/utility/guiInputCtrl.cpp
+++ b/Engine/source/gui/utility/guiInputCtrl.cpp
@@ -58,9 +58,25 @@ ConsoleDocClass( GuiInputCtrl,
 
 //------------------------------------------------------------------------------
 
+GuiInputCtrl::GuiInputCtrl()
+   : mSendAxisEvents(false),
+   mSendBreakEvents(false),
+   mSendModifierEvents(false)
+{
+}
+
+//------------------------------------------------------------------------------
+
 void GuiInputCtrl::initPersistFields()
 {
-   
+   addGroup("GuiInputCtrl");
+   addField("sendAxisEvents", TypeBool, Offset(mSendAxisEvents, GuiInputCtrl),
+      "If true, onAxisEvent callbacks will be sent for SI_AXIS Move events (Default false).");
+   addField("sendBreakEvents", TypeBool, Offset(mSendBreakEvents, GuiInputCtrl),
+      "If true, break events for all devices will generate callbacks (Default false).");
+   addField("sendModifierEvents", TypeBool, Offset(mSendModifierEvents, GuiInputCtrl),
+      "If true, Make events will be sent for modifier keys (Default false).");
+   endGroup("GuiInputCtrl");
 
    Parent::initPersistFields();
 }
@@ -110,6 +126,8 @@ static bool isModifierKey( U16 keyCode )
       case KEY_RALT:
       case KEY_LSHIFT:
       case KEY_RSHIFT:
+      case KEY_MAC_LOPT:
+      case KEY_MAC_ROPT:
          return( true );
    }
 
@@ -117,33 +135,46 @@ static bool isModifierKey( U16 keyCode )
 }
 
 IMPLEMENT_CALLBACK( GuiInputCtrl, onInputEvent, void, (const char* device, const char* action, bool state ),
-														  ( device, action, state),
-	"@brief Callback that occurs when an input is triggered on this control\n\n"
-	"@param device The device type triggering the input, such as keyboard, mouse, etc\n"
-	"@param action The actual event occuring, such as a key or button\n"
-	"@param state True if the action is being pressed, false if it is being release\n\n"
-);
+   ( device, action, state),
+   "@brief Callback that occurs when an input is triggered on this control\n\n"
+   "@param device The device type triggering the input, such as keyboard, mouse, etc\n"
+   "@param action The actual event occuring, such as a key or button\n"
+   "@param state True if the action is being pressed, false if it is being release\n\n");
+
+IMPLEMENT_CALLBACK(GuiInputCtrl, onAxisEvent, void, (const char* device, const char* action, F32 axisValue),
+   (device, action, axisValue),
+   "@brief Callback that occurs when an axis event is triggered on this control\n\n"
+   "@param device The device type triggering the input, such as mouse, joystick, gamepad, etc\n"
+   "@param action The ActionMap code for the axis\n"
+   "@param axisValue The current value of the axis\n\n");
 
 //------------------------------------------------------------------------------
 bool GuiInputCtrl::onInputEvent( const InputEventInfo &event )
 {
-   // TODO - add POV support...
+   char deviceString[32];
    if ( event.action == SI_MAKE )
    {
       if ( event.objType == SI_BUTTON
         || event.objType == SI_POV
-        || ( ( event.objType == SI_KEY ) && !isModifierKey( event.objInst ) ) )
+        || event.objType == SI_KEY )
       {
-         char deviceString[32];
          if ( !ActionMap::getDeviceName( event.deviceType, event.deviceInst, deviceString ) )
-            return( false );
+            return false;
 
-         const char* actionString = ActionMap::buildActionString( &event );
+         if ((event.objType == SI_KEY) && isModifierKey(event.objInst))
+         {
+            if (!mSendModifierEvents)
+               return false;
 
-		 //Con::executef( this, "onInputEvent", deviceString, actionString, "1" );
-		 onInputEvent_callback(deviceString, actionString, 1);
-
-         return( true );
+            const char* actionString = INPUTMGR->findKeyboardMapDescFromCode(event.objInst);
+            onInputEvent_callback(deviceString, actionString, 1);
+         }
+         else
+         {
+            const char* actionString = ActionMap::buildActionString(&event);
+            onInputEvent_callback(deviceString, actionString, 1);
+         }
+         return true;
       }
    }
    else if ( event.action == SI_BREAK )
@@ -152,14 +183,36 @@ bool GuiInputCtrl::onInputEvent( const InputEventInfo &event )
       {
          char keyString[32];
          if ( !ActionMap::getKeyString( event.objInst, keyString ) )
-            return( false );
+            return false;
 
-         //Con::executef( this, "onInputEvent", "keyboard", keyString, "0" );
-		 onInputEvent_callback("keyboard", keyString, 0);
+         onInputEvent_callback("keyboard", keyString, 0);
+         return true;
+      }
+      else if (mSendBreakEvents)
+      {
+         if (!ActionMap::getDeviceName(event.deviceType, event.deviceInst, deviceString))
+            return false;
 
-         return( true );
+         const char* actionString = ActionMap::buildActionString(&event);
+
+         onInputEvent_callback(deviceString, actionString, 0);
+         return true;
       }
    }
+   else if (mSendAxisEvents && ((event.objType == SI_AXIS) || (event.objType == SI_INT) || (event.objType == SI_FLOAT)))
+   {
+      F32 fValue = event.fValue;
+      if (event.objType == SI_INT)
+         fValue = (F32)event.iValue;
 
-   return( false );
+      if (!ActionMap::getDeviceName(event.deviceType, event.deviceInst, deviceString))
+         return false;
+
+      const char* actionString = ActionMap::buildActionString(&event);
+
+      onAxisEvent_callback(deviceString, actionString, fValue);
+      return (event.deviceType != MouseDeviceType);   // Don't consume mouse move events
+   }
+
+   return false;
 }

--- a/Engine/source/gui/utility/guiInputCtrl.cpp
+++ b/Engine/source/gui/utility/guiInputCtrl.cpp
@@ -166,8 +166,11 @@ bool GuiInputCtrl::onInputEvent( const InputEventInfo &event )
             if (!mSendModifierEvents)
                return false;
 
-            const char* actionString = INPUTMGR->findKeyboardMapDescFromCode(event.objInst);
-            onInputEvent_callback(deviceString, actionString, 1);
+            char keyString[32];
+            if (!ActionMap::getKeyString(event.objInst, keyString))
+               return false;
+
+            onInputEvent_callback(deviceString, keyString, 1);
          }
          else
          {

--- a/Engine/source/gui/utility/guiInputCtrl.h
+++ b/Engine/source/gui/utility/guiInputCtrl.h
@@ -32,23 +32,31 @@
 /// to script.  This is useful for implementing custom keyboard handling code.
 class GuiInputCtrl : public GuiMouseEventCtrl
 {
-   public:
+protected:
+   bool mSendAxisEvents;
+   bool mSendBreakEvents;
+   bool mSendModifierEvents;
 
-      typedef GuiMouseEventCtrl Parent;
-   
-      // GuiControl.
-      virtual bool onWake();
-      virtual void onSleep();
+public:
 
-      virtual bool onInputEvent( const InputEventInfo &event );
-      
-      static void initPersistFields();
+   typedef GuiMouseEventCtrl Parent;
 
-      DECLARE_CONOBJECT(GuiInputCtrl);
-      DECLARE_CATEGORY( "Gui Other Script" );
-      DECLARE_DESCRIPTION( "A control that locks the mouse and reports all keyboard input events to script." );
+   GuiInputCtrl();
 
-	  DECLARE_CALLBACK( void, onInputEvent, ( const char* device, const char* action, bool state ));
+   // GuiControl.
+   virtual bool onWake();
+   virtual void onSleep();
+
+   virtual bool onInputEvent( const InputEventInfo &event );
+
+   static void initPersistFields();
+
+   DECLARE_CONOBJECT(GuiInputCtrl);
+   DECLARE_CATEGORY( "Gui Other Script" );
+   DECLARE_DESCRIPTION( "A control that locks the mouse and reports all input events to script." );
+
+   DECLARE_CALLBACK( void, onInputEvent, ( const char* device, const char* action, bool state ));
+   DECLARE_CALLBACK(void, onAxisEvent, (const char* device, const char* action, F32 axisValue));
 };
 
 #endif // _GUI_INPUTCTRL_H


### PR DESCRIPTION
This commit adds three new features to the GuiInputCtrl. All three default to off, so it is fully backward compatible with existing scripts. The new options are:
sendAxisEvents – If true, the control will generate onAxisEvent() callbacks for all axis events. This is useful for binding joystick/controller axes to game actions.
sendBreakEvents – If true, the control will generate onInputEvent() callbacks for SI_BREAK events for all keys and buttons. By default the callback is only triggered for break events on modifier keys.
SendModifierEvents – If true SI_MAKE events for modifier keys will generate callbacks. By default, only the break events are sent for modifier keys.