### PR TITLE
Sanity check for calling getFieldValue

### DIFF
--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -2834,7 +2834,8 @@ DefineEngineMethod( SimObject, getFieldValue, const char*, ( const char* fieldNa
    "@param index Optional parameter to specify the index of an array field separately.\n"
    "@return The value of the given field or \"\" if undefined." )
 {
-   if (fieldName == "")
+   const U32 nameLen = dStrlen( fieldName );
+   if (nameLen == 0)
       return "";
 
    char fieldNameBuffer[ 1024 ];

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -2834,6 +2834,9 @@ DefineEngineMethod( SimObject, getFieldValue, const char*, ( const char* fieldNa
    "@param index Optional parameter to specify the index of an array field separately.\n"
    "@return The value of the given field or \"\" if undefined." )
 {
+   if (fieldName == "")
+      return "";
+
    char fieldNameBuffer[ 1024 ];
    char arrayIndexBuffer[ 64 ];
    

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -2844,7 +2844,6 @@ DefineEngineMethod( SimObject, getFieldValue, const char*, ( const char* fieldNa
    // Parse out index if the field is given in the form of 'name[index]'.
    
    const char* arrayIndex = NULL;
-   const U32 nameLen = dStrlen( fieldName );
    if( fieldName[ nameLen - 1 ] == ']' )
    {
       const char* leftBracket = dStrchr( fieldName, '[' );


### PR DESCRIPTION
Sanity check so calling getFieldValue on a blank fieldName doesn't cause a crash.