### PR TITLE
nextfreemask does nothing for proximity mines as there are no subclas…

### DIFF
--- a/Engine/source/T3D/proximityMine.h
+++ b/Engine/source/T3D/proximityMine.h
@@ -72,8 +72,7 @@ class ProximityMine: public Item
 protected:
    enum MaskBits {
       DeployedMask   = Parent::NextFreeMask,
-      ExplosionMask  = Parent::NextFreeMask << 1,
-      NextFreeMask   = Parent::NextFreeMask << 2
+      ExplosionMask  = Parent::NextFreeMask << 1
    };
 
    enum State


### PR DESCRIPTION
…ses on this chain, but does bump it's enum value  over the limit with the new addition to sceneobject. so killed it.