### PR TITLE
Fix SDL Input::getKeyCode on software keyboard layouts

### DIFF
--- a/Engine/source/platformSDL/sdlInput.cpp
+++ b/Engine/source/platformSDL/sdlInput.cpp
@@ -118,7 +118,7 @@ U16 Input::getKeyCode( U16 asciiCode )
     char c[2];
     c[0]= asciiCode;
     c[1] = NULL;
-    return KeyMapSDL::getTorqueScanCodeFromSDL( SDL_GetScancodeFromName( c ) );
+    return KeyMapSDL::getTorqueScanCodeFromSDL( SDL_GetScancodeFromKey( SDL_GetKeyFromName(c) ) );
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Input::getAscii goes Torque keyCode -> SDL Scancode -> SDL Keycode -> SDL ascii key name
Input::getKeycode goes SDL ascii key name -> SDL Scancode -> Torque keyCode

This mismatch makes software keyboard layouts behave incorrectly in different places. For example, if you bind a key to an ActionMap and it will activate with a different button than specified.