### PR TITLE
Modification of #2145

### DIFF
--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -93,6 +93,9 @@ ConsoleDocClass( SceneObject,
    "@ingroup gameObjects\n"
 );
 
+#ifdef TORQUE_TOOLS
+extern bool gEditingMission;
+#endif
 
 Signal< void( SceneObject* ) > SceneObject::smSceneObjectAdd;
 Signal< void( SceneObject* ) > SceneObject::smSceneObjectRemove;
@@ -763,8 +766,14 @@ void SceneObject::onCameraScopeQuery( NetConnection* connection, CameraScopeQuer
 
 bool SceneObject::isRenderEnabled() const
 {
-   AbstractClassRep *classRep = getClassRep();
-   return ( mObjectFlags.test( RenderEnabledFlag ) && classRep->isRenderEnabled() );
+#ifdef TORQUE_TOOLS
+	if (gEditingMission)
+	{
+		AbstractClassRep *classRep = getClassRep();
+		return (mObjectFlags.test(RenderEnabledFlag) && classRep->isRenderEnabled());
+	}
+#endif
+	return (mObjectFlags.test(RenderEnabledFlag));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Original PR(#2145) broke class-type visibility toggles in the editor, so this adjustment on the same setup keeps the optimized path, but also enables the original class-based render toggle if the editor is open.
(Also adds TORQUE_TOOLS check to have it be even leaner if the project doesn't have tool support at all)