### PR TITLE
Travis Compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,42 @@
 language: cpp
-compiler:
-  - clang
-  - gcc
+
+dist: xenial
+
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+      env: if CXXFLAGS="-fgnu-inline-asm -fasm-blocks"
+    - os: linux
+      compiler: gcc
+    - os: linux
+      compiler: clang
+
+addons:
+  apt:
+    packages:
+      - build-essential
+      - nasm
+      - libogg-dev
+      - libxft-dev
+      - libx11-dev
+      - libxxf86vm-dev
+      - libopenal-dev
+      - libfreetype6-dev
+      - libxcursor-dev
+      - libxinerama-dev
+      - libxi-dev
+      - libxrandr-dev
+      - libxss-dev
+      - libglu1-mesa-dev
+      - libgtk-3-dev
+
+script:
+  - mkdir -p My\ Projects/TestProject/buildFiles/travis/
+  - cd My\ Projects/TestProject/buildFiles/travis/
+  - cmake ../../../.. -DTORQUE_APP_NAME=TestProject -DCMAKE_BUILD_TYPE=Debug
+  - make 2>/dev/null # Do the actual build, but ignore all the warnings
+  - make # build again. This time all output is printed but the warnings that happened earlier do not happen again
+  - make install
+  - cd ../../game/
+  - ls


### PR DESCRIPTION
This is essentially the same as #2289 but with a cleaner git history.

It follows the compilation steps from http://wiki.torque3d.org/coder:compiling-in-linux#toc11

This checks both gcc and clang on linux, but only clang on mac

Because there are so many debug warnings they are suppressed in a very hacky way:
Make is run first with error output ignored.
Then an incremental build is run which has the error output, but will only build the files that errored the first time (and will error again).
There is probably a better way to ignore the warnings in cmake, but I'm a bit hesitant to change the cmake files and I couldn't find a way to do it with command line arguments.

Only after writing this I found out that there is a CI pull request already: https://github.com/GarageGames/Torque3D/pull/2211
That older PR probably has more features (including running a windows build on appveyor, and I believe it runs the tests too) but this script is simpler.