### PR TITLE
rewrite of NavMeshUpdateAll/NavMeshUpdateAroundObject

### DIFF
--- a/Engine/source/navigation/navMesh.cpp
+++ b/Engine/source/navigation/navMesh.cpp
@@ -107,8 +107,7 @@ DefineEngineFunction(NavMeshUpdateAll, void, (S32 objid, bool remove), (0, false
    SceneObject *obj;
    if(!Sim::findObject(objid, obj))
       return;
-   if(remove)
-      obj->disableCollision();
+   obj->mPathfindingIgnore = remove;
    SimSet *set = NavMesh::getServerSet();
    for(U32 i = 0; i < set->size(); i++)
    {
@@ -119,8 +118,6 @@ DefineEngineFunction(NavMeshUpdateAll, void, (S32 objid, bool remove), (0, false
          m->buildTiles(obj->getWorldBox());
       }
    }
-   if(remove)
-      obj->enableCollision();
 }
 
 DefineEngineFunction(NavMeshUpdateAroundObject, void, (S32 objid, bool remove), (0, false),
@@ -129,8 +126,7 @@ DefineEngineFunction(NavMeshUpdateAroundObject, void, (S32 objid, bool remove), 
    SceneObject *obj;
    if (!Sim::findObject(objid, obj))
       return;
-   if (remove)
-      obj->disableCollision();
+   obj->mPathfindingIgnore = remove;
    SimSet *set = NavMesh::getServerSet();
    for (U32 i = 0; i < set->size(); i++)
    {
@@ -141,8 +137,6 @@ DefineEngineFunction(NavMeshUpdateAroundObject, void, (S32 objid, bool remove), 
          m->buildTiles(obj->getWorldBox());
       }
    }
-   if (remove)
-      obj->enableCollision();
 }
 
 


### PR DESCRIPTION
the buildtiles method does not in fact build tiles right then and there, but instead queues tiles to update themselves over time. as such, simply disabling then enabling collision no longer functions (and how it did before so before is frankly likely due to exploiting a bug someplace upstream). as such, we set the same flag for NavMeshUpdateAll as we do for NavMeshIgnore to filter something as hidden from navmesh generation or not on a permanent, instead of a temporary basis via removing from the physics sim since it's likely to still be generating by the time it's put back.