### PR TITLE
Tweaks some object handling of guiTreeViewObj

### DIFF
--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -390,7 +390,6 @@ void GuiTreeViewCtrl::Item::setObject(SimObject *obj)
 {
    if(!mState.test(InspectorData))
    {
-      Con::errorf("Tried to set the object for item %d, which is not InspectorData!", mId);
       return;
    }
    
@@ -409,7 +408,6 @@ SimObject *GuiTreeViewCtrl::Item::getObject()
 {
    if(!mState.test(InspectorData))
    {
-      Con::errorf("Tried to get the object for item %d, which is not InspectorData!", mId);
       return NULL;
    }
 
@@ -5101,12 +5099,13 @@ DefineEngineMethod( GuiTreeViewCtrl, editItem, bool, ( S32 itemId, const char* n
    return(object->editItem(itemId, newText, newValue));
 }
 
-DefineEngineMethod( GuiTreeViewCtrl, removeItem, bool, (S32 itemId), ,
+DefineEngineMethod( GuiTreeViewCtrl, removeItem, bool, (S32 itemId, bool deleteObjects), (0, true),
    "Remove an item from the tree with the given id.\n\n"
    "@param itemId TreeItemID of item to remove.\n"
+   "@param deleteObjects Whether the object on the item is deleted when the item is.\n"
    "@return True if successful, false if not.")
 {
-   return(object->removeItem(itemId));
+   return(object->removeItem(itemId, deleteObjects));
 }
 
 DefineEngineMethod( GuiTreeViewCtrl, removeAllChildren, void, (S32 itemId), ,
@@ -5333,6 +5332,31 @@ DefineEngineMethod( GuiTreeViewCtrl, findItemByObjectId, S32, (S32 objectId), ,
    "@return Tree Item Id for the given object ID.")
 {
    return(object->findItemByObjectId(objectId));
+}
+
+//------------------------------------------------------------------------------
+S32 GuiTreeViewCtrl::getItemObject(S32 itemId)
+{
+   GuiTreeViewCtrl::Item* item = getItem(itemId);
+   if (!item)
+   {
+      return 0;
+   }
+
+   SimObject* pObj = item->getObject();
+   if (pObj)
+      return pObj->getId();
+
+   return 0;
+}
+
+//------------------------------------------------------------------------------
+DefineEngineMethod(GuiTreeViewCtrl, getItemObject, S32, (S32 itemId), ,
+   "Gets the object for a particular item.\n\n"
+   "@param itemId  Item id you want the object id for."
+   "@return Object Id for the given tree item ID.")
+{
+   return(object->getItemObject(itemId));
 }
 
 //------------------------------------------------------------------------------

--- a/Engine/source/gui/controls/guiTreeViewCtrl.h
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.h
@@ -554,6 +554,7 @@ class GuiTreeViewCtrl : public GuiArrayCtrl
       S32 findItemByName(const char *name);
       S32 findItemByValue(const char *name);
       S32 findItemByObjectId(S32 iObjId);
+      S32 getItemObject(S32 itemId);
 
       void sortTree( bool caseSensitive, bool traverseHierarchy, bool parentsFirst );
 


### PR DESCRIPTION
Tweaks some handling of guiTreeViewObj so you don't necessarily have to delete an object if you delete the tree item, as well as the ability to look up the object id via tree item.

Also removes spam in the event that an item on the tree is more of a data representation rather than literal object.