### PR TITLE
Allows special inspectorFields to override their height

### DIFF
--- a/Engine/source/gui/editor/inspector/field.cpp
+++ b/Engine/source/gui/editor/inspector/field.cpp
@@ -50,7 +50,9 @@ GuiInspectorField::GuiInspectorField( GuiInspector* inspector,
    mField( field ), 
    mFieldArrayIndex( NULL ), 
    mEdit( NULL ),
-   mTargetObject(NULL)
+   mTargetObject(NULL),
+   mUseHeightOverride(false),
+   mHeightOverride(18)
 {
    if( field != NULL )
       mCaption    = field->pFieldname;
@@ -77,7 +79,9 @@ GuiInspectorField::GuiInspectorField()
    mTargetObject(NULL),
    mVariableName(StringTable->EmptyString()),
    mCallbackName(StringTable->EmptyString()),
-   mSpecialEditField(false)
+   mSpecialEditField(false),
+   mUseHeightOverride(false),
+   mHeightOverride(18)
 {
    setCanSave( false );
 }
@@ -112,7 +116,12 @@ bool GuiInspectorField::onAdd()
    if ( mEdit == NULL )
       return false;
 
-   setBounds(0,0,100,18);
+   S32 fieldHeight = 18;
+
+   if (mUseHeightOverride)
+      fieldHeight = mHeightOverride;
+
+   setBounds(0,0,100, fieldHeight);
 
    // Add our edit as a child
    addObject( mEdit );

--- a/Engine/source/gui/editor/inspector/field.h
+++ b/Engine/source/gui/editor/inspector/field.h
@@ -84,6 +84,10 @@ class GuiInspectorField : public GuiControl
       ///
       bool mHighlighted;
 
+      //These are so we can special-case our height for additional room on certain field-types
+      bool mUseHeightOverride;
+      U32 mHeightOverride;
+
       //An override that lets us bypass inspector-dependent logic for setting/getting variables/fields
       bool mSpecialEditField;
       //An override to make sure this field is associated to an object that isn't expressly


### PR DESCRIPTION
Allows special inspectorFields to override the height they use in the rollouts