### PR TITLE
Fix global variables not being able to be used inside of a foreach$ loop

### DIFF
--- a/Engine/source/console/codeInterpreter.cpp
+++ b/Engine/source/console/codeInterpreter.cpp
@@ -2895,7 +2895,10 @@ OPCodeReturn CodeInterpreter::op_iter_begin(U32 &ip)
 
    IterStackRecord& iter = iterStack[_ITER];
 
-   iter.mVariable = gEvalState.getCurrentFrame().add(varName);
+   if (varName[0] == '$')
+      iter.mVariable = gEvalState.globalVars.add(varName);
+   else
+      iter.mVariable = gEvalState.getCurrentFrame().add(varName);
 
    if (iter.mIsStringIter)
    {


### PR DESCRIPTION
This has been a bug since the old GG interpreter. Probably since foreach$ was introduced. You can now use foreach$ with globals.