### PR TITLE
Fixes some outstanding menubar problems.

### DIFF
--- a/Engine/source/gui/editor/guiMenuBar.cpp
+++ b/Engine/source/gui/editor/guiMenuBar.cpp
@@ -33,6 +33,7 @@
 #include "gfx/gfxDrawUtil.h"
 #include "gfx/primBuilder.h"
 #include "console/engineAPI.h"
+#include "gui/editor/guiPopupMenuCtrl.h"
 
 // menu bar:
 // basic idea - fixed height control bar at the top of a window, placed and sized in gui editor
@@ -1113,6 +1114,13 @@ GuiMenuBar::GuiMenuBar()
 
 void GuiMenuBar::onRemove()
 {
+   GuiPopupMenuBackgroundCtrl* backgroundCtrl;
+   if (Sim::findObject("PopUpMenuControl", backgroundCtrl))
+   {
+      if (backgroundCtrl->mMenuBarCtrl == this)
+         backgroundCtrl->mMenuBarCtrl = nullptr;
+   }
+
    Parent::onRemove();
 }
 
@@ -1472,11 +1480,11 @@ PopupMenu* GuiMenuBar::getMenu(U32 index)
    return mMenuList[index].popupMenu;
 }
 
-PopupMenu* GuiMenuBar::findMenu(StringTableEntry barTitle)
+PopupMenu* GuiMenuBar::findMenu(String barTitle)
 {
    for (U32 i = 0; i < mMenuList.size(); i++)
    {
-      if (mMenuList[i].text == barTitle)
+      if (String::ToLower(mMenuList[i].text) == String::ToLower(barTitle))
          return mMenuList[i].popupMenu;
    }
 
@@ -1521,8 +1529,7 @@ DefineEngineMethod(GuiMenuBar, insert, void, (SimObject* pObject, S32 pos), (nul
 
 DefineEngineMethod(GuiMenuBar, findMenu, S32, (const char* barTitle), (""), "(barTitle)")
 {
-   StringTableEntry barTitleStr = StringTable->insert(barTitle);
-   PopupMenu* menu = object->findMenu(barTitleStr);
+   PopupMenu* menu = object->findMenu(barTitle);
 
    if (menu)
       return menu->getId();

--- a/Engine/source/gui/editor/guiMenuBar.h
+++ b/Engine/source/gui/editor/guiMenuBar.h
@@ -116,7 +116,7 @@ public:
    U32 getMenuListCount() { return mMenuList.size(); }
 
    PopupMenu* getMenu(U32 index);
-   PopupMenu* findMenu(StringTableEntry barTitle);
+   PopupMenu* findMenu(String barTitle);
 
    DECLARE_CONOBJECT(GuiMenuBar);
    DECLARE_CALLBACK( void, onMouseInMenu, ( bool hasLeftMenu ));

--- a/Templates/BaseGame/game/tools/physicsTools/main.cs
+++ b/Templates/BaseGame/game/tools/physicsTools/main.cs
@@ -64,28 +64,6 @@ function destroyPhysicsTools()
 
 function PhysicsEditorPlugin::onWorldEditorStartup( %this )
 {      
-   new PopupMenu( PhysicsToolsMenu )
-   {
-      superClass = "MenuBuilder";
-      //class = "PhysXToolsMenu";
-
-      barTitle = "Physics";
-                                 
-      item[0] = "Start Simulation" TAB "Ctrl-Alt P" TAB "physicsStartSimulation( \"client\" );physicsStartSimulation( \"server\" );";         
-      //item[1] = "Stop Simulation" TAB "" TAB "physicsSetTimeScale( 0 );";
-      item[1] = "-";
-      item[2] = "Speed 25%" TAB "" TAB "physicsSetTimeScale( 0.25 );";
-      item[3] = "Speed 50%" TAB "" TAB "physicsSetTimeScale( 0.5 );";
-      item[4] = "Speed 100%" TAB "" TAB "physicsSetTimeScale( 1.0 );";
-      item[5] = "-";
-      item[6] = "Reload NXBs" TAB "" TAB "";
-   };
-      
-   // Add our menu.
-   EditorGui.menuBar.insert( PhysicsToolsMenu, EditorGui.menuBar.dynamicItemInsertPos );
-         
-   // Add ourselves to the window menu.
-   //EditorGui.addToWindowMenu( "Road and Path Editor", "", "RoadEditor" );   
 }
 
 function PhysicsToolsMenu::onMenuSelect(%this)

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -317,9 +317,14 @@ function EditorGui::shutdown( %this )
 /// will take over the default world editor window.
 function EditorGui::addToEditorsMenu( %this, %displayName, %accel, %newPlugin )
 {
+   //We need to cache the editors list. So first see if we have our list we cache the entries into
+   if(!isObject(EditorsMenuList))
+   {
+      new ArrayObject(EditorsMenuList);   
+   }
+   
    %windowMenu = %this.findMenu( "Editors" );   
    %count = %windowMenu.getItemCount();      
-   
    
    %alreadyExists = false;
    for ( %i = 0; %i < %count; %i++ )
@@ -336,7 +341,10 @@ function EditorGui::addToEditorsMenu( %this, %displayName, %accel, %newPlugin )
       %accel = "";
          
    if(!%alreadyExists)
+   {
+      EditorsMenuList.add(%displayName TAB %accel TAB %newPlugin);
       %windowMenu.addItem( %count, %displayName TAB %accel TAB %newPlugin );
+   }
       
    return %accel;
 }

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/menus.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/menus.ed.cs
@@ -113,7 +113,7 @@ function EditorGui::buildMenus(%this)
    %this.menuBar = new GuiMenuBar(WorldEditorMenubar)
    {
       dynamicItemInsertPos = 3;
-      extent = "1024 20";
+      extent = Canvas.extent.x SPC "20";
       minExtent = "320 20";
       horizSizing = "width";
       profile = "GuiMenuBarProfile";
@@ -251,6 +251,41 @@ function EditorGui::buildMenus(%this)
          //item[5] = "-";
    };
    %this.menuBar.insert(%editorsMenu);
+   
+   //if we're just refreshing the menus, we probably have a list of editors we want added to the Editors menu there, so check and if so, add them now
+   if(isObject(EditorsMenuList))
+   {
+      %editorsListCount = EditorsMenuList.count();
+      
+      for(%e = 0; %e < %editorsListCount; %e++)
+      {
+         %menuEntry = EditorsMenuList.getKey(%e);
+         %editorsMenu.addItem(%e, %menuEntry);
+      }
+   }
+   
+   if(isObject(PhysicsEditorPlugin))
+   {
+      %physicsToolsMenu = new PopupMenu()
+      {
+         superClass = "MenuBuilder";
+         //class = "PhysXToolsMenu";
+
+         barTitle = "Physics";
+                                    
+         item[0] = "Start Simulation" TAB "Ctrl-Alt P" TAB "physicsStartSimulation( \"client\" );physicsStartSimulation( \"server\" );";         
+         //item[1] = "Stop Simulation" TAB "" TAB "physicsSetTimeScale( 0 );";
+         item[1] = "-";
+         item[2] = "Speed 25%" TAB "" TAB "physicsSetTimeScale( 0.25 );";
+         item[3] = "Speed 50%" TAB "" TAB "physicsSetTimeScale( 0.5 );";
+         item[4] = "Speed 100%" TAB "" TAB "physicsSetTimeScale( 1.0 );";
+         item[5] = "-";
+         item[6] = "Reload NXBs" TAB "" TAB "";
+      };
+      
+      // Add our menu.
+      %this.menuBar.insert( %physicsToolsMenu, EditorGui.menuBar.dynamicItemInsertPos );
+   }
       
    // Lighting Menu
    %lightingMenu = new PopupMenu()
@@ -388,6 +423,11 @@ function EditorGui::buildMenus(%this)
 }
 
 //////////////////////////////////////////////////////////////////////////
+
+function WorldEditorMenubar::onResize(%this)
+{
+   %this.extent.x = Canvas.extent.x;
+}
 
 function EditorGui::attachMenus(%this)
 {

--- a/Templates/Full/game/tools/physicsTools/main.cs
+++ b/Templates/Full/game/tools/physicsTools/main.cs
@@ -64,28 +64,6 @@ function destroyPhysicsTools()
 
 function PhysicsEditorPlugin::onWorldEditorStartup( %this )
 {      
-   new PopupMenu( PhysicsToolsMenu )
-   {
-      superClass = "MenuBuilder";
-      //class = "PhysXToolsMenu";
-
-      barTitle = "Physics";
-                                 
-      item[0] = "Start Simulation" TAB "Ctrl-Alt P" TAB "physicsStartSimulation( \"client\" );physicsStartSimulation( \"server\" );";         
-      //item[1] = "Stop Simulation" TAB "" TAB "physicsSetTimeScale( 0 );";
-      item[1] = "-";
-      item[2] = "Speed 25%" TAB "" TAB "physicsSetTimeScale( 0.25 );";
-      item[3] = "Speed 50%" TAB "" TAB "physicsSetTimeScale( 0.5 );";
-      item[4] = "Speed 100%" TAB "" TAB "physicsSetTimeScale( 1.0 );";
-      item[5] = "-";
-      item[6] = "Reload NXBs" TAB "" TAB "";
-   };
-      
-   // Add our menu.
-   EditorGui.menuBar.insert( PhysicsToolsMenu, EditorGui.menuBar.dynamicItemInsertPos );
-         
-   // Add ourselves to the window menu.
-   //EditorGui.addToWindowMenu( "Road and Path Editor", "", "RoadEditor" );   
 }
 
 function PhysicsToolsMenu::onMenuSelect(%this)

--- a/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -317,10 +317,15 @@ function EditorGui::shutdown( %this )
 /// will take over the default world editor window.
 function EditorGui::addToEditorsMenu( %this, %displayName, %accel, %newPlugin )
 {
+   //We need to cache the editors list. So first see if we have our list we cache the entries into
+   if(!isObject(EditorsMenuList))
+   {
+      new ArrayObject(EditorsMenuList);   
+   }
+   
    %windowMenu = %this.findMenu( "Editors" );   
    %count = %windowMenu.getItemCount();      
-   
-   
+
    %alreadyExists = false;
    for ( %i = 0; %i < %count; %i++ )
    {      
@@ -336,7 +341,10 @@ function EditorGui::addToEditorsMenu( %this, %displayName, %accel, %newPlugin )
       %accel = "";
          
    if(!%alreadyExists)
+   {
+      EditorsMenuList.add(%displayName TAB %accel TAB %newPlugin);
       %windowMenu.addItem( %count, %displayName TAB %accel TAB %newPlugin );
+   }
       
    return %accel;
 }

--- a/Templates/Full/game/tools/worldEditor/scripts/menus.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/menus.ed.cs
@@ -113,7 +113,7 @@ function EditorGui::buildMenus(%this)
    %this.menuBar = new GuiMenuBar(WorldEditorMenubar)
    {
       dynamicItemInsertPos = 3;
-      extent = "1024 20";
+      extent = Canvas.extent.x SPC "20";
       minExtent = "320 20";
       horizSizing = "width";
       profile = "GuiMenuBarProfile";
@@ -251,6 +251,41 @@ function EditorGui::buildMenus(%this)
          //item[5] = "-";
    };
    %this.menuBar.insert(%editorsMenu);
+   
+   //if we're just refreshing the menus, we probably have a list of editors we want added to the Editors menu there, so check and if so, add them now
+   if(isObject(EditorsMenuList))
+   {
+      %editorsListCount = EditorsMenuList.count();
+      
+      for(%e = 0; %e < %editorsListCount; %e++)
+      {
+         %menuEntry = EditorsMenuList.getKey(%e);
+         %editorsMenu.addItem(%e, %menuEntry);
+      }
+   }
+   
+   if(isObject(PhysicsEditorPlugin))
+   {
+      %physicsToolsMenu = new PopupMenu()
+      {
+         superClass = "MenuBuilder";
+         //class = "PhysXToolsMenu";
+
+         barTitle = "Physics";
+                                    
+         item[0] = "Start Simulation" TAB "Ctrl-Alt P" TAB "physicsStartSimulation( \"client\" );physicsStartSimulation( \"server\" );";         
+         //item[1] = "Stop Simulation" TAB "" TAB "physicsSetTimeScale( 0 );";
+         item[1] = "-";
+         item[2] = "Speed 25%" TAB "" TAB "physicsSetTimeScale( 0.25 );";
+         item[3] = "Speed 50%" TAB "" TAB "physicsSetTimeScale( 0.5 );";
+         item[4] = "Speed 100%" TAB "" TAB "physicsSetTimeScale( 1.0 );";
+         item[5] = "-";
+         item[6] = "Reload NXBs" TAB "" TAB "";
+      };
+      
+      // Add our menu.
+      %this.menuBar.insert( %physicsToolsMenu, EditorGui.menuBar.dynamicItemInsertPos );
+   }
       
    // Lighting Menu
    %lightingMenu = new PopupMenu()
@@ -386,6 +421,11 @@ function EditorGui::buildMenus(%this)
 }
 
 //////////////////////////////////////////////////////////////////////////
+
+function WorldEditorMenubar::onResize(%this)
+{
+   %this.extent.x = Canvas.extent.x;
+}
 
 function EditorGui::attachMenus(%this)
 {


### PR DESCRIPTION
Fixes a crash that comes from toggling the editors on and off, then clicking a menubar item

Fixes the menubar not resizing with the Window
Fixes the Editors Menubar item not being repopulated if the editor was closed/reopened
Fixes the Physics menubar item not appearing if the editor was closed/reopened
Fixes issue where findMenu could fail if the StringTableEntry happened to trip against a different capitalization.