### PR TITLE
Moves the path return from fileDialog through the returnBuffer

### DIFF
--- a/Engine/source/platform/nativeDialogs/fileDialog.cpp
+++ b/Engine/source/platform/nativeDialogs/fileDialog.cpp
@@ -285,9 +285,9 @@ bool FileDialog::Execute()
    {
       // Single file selection, do it the easy way
       if(mForceRelativePath)
-         mData.mFile = Platform::makeRelativePathName(resultPath.c_str(), NULL);
+         mData.mFile = Con::getReturnBuffer(Platform::makeRelativePathName(resultPath.c_str(), NULL));
       else
-         mData.mFile = resultPath.c_str();
+         mData.mFile = Con::getReturnBuffer(resultPath.c_str());
    }
    else if (mData.mStyle & FileDialogData::FDS_MULTIPLEFILES)
    {


### PR DESCRIPTION
Moves the path return from fileDialog through the returnBuffer so it doesn't get mangled or corrupted in memory inadvertently.