### PR TITLE
corrects a copy-corruption flaw with GuiSwatchButtonCtrl::onMouseDragged

### DIFF
--- a/Engine/source/gui/buttons/guiSwatchButtonCtrl.cpp
+++ b/Engine/source/gui/buttons/guiSwatchButtonCtrl.cpp
@@ -72,7 +72,7 @@ GuiSwatchButtonCtrl::GuiSwatchButtonCtrl()
 void GuiSwatchButtonCtrl::initPersistFields()
 {
    addField("color", TypeColorF, Offset(mSwatchColor, GuiSwatchButtonCtrl), "The foreground color of GuiSwatchButtonCtrl");
-   addField( "gridBitmap", TypeString, Offset( mGridBitmap, GuiSwatchButtonCtrl ), "The bitmap used for the transparent grid" );
+   addField( "gridBitmap", TypeRealString, Offset( mGridBitmap, GuiSwatchButtonCtrl ), "The bitmap used for the transparent grid" );
    
    Parent::initPersistFields();
 }


### PR DESCRIPTION
pretty sure the offending leak-line creeps in with
 https://github.com/GarageGames/Torque3D/blob/561f010f2e6411d8253d23f0cfcff794e81f60bf/Templates/BaseGame/game/tools/base/utils/swatchButtons.ed.cs#L34
comparative release/debug results in
string gridBitmap = "\c0"
vs
string gridBitmap = "ic\c1Gl\c0"
and the relavent initpersistfields entry of TypeString points to
https://github.com/GarageGames/Torque3D/blob/561f010f2e6411d8253d23f0cfcff794e81f60bf/Engine/source/console/consoleTypes.h#L71
which is likely causing malformation