### PR TITLE
Switches to absolute position for mouse tracking.

### DIFF
--- a/Engine/source/windowManager/windowInputGenerator.h
+++ b/Engine/source/windowManager/windowInputGenerator.h
@@ -37,8 +37,6 @@ class PlatformWindow;
 
 class WindowInputGenerator
 {
-      bool mNotifyPosition;
-      
    protected:
 
       PlatformWindow *mWindow;


### PR DESCRIPTION
The SI_XAXIS and SI_YAXIS (mouse absolute position SI_MAKE) events are sent whenever the mouse moves while the platform cursor is visible.