### PR TITLE
Snap to terrain Z offset.

### DIFF
--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -816,6 +816,21 @@ void WorldEditor::terrainSnapSelection(Selection* sel, U8 modifier, Point3F gizm
    {
       mStuckToGround = true;
 
+      const F32 OffsetZValueMin = 0.01f;
+
+      if (mTerrainSnapOffsetZ)
+      {
+         if (mOffsetZValue == 0.0f)
+         {
+            ri.point.z += OffsetZValueMin;
+         }
+         else
+         {
+            ri.point.z += mOffsetZValue;
+         }
+         
+      }
+      
       sel->offset(ri.point - centroid, (!mUseGroupCenter && mGridSnap) ? mGridPlaneSize : 0.f);
 
       if(mTerrainSnapAlignment != AlignNone)
@@ -1795,6 +1810,9 @@ WorldEditor::WorldEditor()
    mStickToGround = false;
    mStuckToGround = false;
    mTerrainSnapAlignment = AlignNone;
+   mTerrainSnapOffsetZ = false;
+   mOffsetZValue = 0.0f;
+
    mDropAtBounds = false;
    mDropBelowCameraOffset = 15.0f;
    mDropAtScreenCenterScalar = 1.0f;
@@ -2788,6 +2806,8 @@ void WorldEditor::initPersistFields()
 
       addField( "isDirty",                TypeBool,   Offset(mIsDirty, WorldEditor) );
       addField( "stickToGround",          TypeBool,   Offset(mStickToGround, WorldEditor) );
+      addField("TerrainSnapOffsetZ",      TypeBool,   Offset(mTerrainSnapOffsetZ, WorldEditor));
+      addField("OffsetZValue",            TypeF32,    Offset(mOffsetZValue, WorldEditor));
       //addField("sameScaleAllAxis", TypeBool, Offset(mSameScaleAllAxis, WorldEditor));
       addField( "toggleIgnoreList",       TypeBool,   Offset(mToggleIgnoreList, WorldEditor) );
 

--- a/Engine/source/gui/worldEditor/worldEditor.h
+++ b/Engine/source/gui/worldEditor/worldEditor.h
@@ -358,6 +358,8 @@ class WorldEditor : public EditTSCtrl
       bool              mStickToGround;
       bool              mStuckToGround;            ///< Selection is stuck to the ground
       AlignmentType     mTerrainSnapAlignment;     ///< How does the stickied object align to the terrain
+      bool              mTerrainSnapOffsetZ;       ///< Allows the use of an offset to avoid z-fighting with flat objects on a flat terrain.
+      F32               mOffsetZValue;             ///< Value of the Z offset (note: this shouldnt be changed once set)
 
       bool              mSoftSnap;                 ///< Allow soft snapping all of the time
       bool              mSoftSnapActivated;        ///< Soft snap has been activated by the user and allowed by the current rules

--- a/Templates/Full/game/tools/worldEditor/scripts/editorPrefs.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/editorPrefs.ed.cs
@@ -60,6 +60,9 @@ EditorSettings.endGroup();
 
 EditorSettings.beginGroup( "Tools" );
 EditorSettings.setDefaultValue(  "snapGround",              "0"               );
+EditorSettings.setDefaultValue(  "TerrainSnapOffsetZ",      "0"               );
+EditorSettings.setDefaultValue(  "OffsetZValue",            "0.01"             );
+
 EditorSettings.setDefaultValue(  "snapSoft",                "0"               );
 EditorSettings.setDefaultValue(  "snapSoftSize",            "2.0"             );
 EditorSettings.setDefaultValue(  "boundingBoxCollision",    "0"               );
@@ -215,6 +218,10 @@ function EditorGui::readWorldEditorSettings(%this)
    
    EditorSettings.beginGroup( "Tools" );
    EWorldEditor.stickToGround             = EditorSettings.value("snapGround");                 //$pref::WorldEditor::snapGround;
+   EWorldEditor.TerrainSnapOffsetZ        = EditorSettings.value("TerrainSnapOffsetZ");         //$pref::WorldEditor::TerrainSnapOffsetZ;
+   EWorldEditor.OffsetZValue              = EditorSettings.value("OffsetZValue");               //$pref::WorldEditor::OffsetZValue;
+   
+   
    EWorldEditor.setSoftSnap( EditorSettings.value("snapSoft") );                                //$pref::WorldEditor::snapSoft
    EWorldEditor.setSoftSnapSize( EditorSettings.value("snapSoftSize") );                        //$pref::WorldEditor::snapSoftSize
    EWorldEditor.boundingBoxCollision      = EditorSettings.value("boundingBoxCollision");       //$pref::WorldEditor::boundingBoxCollision;
@@ -310,6 +317,9 @@ function EditorGui::writeWorldEditorSettings(%this)
 
    EditorSettings.beginGroup( "Tools" );
    EditorSettings.setValue( "snapGround",             EWorldEditor.stickToGround );          //$Pref::WorldEditor::snapGround
+   EditorSettings.setValue( "TerrainSnapOffsetZ",      EWorldEditor.TerrainSnapOffsetZ );     //$pref::WorldEditor::TerrainSnapOffsetZ;
+   EditorSettings.setValue( "OffsetZValue",            EWorldEditor.OffsetZValue );           //$pref::WorldEditor::OffsetZValue;
+   
    EditorSettings.setValue( "snapSoft",               EWorldEditor.getSoftSnap() );          //$Pref::WorldEditor::snapSoft
    EditorSettings.setValue( "snapSoftSize",           EWorldEditor.getSoftSnapSize() );      //$Pref::WorldEditor::snapSoftSize
    EditorSettings.setValue( "boundingBoxCollision",   EWorldEditor.boundingBoxCollision );   //$Pref::WorldEditor::boundingBoxCollision


### PR DESCRIPTION
Adds the capability to add a small offset to the Z value of items being told to snap to terrain.

Useful if you are building on flat terrain, using models that use a single place flooring. Stops the zfighting, the default is set to 1cm so its barely visible and zfighting is only seen when you view the plane from a much further distance. by default the offset feature is disabled

Both of the values can be set on line 63 and 64 of editorPrefs.ed,cs. 

TerrainSnapOffsetZ off/on = 0/1
OffsetZValue is in meters/units so 0.01 =1cm

