### PR TITLE
Adds visualizers for various types of colorblindness

### DIFF
--- a/Templates/BaseGame/game/tools/settings.xml
+++ b/Templates/BaseGame/game/tools/settings.xml
@@ -1,80 +1,83 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <EditorSettings>
-    <Group name="AxisGizmo">
-        <Setting name="axisGizmoMaxScreenLen">100</Setting>
-        <Setting name="snapRotations">0</Setting>
-        <Setting name="mouseScaleScalar">0.8</Setting>
-        <Setting name="renderInfoText">1</Setting>
-        <Setting name="rotationSnap">15</Setting>
-        <Setting name="mouseRotateScalar">0.8</Setting>
-        <Setting name="renderWhenUsed">0</Setting>
-        <Group name="Grid">
-            <Setting name="planeDim">500</Setting>
-            <Setting name="gridColor">255 255 255 20</Setting>
-            <Setting name="snapToGrid">0</Setting>
-            <Setting name="renderPlaneHashes">0</Setting>
-            <Setting name="gridSize">10 10 10</Setting>
-            <Setting name="renderPlane">0</Setting>
-        </Group>
-    </Group>
     <Group name="WorldEditor">
-        <Setting name="dropType">screenCenter</Setting>
-        <Setting name="forceLoadDAE">0</Setting>
-        <Setting name="orthoFOV">50</Setting>
-        <Setting name="currentEditor">WorldEditorInspectorPlugin</Setting>
-        <Setting name="undoLimit">40</Setting>
-        <Setting name="displayType">6</Setting>
         <Setting name="orthoShowGrid">1</Setting>
-        <Group name="Tools">
-            <Setting name="snapSoft">0</Setting>
-            <Setting name="boundingBoxCollision">0</Setting>
-            <Setting name="snapGround">0</Setting>
-            <Setting name="dropAtScreenCenterMax">100</Setting>
-            <Setting name="snapSoftSize">2</Setting>
-            <Setting name="dropAtScreenCenterScalar">1</Setting>
-            <Setting name="objectsUseBoxCenter">1</Setting>
-        </Group>
-        <Group name="Docs">
-            <Setting name="documentationURL">http://www.garagegames.com/products/torque-3d/documentation/user</Setting>
-            <Setting name="documentationLocal">../../../Documentation/Official Documentation.html</Setting>
-            <Setting name="forumURL">http://www.garagegames.com/products/torque-3d/forums</Setting>
-            <Setting name="documentationReference">../../../Documentation/Torque 3D - Script Manual.chm</Setting>
-        </Group>
-        <Group name="Grid">
-            <Setting name="gridOriginColor">255 255 255 100</Setting>
-            <Setting name="gridSize">1</Setting>
-            <Setting name="gridColor">102 102 102 100</Setting>
-            <Setting name="gridMinorColor">51 51 51 100</Setting>
-            <Setting name="gridSnap">0</Setting>
-        </Group>
-        <Group name="Images">
-            <Setting name="lockedHandle">tools/worldEditor/images/LockedHandle</Setting>
-            <Setting name="defaultHandle">tools/worldEditor/images/DefaultHandle</Setting>
-            <Setting name="selectHandle">tools/worldEditor/images/SelectHandle</Setting>
-        </Group>
-        <Group name="Render">
-            <Setting name="showMousePopupInfo">1</Setting>
-            <Setting name="renderObjHandle">1</Setting>
-            <Setting name="renderSelectionBox">1</Setting>
-            <Setting name="renderPopupBackground">1</Setting>
-            <Setting name="renderObjText">1</Setting>
-        </Group>
+        <Setting name="forceLoadDAE">0</Setting>
+        <Setting name="currentEditor">WorldEditorInspectorPlugin</Setting>
+        <Setting name="displayType">6</Setting>
+        <Setting name="dropType">screenCenter</Setting>
+        <Setting name="orthoFOV">50</Setting>
+        <Setting name="undoLimit">40</Setting>
         <Group name="Color">
-            <Setting name="objMouseOverColor">0 255 0 255</Setting>
-            <Setting name="popupBackgroundColor">100 100 100 255</Setting>
-            <Setting name="objectTextColor">255 255 255 255</Setting>
-            <Setting name="objSelectColor">255 0 0 255</Setting>
             <Setting name="selectionBoxColor">255 255 0 255</Setting>
-            <Setting name="objMouseOverSelectColor">0 0 255 255</Setting>
+            <Setting name="objMouseOverColor">0 255 0 255</Setting>
+            <Setting name="objSelectColor">255 0 0 255</Setting>
             <Setting name="dragRectColor">255 255 0 255</Setting>
+            <Setting name="objectTextColor">255 255 255 255</Setting>
+            <Setting name="objMouseOverSelectColor">0 0 255 255</Setting>
+            <Setting name="popupBackgroundColor">100 100 100 255</Setting>
         </Group>
         <Group name="ObjectIcons">
             <Setting name="fadeIconsStartDist">8</Setting>
-            <Setting name="fadeIcons">1</Setting>
-            <Setting name="fadeIconsEndAlpha">0</Setting>
-            <Setting name="fadeIconsStartAlpha">255</Setting>
             <Setting name="fadeIconsEndDist">20</Setting>
+            <Setting name="fadeIconsStartAlpha">255</Setting>
+            <Setting name="fadeIconsEndAlpha">0</Setting>
+            <Setting name="fadeIcons">1</Setting>
         </Group>
+        <Group name="Render">
+            <Setting name="showMousePopupInfo">1</Setting>
+            <Setting name="renderObjText">1</Setting>
+            <Setting name="renderSelectionBox">1</Setting>
+            <Setting name="renderPopupBackground">1</Setting>
+            <Setting name="renderObjHandle">1</Setting>
+        </Group>
+        <Group name="Grid">
+            <Setting name="gridOriginColor">255 255 255 100</Setting>
+            <Setting name="gridColor">102 102 102 100</Setting>
+            <Setting name="gridSnap">0</Setting>
+            <Setting name="gridSize">1</Setting>
+            <Setting name="gridMinorColor">51 51 51 100</Setting>
+        </Group>
+        <Group name="Docs">
+            <Setting name="documentationLocal">../../../Documentation/Official Documentation.html</Setting>
+            <Setting name="documentationReference">../../../Documentation/Torque 3D - Script Manual.chm</Setting>
+            <Setting name="documentationURL">http://www.garagegames.com/products/torque-3d/documentation/user</Setting>
+            <Setting name="forumURL">http://www.garagegames.com/products/torque-3d/forums</Setting>
+        </Group>
+        <Group name="Images">
+            <Setting name="lockedHandle">tools/worldEditor/images/LockedHandle</Setting>
+            <Setting name="selectHandle">tools/worldEditor/images/SelectHandle</Setting>
+            <Setting name="defaultHandle">tools/worldEditor/images/DefaultHandle</Setting>
+        </Group>
+        <Group name="Tools">
+            <Setting name="boundingBoxCollision">0</Setting>
+            <Setting name="snapSoftSize">2</Setting>
+            <Setting name="dropAtScreenCenterMax">100</Setting>
+            <Setting name="snapSoft">0</Setting>
+            <Setting name="objectsUseBoxCenter">1</Setting>
+            <Setting name="dropAtScreenCenterScalar">1</Setting>
+            <Setting name="snapGround">0</Setting>
+        </Group>
+    </Group>
+    <Group name="AxisGizmo">
+        <Setting name="renderInfoText">1</Setting>
+        <Setting name="mouseRotateScalar">0.8</Setting>
+        <Setting name="axisGizmoMaxScreenLen">100</Setting>
+        <Setting name="mouseScaleScalar">0.8</Setting>
+        <Setting name="rotationSnap">15</Setting>
+        <Setting name="renderWhenUsed">0</Setting>
+        <Setting name="snapRotations">0</Setting>
+        <Group name="Grid">
+            <Setting name="renderPlane">0</Setting>
+            <Setting name="planeDim">500</Setting>
+            <Setting name="snapToGrid">0</Setting>
+            <Setting name="gridSize">10 10 10</Setting>
+            <Setting name="gridColor">255 255 255 20</Setting>
+            <Setting name="renderPlaneHashes">0</Setting>
+        </Group>
+    </Group>
+    <Group name="NavEditor">
+        <Setting name="SpawnClass">AIPlayer</Setting>
     </Group>
     <Group name="LevelInformation">
         <Setting name="levelsDirectory">data/FPSGameplay/levels</Setting>
@@ -83,8 +86,5 @@
                 <Setting name="cameraSpeed">25</Setting>
             </Group>
         </Group>
-    </Group>
-    <Group name="NavEditor">
-        <Setting name="SpawnClass">AIPlayer</Setting>
     </Group>
 </EditorSettings>

--- a/Templates/BaseGame/game/tools/worldEditor/main.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/main.cs
@@ -133,6 +133,15 @@ function initializeWorldEditor()
    EVisibility.addOption( "Frustum Lock", "$Scene::lockCull", "" );
    EVisibility.addOption( "Disable Zone Culling", "$Scene::disableZoneCulling", "" );
    EVisibility.addOption( "Disable Terrain Occlusion", "$Scene::disableTerrainOcclusion", "" );
+
+   EVisibility.addOption( "Colorblindness: Protanopia", "$CBV_Protanopia", "toggleColorBlindnessViz" );
+   EVisibility.addOption( "Colorblindness: Protanomaly", "$CBV_Protanomaly", "toggleColorBlindnessViz" );
+   EVisibility.addOption( "Colorblindness: Deuteranopia", "$CBV_Deuteranopia", "toggleColorBlindnessViz" );
+   EVisibility.addOption( "Colorblindness: Deuteranomaly", "$CBV_Deuteranomaly", "toggleColorBlindnessViz" );
+   EVisibility.addOption( "Colorblindness: Tritanopia", "$CBV_Tritanopia", "toggleColorBlindnessViz" );
+   EVisibility.addOption( "Colorblindness: Tritanomaly", "$CBV_Tritanomaly", "toggleColorBlindnessViz" );
+   EVisibility.addOption( "Colorblindness: Achromatopsia", "$CBV_Achromatopsia", "toggleColorBlindnessViz" );
+   EVisibility.addOption( "Colorblindness: Achromatomaly", "$CBV_Achromatomaly", "toggleColorBlindnessViz" );
 }
 
 function destroyWorldEditor()

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/lightViz.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/lightViz.cs
@@ -367,3 +367,81 @@ function toggleBackbufferViz( %enable )
    else if ( !%enable )
       AL_DeferredShading.enable();    
 }
+
+function toggleColorBlindnessViz( %enable )
+{   
+   if ( %enable $= "" )
+   {
+      $CBV_Protanopia = ColorBlindnessVisualize.isEnabled() ? false : true;
+      ColorBlindnessVisualize.toggle();
+   }
+   else if ( %enable )
+      ColorBlindnessVisualize.enable();
+   else if ( !%enable )
+      ColorBlindnessVisualize.disable();    
+}
+
+new ShaderData( ColorBlindnessVisualizeShader )
+{
+   DXVertexShaderFile = $Core::CommonShaderPath @ "/postFX/postFxV.hlsl";
+   DXPixelShaderFile  = "tools/worldEditor/scripts/shaders/dbgColorBlindnessVisualizeP.hlsl";
+
+   OGLVertexShaderFile = $Core::CommonShaderPath @ "/postFX/gl/postFxV.glsl";
+   OGLPixelShaderFile  = "tools/worldEditor/scripts/shaders/dbgColorBlindnessVisualizeP.glsl";
+   
+   samplerNames[0] = "$backBuffer";
+   
+   pixVersion = 2.0;
+};
+
+singleton PostEffect( ColorBlindnessVisualize )
+{   
+   isEnabled         = false;
+   allowReflectPass  = false;
+   renderTime        = "PFXAfterBin";
+   renderBin         = "GlowBin";
+   
+   shader = ColorBlindnessVisualizeShader;
+   stateBlock = PFX_DefaultStateBlock;
+   texture[0] = "$backBuffer";
+   target = "$backBuffer";
+   renderPriority    = 10;
+};
+
+function ColorBlindnessVisualize::setShaderConsts(%this)
+{
+   %mode = 0;
+   
+   if($CBV_Protanopia)
+      %mode = 1;
+   else if($CBV_Protanomaly)
+      %mode = 2;
+   else if($CBV_Deuteranopia)
+      %mode = 3;
+   else if($CBV_Deuteranomaly)
+      %mode = 4;
+   else if($CBV_Tritanopia)
+      %mode = 5;
+   else if($CBV_Tritanomaly)
+      %mode = 6;
+   else if($CBV_Achromatopsia)
+      %mode = 7;
+   else if($CBV_Achromatomaly)
+      %mode = 8;
+      
+   %this.setShaderConst("$mode", %mode);
+}
+
+function ColorBlindnessVisualize::onEnabled( %this )
+{
+   AL_NormalsVisualize.disable();
+   AL_DepthVisualize.disable();
+   AL_LightSpecularVisualize.disable();
+   AL_LightColorVisualize.disable();
+   $AL_NormalsVisualizeVar = false;
+   $AL_DepthVisualizeVar = false;
+   $AL_LightSpecularVisualizeVar = false;   
+   $AL_LightColorVisualizeVar = false;   
+   
+   return true;
+}

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgColorBlindnessVisualizeP.glsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgColorBlindnessVisualizeP.glsl
@@ -1,0 +1,121 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2012 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
+//Using calculations and values provided by Alan Zucconi
+// www.alanzucconi.com
+
+#include "../../../../core/rendering/shaders/gl/hlslCompat.glsl"
+#include "shadergen:/autogenConditioners.h"
+
+in vec2 uv0;
+uniform sampler2D backBufferTex;
+
+in float mode;
+
+out vec4 OUT_col;
+
+void main()
+{   
+    vec4 imageColor = texture( backBufferTex, uv0 );  
+
+    if(mode == 0)
+    {
+        OUT_col = imageColor;
+    }
+    else
+    {
+        vec3 R = imageColor.r;
+        vec3 G = imageColor.g;
+        vec3 B = imageColor.b;
+
+        if(mode == 1) // Protanopia
+        {
+            R = vec3(0.56667, 0.43333, 0);
+            G = vec3(0.55833, 0.44167, 0);
+            B = vec3(0, 0.24167, 0.75833);
+        }
+        else if(mode == 2) // Protanomaly
+        {
+            R = vec3(0.81667, 0.18333, 0);
+            G = vec3(0.33333, 0.66667, 0);
+            B = vec3(0, 0.125, 0.875);
+        }
+        else if(mode == 3) // Deuteranopia
+        {
+            R = vec3(0.625, 0.375, 0);
+            G = vec3(0.70, 0.30, 0);
+            B = vec3(0, 0.30, 0.70);
+        }
+        else if(mode == 4) // Deuteranomaly
+        {
+            R = vec3(0.80, 0.20, 0);
+            G = vec3(0.25833, 0.74167, 0);
+            B = vec3(0, 0.14167, 0.85833);
+        }
+        else if(mode == 5) // Tritanopia
+        {
+            R = vec3(0.95, 0.05, 0);
+            G = vec3(0, 0.43333, 0.56667);
+            B = vec3(0, 0.475, 0.525);
+        }
+        else if(mode == 6) // Tritanomaly
+        {
+            R = vec3(0.96667, 0.03333, 0);
+            G = vec3(0, 0.73333, 0.26667);
+            B = vec3(0, 0.18333, 0.81667);
+        }
+        else if(mode == 7) // Achromatopsia
+        {
+            R = vec3(0.299, 0.587, 0.114);
+            G = vec3(0.299, 0.587, 0.114);
+            B = vec3(0.299, 0.587, 0.114);
+        }
+        else if(mode == 8) // Achromatomaly
+        {
+            R = vec3(0.618, 0.32, 0.062);
+            G = vec3(0.163, 0.775, 0.062);
+            B = vec3(0.163, 0.320, 0.516);
+        }
+
+        //First set
+        vec4 c = imageColor;
+
+        c.r = c.r * R[0] + c.g * R[1] + c.b * R[2];
+        c.g = c.r * G[0] + c.g * G[1] + c.b * G[2];
+        c.b = c.r * B[0] + c.g * B[1] + c.b * B[2];
+
+        vec3 cb = c.rgb;
+
+        cb.r = c.r * R[0] + c.g * R[1] + c.b * R[2];
+        cb.g = c.r * G[0] + c.g * G[1] + c.b * G[2];
+        cb.b = c.r * B[0] + c.g * B[1] + c.b * B[2];
+
+        // Difference
+        vec3 diff = abs(c.rgb - cb);
+
+        float lum = c.r*.3 + c.g*.59 + c.b*.11;
+        vec3 bw = vec3(lum, lum, lum);
+
+       // return vec4(lerp(bw, vec3(1, 0, 0), saturate((diff.r + diff.g + diff.b) / 3)), c.a); 
+       OUT_col = vec4(c.rgb,1);
+    }
+}

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgColorBlindnessVisualizeP.hlsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgColorBlindnessVisualizeP.hlsl
@@ -1,0 +1,118 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2012 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
+//Using calculations and values provided by Alan Zucconi
+// www.alanzucconi.com
+
+#include "../../../../core/rendering/shaders/shaderModelAutoGen.hlsl"
+#include "../../../../core/rendering/shaders/postFX/postFx.hlsl"
+
+TORQUE_UNIFORM_SAMPLER2D(backBufferTex,0);
+
+uniform float mode;
+
+float4 main( PFXVertToPix IN ) : TORQUE_TARGET0
+{   
+    float4 imageColor = TORQUE_TEX2D( backBufferTex, IN.uv0 );  
+
+    if(mode == 0)
+    {
+        return imageColor;
+    }
+    else
+    {
+        float3 R = imageColor.r;
+        float3 G = imageColor.g;
+        float3 B = imageColor.b;
+
+        if(mode == 1) // Protanopia
+        {
+            R = float3(0.56667, 0.43333, 0);
+            G = float3(0.55833, 0.44167, 0);
+            B = float3(0, 0.24167, 0.75833);
+        }
+        else if(mode == 2) // Protanomaly
+        {
+            R = float3(0.81667, 0.18333, 0);
+            G = float3(0.33333, 0.66667, 0);
+            B = float3(0, 0.125, 0.875);
+        }
+        else if(mode == 3) // Deuteranopia
+        {
+            R = float3(0.625, 0.375, 0);
+            G = float3(0.70, 0.30, 0);
+            B = float3(0, 0.30, 0.70);
+        }
+        else if(mode == 4) // Deuteranomaly
+        {
+            R = float3(0.80, 0.20, 0);
+            G = float3(0.25833, 0.74167, 0);
+            B = float3(0, 0.14167, 0.85833);
+        }
+        else if(mode == 5) // Tritanopia
+        {
+            R = float3(0.95, 0.05, 0);
+            G = float3(0, 0.43333, 0.56667);
+            B = float3(0, 0.475, 0.525);
+        }
+        else if(mode == 6) // Tritanomaly
+        {
+            R = float3(0.96667, 0.03333, 0);
+            G = float3(0, 0.73333, 0.26667);
+            B = float3(0, 0.18333, 0.81667);
+        }
+        else if(mode == 7) // Achromatopsia
+        {
+            R = float3(0.299, 0.587, 0.114);
+            G = float3(0.299, 0.587, 0.114);
+            B = float3(0.299, 0.587, 0.114);
+        }
+        else if(mode == 8) // Achromatomaly
+        {
+            R = float3(0.618, 0.32, 0.062);
+            G = float3(0.163, 0.775, 0.062);
+            B = float3(0.163, 0.320, 0.516);
+        }
+
+        //First set
+        float4 c = imageColor;
+
+        c.r = c.r * R[0] + c.g * R[1] + c.b * R[2];
+        c.g = c.r * G[0] + c.g * G[1] + c.b * G[2];
+        c.b = c.r * B[0] + c.g * B[1] + c.b * B[2];
+
+        float3 cb = c.rgb;
+
+        cb.r = c.r * R[0] + c.g * R[1] + c.b * R[2];
+        cb.g = c.r * G[0] + c.g * G[1] + c.b * G[2];
+        cb.b = c.r * B[0] + c.g * B[1] + c.b * B[2];
+
+        // Difference
+        float3 diff = abs(c.rgb - cb);
+
+        float lum = c.r*.3 + c.g*.59 + c.b*.11;
+        float3 bw = float3(lum, lum, lum);
+
+       // return float4(lerp(bw, float3(1, 0, 0), saturate((diff.r + diff.g + diff.b) / 3)), c.a); 
+        return float4(c.rgb,1);
+    }
+}

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgColorBufferP.glsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgColorBufferP.glsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/gl/hlslCompat.glsl"
+#include "../../../../core/rendering/shaders/gl/hlslCompat.glsl"
 
 in vec2 uv0;
 uniform sampler2D colorBufferTex;

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgColorBufferP.hlsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgColorBufferP.hlsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/postfx/postFx.hlsl"
+#include "../../../../core/rendering/shaders/postFX/postFx.hlsl"
 
 TORQUE_UNIFORM_SAMPLER2D(colorBufferTex,0);
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgDepthVisualizeP.glsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgDepthVisualizeP.glsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/gl/hlslCompat.glsl"
+#include "../../../../core/rendering/shaders/gl/hlslCompat.glsl"
 #include "shadergen:/autogenConditioners.h"
 
 in vec2 uv0;

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgDepthVisualizeP.hlsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgDepthVisualizeP.hlsl
@@ -20,8 +20,8 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/postfx/postFx.hlsl"
-#include "core/shaders/shaderModelAutoGen.hlsl"
+#include "../../../../core/rendering/shaders/postFX/postFx.hlsl"
+#include "../../../../core/rendering/shaders/shaderModelAutoGen.hlsl"
 
 TORQUE_UNIFORM_SAMPLER2D(deferredTex, 0);
 TORQUE_UNIFORM_SAMPLER1D(depthViz, 1);

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgGlowVisualizeP.glsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgGlowVisualizeP.glsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/gl/hlslCompat.glsl"
+#include "../../../../core/rendering/shaders/gl/hlslCompat.glsl"
 
 in vec2 uv0;
 uniform sampler2D glowBuffer;

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgGlowVisualizeP.hlsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgGlowVisualizeP.hlsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/postfx/postFx.hlsl"
+#include "../../../../core/rendering/shaders/postFX/postFx.hlsl"
 
 TORQUE_UNIFORM_SAMPLER2D(glowBuffer, 0);
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgLightColorVisualizeP.glsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgLightColorVisualizeP.glsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/gl/hlslCompat.glsl"
+#include "../../../../core/rendering/shaders/gl/hlslCompat.glsl"
 
 in vec2 uv0;
 uniform sampler2D lightDeferredTex;

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgLightColorVisualizeP.hlsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgLightColorVisualizeP.hlsl
@@ -20,8 +20,8 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/shaderModelAutoGen.hlsl"
-#include "core/shaders/postfx/postFx.hlsl"
+#include "../../../../core/rendering/shaders/shaderModelAutoGen.hlsl"
+#include "../../../../core/rendering/shaders/postFX/postFx.hlsl"
 
 TORQUE_UNIFORM_SAMPLER2D(lightDeferredTex,0);
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgLightSpecularVisualizeP.glsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgLightSpecularVisualizeP.glsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/gl/hlslCompat.glsl"
+#include "../../../../core/rendering/shaders/gl/hlslCompat.glsl"
 
 in vec2 uv0;
 uniform sampler2D lightDeferredTex;

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgLightSpecularVisualizeP.hlsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgLightSpecularVisualizeP.hlsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/postfx/postFx.hlsl"
+#include "../../../../core/rendering/shaders/postFX/postFx.hlsl"
  
 TORQUE_UNIFORM_SAMPLER2D(lightDeferredTex,0);
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgNormalVisualizeP.glsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgNormalVisualizeP.glsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/gl/hlslCompat.glsl"
+#include "../../../../core/rendering/shaders/gl/hlslCompat.glsl"
 #include "shadergen:/autogenConditioners.h"
 
 in vec2 uv0;

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgNormalVisualizeP.hlsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgNormalVisualizeP.hlsl
@@ -20,8 +20,8 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/postfx/postFx.hlsl"
-#include "core/shaders/shaderModelAutoGen.hlsl"
+#include "../../../../core/rendering/shaders/postFX/postFx.hlsl"
+#include "../../../../core/rendering/shaders/shaderModelAutoGen.hlsl"
 
 TORQUE_UNIFORM_SAMPLER2D(deferredTex, 0);
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgShadowVisualizeP.glsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgShadowVisualizeP.glsl
@@ -19,7 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
-#include "core/shaders/gl/hlslCompat.glsl"
+#include "../../../../core/rendering/shaders/gl/hlslCompat.glsl"
 
 in vec2 uv0;
 uniform sampler2D shadowMap;

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgShadowVisualizeP.hlsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgShadowVisualizeP.hlsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/shaderModel.hlsl"
+#include "../../../../core/rendering/shaders/shaderModel.hlsl"
 
 struct MaterialDecoratorConnectV
 {

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgSpecMapVisualizeP.glsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgSpecMapVisualizeP.glsl
@@ -19,7 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
-#include "core/shaders/gl/hlslCompat.glsl"
+#include "../../../../core/rendering/shaders/gl/hlslCompat.glsl"
 
 in vec2 uv0;
 uniform sampler2D matinfoTex;

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgSpecMapVisualizeP.hlsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/shaders/dbgSpecMapVisualizeP.hlsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#include "core/shaders/postfx/postFx.hlsl"
+#include "../../../../core/rendering/shaders/postFX/postFx.hlsl"
 
 TORQUE_UNIFORM_SAMPLER2D(matinfoTex,0);
 


### PR DESCRIPTION
Adds visualizers for various types of colorblindness to help calibrate scene's visual clarity given certain vision impairments.

(Also corrects some erroneous pathing in the other render visualizers to match)