### PR TITLE
Improve cinterface

### DIFF
--- a/Engine/source/T3D/components/game/triggerComponent.cpp
+++ b/Engine/source/T3D/components/game/triggerComponent.cpp
@@ -18,28 +18,28 @@
 
 #include "gfx/sim/debugDraw.h"
 
-IMPLEMENT_CALLBACK( TriggerComponent, onEnterViewCmd, void, 
+IMPLEMENT_CALLBACK( TriggerComponent, onEnterView, void, 
    ( Entity* cameraEnt, bool firstTimeSeeing ), ( cameraEnt, firstTimeSeeing ),
    "@brief Called when an object enters the volume of the Trigger instance using this TriggerData.\n\n"
 
    "@param trigger the Trigger instance whose volume the object entered\n"
    "@param obj the object that entered the volume of the Trigger instance\n" );
 
-IMPLEMENT_CALLBACK( TriggerComponent, onExitViewCmd, void, 
+IMPLEMENT_CALLBACK( TriggerComponent, onExitView, void, 
    ( Entity* cameraEnt ), ( cameraEnt ),
    "@brief Called when an object enters the volume of the Trigger instance using this TriggerData.\n\n"
 
    "@param trigger the Trigger instance whose volume the object entered\n"
    "@param obj the object that entered the volume of the Trigger instance\n" );
 
-IMPLEMENT_CALLBACK( TriggerComponent, onUpdateInViewCmd, void, 
+IMPLEMENT_CALLBACK( TriggerComponent, onUpdateInView, void, 
    ( Entity* cameraEnt ), ( cameraEnt ),
    "@brief Called when an object enters the volume of the Trigger instance using this TriggerData.\n\n"
 
    "@param trigger the Trigger instance whose volume the object entered\n"
    "@param obj the object that entered the volume of the Trigger instance\n" );
 
-IMPLEMENT_CALLBACK( TriggerComponent, onUpdateOutOfViewCmd, void, 
+IMPLEMENT_CALLBACK( TriggerComponent, onUpdateOutOfView, void, 
    ( Entity* cameraEnt ), ( cameraEnt ),
    "@brief Called when an object enters the volume of the Trigger instance using this TriggerData.\n\n"
 
@@ -146,8 +146,8 @@ void TriggerComponent::initPersistFields()
 
    addField("visibile",   TypeBool,  Offset( mVisible, TriggerComponent ), "" );
 
-   addField("onEnterViewCmd", TypeCommand, Offset(mEnterCommand, TriggerComponent), "");
-   addField("onExitViewCmd", TypeCommand, Offset(mOnExitCommand, TriggerComponent), "");
+   addField("onEnterViewCmd", TypeCommand, Offset(mOnEnterViewCmd, TriggerComponent), "");
+   addField("onExitViewCmd", TypeCommand, Offset(mOnExitViewCmd, TriggerComponent), "");
    addField("onUpdateInViewCmd", TypeCommand, Offset(mOnUpdateInViewCmd, TriggerComponent), "");
 }
 
@@ -180,10 +180,10 @@ void TriggerComponent::potentialEnterObject(SceneObject *collider)
       {
          mObjectList.push_back(collider);
 
-         if (!mEnterCommand.isEmpty())
+         if (!mOnEnterViewCmd.isEmpty())
          {
             String command = String("%obj = ") + collider->getIdString() + ";" + 
-               String("%this = ") + getIdString() + ";" + mEnterCommand;
+               String("%this = ") + getIdString() + ";" + mOnEnterViewCmd;
             Con::evaluate(command.c_str());
          }
 
@@ -262,10 +262,10 @@ void TriggerComponent::processTick()
       {
          if(!testObject(mObjectList[i]))
          {
-            if (!mOnExitCommand.isEmpty())
+            if (!mOnExitViewCmd.isEmpty())
             {
                String command = String("%obj = ") + mObjectList[i]->getIdString() + ";" +
-                  String("%this = ") + getIdString() + ";" + mOnExitCommand;
+                  String("%this = ") + getIdString() + ";" + mOnExitViewCmd;
                Con::evaluate(command.c_str());
             }
 

--- a/Engine/source/T3D/components/game/triggerComponent.h
+++ b/Engine/source/T3D/components/game/triggerComponent.h
@@ -30,8 +30,8 @@ protected:
 
    bool mVisible;
 
-   String mEnterCommand;
-   String mOnExitCommand;
+   String mOnEnterViewCmd;
+   String mOnExitViewCmd;
    String mOnUpdateInViewCmd;
 
 public:
@@ -65,10 +65,10 @@ public:
 
    void visualizeFrustums(F32 renderTimeMS);
 
-   DECLARE_CALLBACK(void, onEnterViewCmd, (Entity* cameraEnt, bool firstTimeSeeing));
-   DECLARE_CALLBACK(void, onExitViewCmd, (Entity* cameraEnt));
-   DECLARE_CALLBACK(void, onUpdateInViewCmd, (Entity* cameraEnt));
-   DECLARE_CALLBACK(void, onUpdateOutOfViewCmd, (Entity* cameraEnt));
+   DECLARE_CALLBACK(void, onEnterView, (Entity* cameraEnt, bool firstTimeSeeing));
+   DECLARE_CALLBACK(void, onExitView, (Entity* cameraEnt));
+   DECLARE_CALLBACK(void, onUpdateInView, (Entity* cameraEnt));
+   DECLARE_CALLBACK(void, onUpdateOutOfView, (Entity* cameraEnt));
 };
 
 #endif // _EXAMPLEBEHAVIOR_H_

--- a/Engine/source/T3D/trigger.cpp
+++ b/Engine/source/T3D/trigger.cpp
@@ -235,6 +235,11 @@ bool Trigger::castRay(const Point3F &start, const Point3F &end, RayInfo* info)
 DECLARE_STRUCT( Polyhedron );
 IMPLEMENT_STRUCT( Polyhedron, Polyhedron,,
    "" )
+
+   FIELD(mPointList, pointList, 1, "")
+   FIELD(mPlaneList, planeList, 1, "")
+   FIELD(mEdgeList, edgeList, 1, "")
+
 END_IMPLEMENT_STRUCT;
 ConsoleType(floatList, TypeTriggerPolyhedron, Polyhedron, "")
 

--- a/Engine/source/T3D/vehicles/guiSpeedometer.cpp
+++ b/Engine/source/T3D/vehicles/guiSpeedometer.cpp
@@ -41,7 +41,7 @@ class GuiSpeedometerHud : public GuiBitmapCtrl
    F32   mMaxAngle;     ///< Max pos of needle
    F32   mMinAngle;     ///< Min pos of needle
    Point2F mCenter;     ///< Center of needle rotation
-   LinearColorF mColor;       ///< Needle Color
+   LinearColorF mNeedleColor;       ///< Needle Color
    F32   mNeedleLength;
    F32   mNeedleWidth;
    F32   mTailLength;
@@ -103,7 +103,7 @@ GuiSpeedometerHud::GuiSpeedometerHud()
    mNeedleWidth = 3;
    mNeedleLength = 10;
    mTailLength = 5;
-   mColor.set(1,0,0,1);
+   mNeedleColor.set(1,0,0,1);
 }
 
 void GuiSpeedometerHud::initPersistFields()
@@ -122,7 +122,7 @@ void GuiSpeedometerHud::initPersistFields()
       "Angle (in radians) of the needle when the Vehicle speed is >= maxSpeed. "
       "An angle of 0 points right, 90 points up etc)." );
 
-   addField("color", TypeColorF, Offset( mColor, GuiSpeedometerHud ),
+   addField("color", TypeColorF, Offset( mNeedleColor, GuiSpeedometerHud ),
       "Color of the needle" );
 
    addField("center", TypePoint2F, Offset( mCenter, GuiSpeedometerHud ),
@@ -210,7 +210,7 @@ void GuiSpeedometerHud::onRender(Point2I offset, const RectI &updateRect)
    GFX->setTexture(0, NULL);
 
    // Render the needle
-   PrimBuild::color4f(mColor.red, mColor.green, mColor.blue, mColor.alpha);
+   PrimBuild::color4f(mNeedleColor.red, mNeedleColor.green, mNeedleColor.blue, mNeedleColor.alpha);
    PrimBuild::begin(GFXLineStrip, 5);
    for(int k=0; k<5; k++){
       rotMatrix.mulP(vertList[k]);

--- a/Engine/source/afx/afxEffectGroup.cpp
+++ b/Engine/source/afx/afxEffectGroup.cpp
@@ -253,13 +253,13 @@ DefineEngineMethod(afxEffectGroupData, reset, void, (),,
   object->reloadReset();
 }
 
-DefineEngineMethod(afxEffectGroupData, addEffect, void, (afxEffectBaseData* effect),,
-                   "Adds an effect (wrapper or group) to an effect-group.\n\n"
+DefineEngineMethod(afxEffectGroupData, pushEffect, void, (afxEffectBaseData* effect),,
+                   "Pushes an effect (wrapper or group) to an effect-group.\n\n"
                    "@ingroup AFX")
 {
   if (!effect) 
   {
-    Con::errorf("afxEffectGroupData::addEffect() -- missing afxEffectWrapperData.");
+    Con::errorf("afxEffectGroupData::pushEffect() -- missing afxEffectWrapperData.");
     return;
   }
   

--- a/Engine/source/afx/afxEffectron.cpp
+++ b/Engine/source/afx/afxEffectron.cpp
@@ -216,13 +216,13 @@ DefineEngineMethod(afxEffectronData, reset, void, (),,
   object->reloadReset();
 }
 
-DefineEngineMethod(afxEffectronData, addEffect, void, (afxEffectBaseData* effect),,
-                   "Adds an effect (wrapper or group) to an effectron's phase.\n\n"
+DefineEngineMethod(afxEffectronData, pushEffect, void, (afxEffectBaseData* effect),,
+                   "Pushes an effect (wrapper or group) to an effectron's phase.\n\n"
                    "@ingroup AFX")
 {
   if (!effect) 
   {
-    Con::errorf("afxEffectronData::addEffect() -- missing afxEffectWrapperData.");
+    Con::errorf("afxEffectronData::pushEffect() -- missing afxEffectWrapperData.");
     return;
   }
   

--- a/Engine/source/afx/afxMagicSpell.cpp
+++ b/Engine/source/afx/afxMagicSpell.cpp
@@ -460,14 +460,14 @@ DefineEngineMethod(afxMagicSpellData, reset, void, (),,
   object->reloadReset();
 }
 
-DefineEngineMethod(afxMagicSpellData, addCastingEffect, void, (afxEffectBaseData* effect),,
-                   "Adds an effect (wrapper or group) to a spell's casting phase.\n\n"
+DefineEngineMethod(afxMagicSpellData, pushCastingEffect, void, (afxEffectBaseData* effect),,
+                   "Pushes an effect (wrapper or group) to a spell's casting phase.\n\n"
                    "@ingroup AFX")
 {
   if (!effect)
   {
     Con::errorf(ConsoleLogEntry::General,
-                "afxMagicSpellData::addCastingEffect() -- "
+                "afxMagicSpellData::pushCastingEffect() -- "
                 "missing afxEffectWrapperData.");
     return;
   }
@@ -475,15 +475,15 @@ DefineEngineMethod(afxMagicSpellData, addCastingEffect, void, (afxEffectBaseData
   object->mCasting_fx_list.push_back(effect);
 }
 
-DefineEngineMethod(afxMagicSpellData, addLaunchEffect, void, (afxEffectBaseData* effect),,
-                   "Adds an effect (wrapper or group) to a spell's launch phase.\n\n"
+DefineEngineMethod(afxMagicSpellData, pushLaunchEffect, void, (afxEffectBaseData* effect),,
+                   "Pushes an effect (wrapper or group) to a spell's launch phase.\n\n"
                    "@ingroup AFX")
 
 {
   if (!effect)
   {
     Con::errorf(ConsoleLogEntry::General,
-                "afxMagicSpellData::addLaunchEffect() -- "
+                "afxMagicSpellData::pushLaunchEffect() -- "
                 "failed to find afxEffectWrapperData.");
     return;
   }
@@ -491,15 +491,15 @@ DefineEngineMethod(afxMagicSpellData, addLaunchEffect, void, (afxEffectBaseData*
   object->mLaunch_fx_list.push_back(effect);
 }
 
-DefineEngineMethod(afxMagicSpellData, addDeliveryEffect, void, (afxEffectBaseData* effect),,
-                   "Adds an effect (wrapper or group) to a spell's delivery phase.\n\n"
+DefineEngineMethod(afxMagicSpellData, pushDeliveryEffect, void, (afxEffectBaseData* effect),,
+                   "Pushes an effect (wrapper or group) to a spell's delivery phase.\n\n"
                    "@ingroup AFX")
 
 {
   if (!effect)
   {
     Con::errorf(ConsoleLogEntry::General,
-                "afxMagicSpellData::addDeliveryEffect() -- "
+                "afxMagicSpellData::pushDeliveryEffect() -- "
                 "missing afxEffectWrapperData.");
     return;
   }
@@ -507,15 +507,15 @@ DefineEngineMethod(afxMagicSpellData, addDeliveryEffect, void, (afxEffectBaseDat
   object->mDelivery_fx_list.push_back(effect);
 }
 
-DefineEngineMethod(afxMagicSpellData, addImpactEffect, void, (afxEffectBaseData* effect),,
-                   "Adds an effect (wrapper or group) to a spell's impact phase.\n\n"
+DefineEngineMethod(afxMagicSpellData, pushImpactEffect, void, (afxEffectBaseData* effect),,
+                   "Pushes an effect (wrapper or group) to a spell's impact phase.\n\n"
                    "@ingroup AFX")
 
 {
   if (!effect)
   {
     Con::errorf(ConsoleLogEntry::General,
-                "afxMagicSpellData::addImpactEffect() -- "
+                "afxMagicSpellData::pushImpactEffect() -- "
                 "missing afxEffectWrapperData.");
     return;
   }
@@ -523,15 +523,15 @@ DefineEngineMethod(afxMagicSpellData, addImpactEffect, void, (afxEffectBaseData*
   object->mImpact_fx_list.push_back(effect);
 }
 
-DefineEngineMethod(afxMagicSpellData, addLingerEffect, void, (afxEffectBaseData* effect),,
-                   "Adds an effect (wrapper or group) to a spell's linger phase.\n\n"
+DefineEngineMethod(afxMagicSpellData, pushLingerEffect, void, (afxEffectBaseData* effect),,
+                   "Pushes an effect (wrapper or group) to a spell's linger phase.\n\n"
                    "@ingroup AFX")
 
 {
   if (!effect)
   {
     Con::errorf(ConsoleLogEntry::General,
-                "afxMagicSpellData::addLingerEffect() -- "
+                "afxMagicSpellData::pushLingerEffect() -- "
                 "missing afxEffectWrapperData.");
     return;
   }

--- a/Engine/source/afx/ce/afxPhraseEffect.cpp
+++ b/Engine/source/afx/ce/afxPhraseEffect.cpp
@@ -297,12 +297,12 @@ void afxPhraseEffectData::gather_cons_defs(Vector<afxConstraintDef>& defs)
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//
 
-DefineEngineMethod( afxPhraseEffectData, addEffect, void, ( afxEffectBaseData* effectData ),,
-   "Add a child effect to a phrase effect datablock. Argument can be an afxEffectWrappperData or an afxEffectGroupData.\n" )
+DefineEngineMethod( afxPhraseEffectData, pushEffect, void, ( afxEffectBaseData* effectData ),,
+   "Push a child effect to a phrase effect datablock. Argument can be an afxEffectWrappperData or an afxEffectGroupData.\n" )
 {
   if (!effectData) 
   {
-    Con::errorf("afxPhraseEffectData::addEffect() -- failed to resolve effect datablock.");
+    Con::errorf("afxPhraseEffectData::pushEffect() -- failed to resolve effect datablock.");
     return;
   }
 

--- a/Engine/source/cinterface/c_consoleInterface.cpp
+++ b/Engine/source/cinterface/c_consoleInterface.cpp
@@ -26,12 +26,24 @@
 
 namespace Con
 {
+   /* Consumer Callback is not defined as EngineType yet, until then we have to define these methods directly.
    DefineNewEngineFunction(AddConsumer, void, (ConsumerCallback cb), , "")
    {
       addConsumer(cb);
    }
 
    DefineNewEngineFunction(RemoveConsumer, void, (ConsumerCallback cb), , "")
+   {
+      removeConsumer(cb);
+   }
+   */
+
+   TORQUE_API void fnAddConsumer(ConsumerCallback cb)
+   {
+      addConsumer(cb);
+   }
+
+   TORQUE_API void fnRemoveConsumer(ConsumerCallback cb)
    {
       removeConsumer(cb);
    }

--- a/Engine/source/cinterface/c_simobjectInterface.cpp
+++ b/Engine/source/cinterface/c_simobjectInterface.cpp
@@ -28,16 +28,6 @@ DefineNewEngineMethod(SimObject, RegisterObject, bool, (),,"")
    return object->registerObject();
 }
 
-DefineNewEngineMethod(SimObject, GetField, String, (String fieldName, String arrayIndex),, "")
-{
-   return object->getDataField(StringTable->insert(fieldName), StringTable->insert(arrayIndex));
-}
-
-DefineNewEngineMethod(SimObject, SetField, void, (String fieldName, String arrayIndex, String value),, "")
-{
-   object->setDataField(StringTable->insert(fieldName), StringTable->insert(arrayIndex), StringTable->insert(value));
-}
-
 DefineNewEngineMethod(SimObject, CopyFrom, void, (SimObject* parent),, "")
 {
    if (parent)

--- a/Engine/source/console/codeInterpreter.cpp
+++ b/Engine/source/console/codeInterpreter.cpp
@@ -2178,14 +2178,15 @@ OPCodeReturn CodeInterpreter::op_callfunc(U32 &ip)
 
    // ConsoleFunctionType is for any function defined by script.
    // Any 'callback' type is an engine function that is exposed to script.
-   if (mNSEntry->mType == Namespace::Entry::ConsoleFunctionType
-      || cFunctionRes)
+   if (cFunctionRes || mNSEntry->mType == Namespace::Entry::ConsoleFunctionType)
    {
+      ConsoleValue retVal;
       ConsoleValueRef ret;
       if (cFunctionRes)
       {
-         StringStackConsoleWrapper retVal(1, &cRetRes);
-         ret = retVal.argv[0];
+         retVal.init();
+         ret.value = &retVal;
+         retVal.setStackStringValue(cRetRes);
       }
       else if (mNSEntry->mFunctionOffset)
       {

--- a/Engine/source/console/codeInterpreter.cpp
+++ b/Engine/source/console/codeInterpreter.cpp
@@ -2079,7 +2079,7 @@ OPCodeReturn CodeInterpreter::op_callfunc(U32 &ip)
          mNSEntry = Namespace::global()->lookup(fnName);
 
       StringStackWrapper args(mCallArgc, mCallArgv);
-      cRetRes = CInterface::GetCInterface().CallFunction(fnNamespace, fnName, args.argv, args.argc, &cFunctionRes);
+      cRetRes = CInterface::CallFunction(fnNamespace, fnName, args.argv + 1, args.argc - 1, &cFunctionRes);
    }
    else if (callType == FuncCallExprNode::MethodCall)
    {
@@ -2112,7 +2112,7 @@ OPCodeReturn CodeInterpreter::op_callfunc(U32 &ip)
          mNSEntry = NULL;
 
       StringStackWrapper args(mCallArgc, mCallArgv);
-      cRetRes = CInterface::GetCInterface().CallMethod(gEvalState.thisObject, fnName, args.argv, args.argc, &cFunctionRes);
+      cRetRes = CInterface::CallMethod(gEvalState.thisObject, fnName, args.argv + 2, args.argc - 2, &cFunctionRes);
    }
    else // it's a ParentCall
    {

--- a/Engine/source/console/engineAPI.h
+++ b/Engine/source/console/engineAPI.h
@@ -403,7 +403,7 @@ private:
 
    template<size_t I>
    static typename fixed_tuple_element<I, fixed_tuple<ArgTs...>>::type getAndToType(const ArgsType& args) {
-      return typename EngineTypeTraits<typename fixed_tuple_element<I, fixed_tuple<ArgTs...>>::type>::ArgumentToValue(fixed_tuple_accessor<I>::get(args));
+      return EngineTypeTraits<typename fixed_tuple_element<I, fixed_tuple<ArgTs...>>::type>::ArgumentToValue(fixed_tuple_accessor<I>::get(args));
    }
 
    template<size_t ...I>

--- a/Engine/source/console/engineAPI.h
+++ b/Engine/source/console/engineAPI.h
@@ -104,20 +104,6 @@ namespace engineAPI {
    extern bool gIsInitialized;
 }
 
-
-//FIXME: this allows const char* to be used as a struct field type
-
-// Temp support for allowing const char* to remain in the API functions as long as we
-// still have the console system around.  When that is purged, these definitions should
-// be deleted and all const char* uses be replaced with String.
-template<> struct EngineTypeTraits< const char* > : public EngineTypeTraits< String > {};
-template<> inline const EngineTypeInfo* TYPE< const char* >() { return TYPE< String >(); }
-
-
-
-
-
-
 /// @name Marshalling
 ///
 /// Functions for converting to/from string-based data representations.

--- a/Engine/source/console/engineAPI.h
+++ b/Engine/source/console/engineAPI.h
@@ -364,7 +364,7 @@ private:
 
    template<size_t I>
    static typename fixed_tuple_element<I, fixed_tuple<ArgTs...>>::type getAndToType(const ArgsType& args) {
-      return typename EngineTypeTraits<typename fixed_tuple_element<I, fixed_tuple<ArgTs...>>::type>::ArgumentToValue(fixed_tuple_accessor<I>::get(args));
+      return EngineTypeTraits<typename fixed_tuple_element<I, fixed_tuple<ArgTs...>>::type>::ArgumentToValue(fixed_tuple_accessor<I>::get(args));
    }
 
    template<size_t ...I>

--- a/Engine/source/console/engineFunctions.h
+++ b/Engine/source/console/engineFunctions.h
@@ -112,7 +112,7 @@ private:
 
    template<typename ...TailTs> using MaybeSelfEnabled = typename DodgyVCHelper<TailTs...>::type;
 #else
-   template<typename ...TailTs> using MaybeSelfEnabled = typename std::enable_if<sizeof...(TailTs) <= sizeof...(ArgTs), decltype(mArgs)>::type;
+   template<typename ...TailTs> using MaybeSelfEnabled = typename std::enable_if<sizeof...(TailTs) <= sizeof...(ArgTs), std::tuple<DefVST<ArgTs>...>>::type;
 #endif
    
    template<typename ...TailTs> static MaybeSelfEnabled<TailTs...> tailInit(TailTs ...tail) {

--- a/Engine/source/console/enginePrimitives.cpp
+++ b/Engine/source/console/enginePrimitives.cpp
@@ -27,9 +27,22 @@
 IMPLEMENT_PRIMITIVE( bool,          bool,,      "Boolean true/false." );
 IMPLEMENT_PRIMITIVE( S8,            byte,,      "8bit signed integer." );
 IMPLEMENT_PRIMITIVE( U8,            ubyte,,     "8bit unsigned integer." );
+IMPLEMENT_PRIMITIVE( S16,           short,,     "16bit signed integer.");
+IMPLEMENT_PRIMITIVE( U16,           ushort,,    "16bit unsigned integer.");
 IMPLEMENT_PRIMITIVE( S32,           int,,       "32bit signed integer." );
 IMPLEMENT_PRIMITIVE( U32,           uint,,      "32bit unsigned integer." );
 IMPLEMENT_PRIMITIVE( F32,           float,,     "32bit single-precision floating-point." );
 IMPLEMENT_PRIMITIVE( F64,           double,,    "64bit double-precision floating-point." );
 IMPLEMENT_PRIMITIVE( String,        string,,    "Null-terminated UTF-16 Unicode string." );
 IMPLEMENT_PRIMITIVE( void*,         ptr,,       "Opaque pointer." );
+
+// Define pointer types for vectors.
+IMPLEMENT_PRIMITIVE( bool*,                 ptr_bool,,    "Pointer to a bool." );
+IMPLEMENT_PRIMITIVE( U8*,                   ptr_ubyte,,   "Pointer to an unsigned byte." );
+IMPLEMENT_PRIMITIVE( U32*,                  ptr_uint,,    "Pointer to an unsigned 32bit int." );
+IMPLEMENT_PRIMITIVE( S32*,                  ptr_int,,     "Pointer to a 32bit int." );
+IMPLEMENT_PRIMITIVE( F32*,                  ptr_float,,   "Pointer to a 32bit float." );
+IMPLEMENT_PRIMITIVE( Point3F*,              ptr_Point3F,, "Pointer to a Point3F struct." );
+IMPLEMENT_PRIMITIVE( PlaneF*,               ptr_PlaneF,,  "Pointer to a PlaneF struct." );
+IMPLEMENT_PRIMITIVE( PolyhedronData::Edge*, ptr_Edge,,    "Pointer to an Edge struct." );
+IMPLEMENT_PRIMITIVE( const UTF8**,          ptr_string,,  "Pointer to an UTF-8 string." );

--- a/Engine/source/console/enginePrimitives.cpp
+++ b/Engine/source/console/enginePrimitives.cpp
@@ -34,6 +34,7 @@ IMPLEMENT_PRIMITIVE( U32,           uint,,      "32bit unsigned integer." );
 IMPLEMENT_PRIMITIVE( F32,           float,,     "32bit single-precision floating-point." );
 IMPLEMENT_PRIMITIVE( F64,           double,,    "64bit double-precision floating-point." );
 IMPLEMENT_PRIMITIVE( String,        string,,    "Null-terminated UTF-16 Unicode string." );
+IMPLEMENT_PRIMITIVE( const UTF8*,   cstring,,   "Null-terminated UTF-8 Unicode string.");
 IMPLEMENT_PRIMITIVE( void*,         ptr,,       "Opaque pointer." );
 
 // Define pointer types for vectors.

--- a/Engine/source/console/enginePrimitives.h
+++ b/Engine/source/console/enginePrimitives.h
@@ -27,6 +27,8 @@
    #include "console/engineTypes.h"
 #endif
 
+#include "math/mPlane.h"
+#include "math/mPolyhedron.h"
 
 /// @file
 /// Definitions for the core primitive types used in the
@@ -37,6 +39,8 @@
 DECLARE_PRIMITIVE_R( bool );
 DECLARE_PRIMITIVE_R(S8);
 DECLARE_PRIMITIVE_R(U8);
+DECLARE_PRIMITIVE_R(S16);
+DECLARE_PRIMITIVE_R(U16);
 DECLARE_PRIMITIVE_R(S32);
 DECLARE_PRIMITIVE_R(U32);
 DECLARE_PRIMITIVE_R(F32);
@@ -45,6 +49,15 @@ DECLARE_PRIMITIVE_R(U64);
 DECLARE_PRIMITIVE_R(S64);
 DECLARE_PRIMITIVE_R(void*);
 
+DECLARE_PRIMITIVE_R(bool*);
+DECLARE_PRIMITIVE_R(U8*);
+DECLARE_PRIMITIVE_R(S32*);
+DECLARE_PRIMITIVE_R(U32*);
+DECLARE_PRIMITIVE_R(F32*);
+DECLARE_PRIMITIVE_R(Point3F*);
+DECLARE_PRIMITIVE_R(PlaneF*);
+DECLARE_PRIMITIVE_R(PolyhedronData::Edge*);
+DECLARE_PRIMITIVE_R(const char**);
 
 //FIXME: this allows String to be used as a struct field type
 
@@ -79,5 +92,13 @@ struct EngineTypeTraits< String > : public _EnginePrimitiveTypeTraits< String >
 template<> struct EngineTypeTraits< const UTF16* > : public EngineTypeTraits< String > {};
 template<> inline const EngineTypeInfo* TYPE< const UTF16* >() { return TYPE< String >(); }
 inline const EngineTypeInfo* TYPE( const UTF16*& ) { return TYPE< String >(); }
+
+//FIXME: this allows const char* to be used as a struct field type
+
+// Temp support for allowing const char* to remain in the API functions as long as we
+// still have the console system around.  When that is purged, these definitions should
+// be deleted and all const char* uses be replaced with String.
+template<> struct EngineTypeTraits< const char* > : public EngineTypeTraits< String > {};
+template<> inline const EngineTypeInfo* TYPE< const char* >() { return TYPE< String >(); }
 
 #endif // !_ENGINEPRIMITIVES_H_

--- a/Engine/source/console/enginePrimitives.h
+++ b/Engine/source/console/enginePrimitives.h
@@ -62,7 +62,7 @@ DECLARE_PRIMITIVE_R(const char**);
 //FIXME: this allows String to be used as a struct field type
 
 // String is special in the way its data is exchanged through the API.  Through
-// calls, strings are passed as plain, null-terminated UTF-16 character strings.
+// calls, strings are passed as plain, null-terminated UTF-8 character strings.
 // In addition, strings passed back as return values from engine API functions
 // are considered to be owned by the API layer itself.  The rule here is that such
 // a string is only valid until the next API call is made.  Usually, control layers
@@ -71,20 +71,19 @@ _DECLARE_TYPE_R(String);
 template<>
 struct EngineTypeTraits< String > : public _EnginePrimitiveTypeTraits< String >
 {
-   typedef const UTF16* ArgumentValueType;
-   typedef const UTF16* ReturnValueType;
+   typedef const UTF8* ArgumentValueType;
+   typedef const UTF8* ReturnValueType;
 
    //FIXME: this needs to be sorted out; for now, we store default value literals in ASCII
    typedef const char* DefaultArgumentValueStoreType;
    
-   static const UTF16* ReturnValue( const String& str )
+   static const UTF8* ReturnValue( const String& str )
    {
       static String sTemp;      
       sTemp = str;
-      return sTemp.utf16();
+      return sTemp.utf8();
    }
 };
-
 
 // For struct fields, String cannot be used directly but "const UTF16*" must be used
 // instead.  Make sure this works with the template machinery by redirecting the type
@@ -93,12 +92,20 @@ template<> struct EngineTypeTraits< const UTF16* > : public EngineTypeTraits< St
 template<> inline const EngineTypeInfo* TYPE< const UTF16* >() { return TYPE< String >(); }
 inline const EngineTypeInfo* TYPE( const UTF16*& ) { return TYPE< String >(); }
 
-//FIXME: this allows const char* to be used as a struct field type
-
 // Temp support for allowing const char* to remain in the API functions as long as we
 // still have the console system around.  When that is purged, these definitions should
 // be deleted and all const char* uses be replaced with String.
-template<> struct EngineTypeTraits< const char* > : public EngineTypeTraits< String > {};
-template<> inline const EngineTypeInfo* TYPE< const char* >() { return TYPE< String >(); }
+_DECLARE_TYPE_R(const UTF8*);
+template<>
+struct EngineTypeTraits< const UTF8* > : public _EnginePrimitiveTypeTraits< const UTF8* >
+{
+   static const UTF8* ReturnValue(const String& str)
+   {
+      static String sTemp;
+      sTemp = str;
+      return sTemp.utf8();
+   }
+};
+
 
 #endif // !_ENGINEPRIMITIVES_H_

--- a/Engine/source/console/engineStructs.cpp
+++ b/Engine/source/console/engineStructs.cpp
@@ -25,31 +25,41 @@
 #include "core/util/tVector.h"
 #include "core/util/uuid.h"
 #include "core/color.h"
+#include "math/mPolyhedron.h"
 
+IMPLEMENT_STRUCT(PlaneF,
+   PlaneF, ,
+   "")
 
-IMPLEMENT_STRUCT( Vector< bool >,
-   BoolVector,,
+   FIELD(x, x, 1, "")
+   FIELD(y, y, 1, "")
+   FIELD(z, z, 1, "")
+   FIELD(d, d, 1, "")
+
+END_IMPLEMENT_STRUCT;
+
+IMPLEMENT_STRUCT( PolyhedronData::Edge,
+   Edge,,
    "" )
+
+   FIELD_AS(U32, face, face, 2, "")
+   FIELD_AS(U32, vertex, vertex, 2, "")
+
 END_IMPLEMENT_STRUCT;
 
 
-IMPLEMENT_STRUCT( Vector< S32 >,
-   IntVector,,
-   "" )
+IMPLEMENT_STRUCT(Torque::UUID,
+   UUID, ,
+   "")
+
+   Torque::UUIDEngineExport::getAField(),
+   Torque::UUIDEngineExport::getBField(),
+   Torque::UUIDEngineExport::getCField(),
+   Torque::UUIDEngineExport::getDField(),
+   Torque::UUIDEngineExport::getEField(),
+   Torque::UUIDEngineExport::getFField(),
+
 END_IMPLEMENT_STRUCT;
-
-
-IMPLEMENT_STRUCT( Vector< F32 >,
-   FloatVector,,
-   "" )
-END_IMPLEMENT_STRUCT;
-
-
-IMPLEMENT_STRUCT( Torque::UUID,
-   UUID,,
-   "" )
-END_IMPLEMENT_STRUCT;
-
 
 IMPLEMENT_STRUCT( ColorI,
    ColorI,,
@@ -71,5 +81,76 @@ IMPLEMENT_STRUCT( LinearColorF,
    FIELD( green, green, 1, "Green channel value." )
    FIELD( blue, blue, 1, "Blue channel value." )
    FIELD( alpha, alpha, 1, "Alpha channel value." )
+
+END_IMPLEMENT_STRUCT;
+
+// Vectors
+IMPLEMENT_STRUCT( Vector< bool >,
+   BoolVector,,
+   "" )
+
+   VectorFieldEngineExport::getElementCountField< bool >(),
+   VectorFieldEngineExport::getArraySizeField< bool >(),
+   VectorFieldEngineExport::getArrayField< bool >(),
+
+END_IMPLEMENT_STRUCT;
+
+IMPLEMENT_STRUCT( Vector< S32 >,
+   IntVector,,
+   "" )
+
+   VectorFieldEngineExport::getElementCountField< S32 >(),
+   VectorFieldEngineExport::getArraySizeField< S32 >(),
+   VectorFieldEngineExport::getArrayField< S32 >(),
+
+END_IMPLEMENT_STRUCT;
+
+IMPLEMENT_STRUCT( Vector< F32 >,
+   FloatVector,,
+   "" )
+
+   VectorFieldEngineExport::getElementCountField< F32 >(),
+   VectorFieldEngineExport::getArraySizeField< F32 >(),
+   VectorFieldEngineExport::getArrayField< F32 >(),
+
+END_IMPLEMENT_STRUCT;
+
+IMPLEMENT_STRUCT( Vector< Point3F >,
+   Point3FVector,,
+   "" )
+
+   VectorFieldEngineExport::getElementCountField< Point3F >(),
+   VectorFieldEngineExport::getArraySizeField< Point3F >(),
+   VectorFieldEngineExport::getArrayField< Point3F >(),
+
+END_IMPLEMENT_STRUCT;
+
+IMPLEMENT_STRUCT(Vector< PlaneF >,
+   PlaneFVector, ,
+   "")
+
+   VectorFieldEngineExport::getElementCountField< PlaneF >(),
+   VectorFieldEngineExport::getArraySizeField< PlaneF >(),
+   VectorFieldEngineExport::getArrayField< PlaneF >(),
+
+END_IMPLEMENT_STRUCT;
+
+IMPLEMENT_STRUCT(Vector< PolyhedronData::Edge >,
+   EdgeVector, ,
+   "")
+
+   VectorFieldEngineExport::getElementCountField< PolyhedronData::Edge >(),
+   VectorFieldEngineExport::getArraySizeField< PolyhedronData::Edge >(),
+   VectorFieldEngineExport::getArrayField< PolyhedronData::Edge >(),
+
+END_IMPLEMENT_STRUCT;
+
+IMPLEMENT_STRUCT(Vector< const char* >,
+   StringVector, ,
+   "")
+
+   VectorFieldEngineExport::getElementCountField< const char* >(),
+   VectorFieldEngineExport::getArraySizeField< const char* >(),
+   VectorFieldEngineExport::getArrayField< const char* >(),
 
 END_IMPLEMENT_STRUCT;

--- a/Engine/source/console/engineStructs.h
+++ b/Engine/source/console/engineStructs.h
@@ -27,6 +27,8 @@
    #include "console/engineTypes.h"
 #endif
 
+#include "math/mPlane.h"
+#include "math/mPolyhedron.h"
 
 /// @file
 /// Definitions for the core engine structured types.
@@ -44,6 +46,12 @@ class LinearColorF;
 DECLARE_STRUCT_R(Vector< bool >);
 DECLARE_STRUCT_R(Vector< S32 >);
 DECLARE_STRUCT_R(Vector< F32 >);
+DECLARE_STRUCT_R(Vector< Point3F >);
+DECLARE_STRUCT_R(PlaneF);
+DECLARE_STRUCT_R(Vector< PlaneF >);
+DECLARE_STRUCT_R(PolyhedronData::Edge);
+DECLARE_STRUCT_R(Vector< PolyhedronData::Edge >);
+DECLARE_STRUCT_R(Vector< const char* >);
 DECLARE_STRUCT_R(Torque::UUID);
 DECLARE_STRUCT_R(ColorI);
 DECLARE_STRUCT_R(LinearColorF);

--- a/Engine/source/console/engineTypes.h
+++ b/Engine/source/console/engineTypes.h
@@ -564,12 +564,18 @@ namespace _Private {
 
 
 ///
+#define _FIELD( fieldName, exportName, numElements, doc ) \
+   { #exportName, doc, numElements, TYPE( ( ( ThisType* ) 16 )->fieldName ), (U32)FIELDOFFSET( fieldName ) } // Artificial offset to avoid compiler warnings.
+
 #define FIELD( fieldName, exportName, numElements, doc ) \
-   { #exportName, doc, numElements, TYPE( ( ( ThisType* ) 16 )->fieldName ), (U32)FIELDOFFSET( fieldName ) }, // Artificial offset to avoid compiler warnings.
+   _FIELD(fieldName, exportName, numElements, doc),
 
 ///
+#define _FIELD_AS( type, fieldName, exportName, numElements, doc ) \
+   { #exportName, doc, numElements, TYPE( *( ( type* ) &( ( ThisType* ) 16 )->fieldName ) ), (U32)FIELDOFFSET( fieldName ) } // Artificial offset to avoid compiler warnings.
+
 #define FIELD_AS( type, fieldName, exportName, numElements, doc ) \
-   { #exportName, doc, numElements, TYPE( *( ( type* ) &( ( ThisType* ) 16 )->fieldName ) ), (U32)FIELDOFFSET( fieldName ) }, // Artificial offset to avoid compiler warnings.
+   _FIELD_AS(type, fieldName, exportName, numElements, doc),
    
 ///
 #define FIELDOFFSET( fieldName ) \

--- a/Engine/source/console/engineTypes.h
+++ b/Engine/source/console/engineTypes.h
@@ -240,12 +240,12 @@ struct _EngineStructTypeTraits
    typedef void SuperType;
    
    // Structs get passed in as pointers and passed out as full copies.
-   typedef T ArgumentValueType;
+   typedef T* ArgumentValueType;
    typedef T ReturnValueType;
    typedef T DefaultArgumentValueStoreType;
 
    typedef ReturnValueType ReturnValue;
-   static ValueType ArgumentToValue( ArgumentValueType val ) { return val; }
+   static ValueType ArgumentToValue( ArgumentValueType val ) { return *val; }
 
    static const EngineTypeInfo* const TYPEINFO;
 };

--- a/Engine/source/console/engineXMLExport.cpp
+++ b/Engine/source/console/engineXMLExport.cpp
@@ -58,9 +58,9 @@ static const char* getDocString(const EngineExport* exportInfo)
 }
 
 template< typename T >
-inline T getArgValue(const EngineFunctionDefaultArguments* defaultArgs, U32 offset)
+inline T getArgValue(const EngineFunctionDefaultArguments* defaultArgs, U32 idx)
 {
-   return *reinterpret_cast< const T* >(defaultArgs->getArgs() + offset);
+   return *(const T*)(defaultArgs->mFirst + defaultArgs->mOffsets[idx]);
 }
 
 
@@ -122,7 +122,7 @@ static Vector< String > parseFunctionArgumentNames(const EngineFunctionInfo* fun
       // Parse out name.
 
       const char* end = ptr + 1;
-      while (ptr > prototype && dIsalnum(*ptr))
+      while (ptr > prototype && (dIsalnum(*ptr) || *ptr == '_'))
          ptr--;
       const char* start = ptr + 1;
 
@@ -169,20 +169,19 @@ static Vector< String > parseFunctionArgumentNames(const EngineFunctionInfo* fun
 }
 
 //-----------------------------------------------------------------------------
-
-static String getDefaultArgumentValue(const EngineFunctionInfo* function, const EngineTypeInfo* type, U32 offset)
+static String getValueForType(const EngineTypeInfo* type, void* addr)
 {
    String value;
-   const EngineFunctionDefaultArguments* defaultArgs = function->getDefaultArguments();
+#define ADDRESS_TO_TYPE(tp) *(const tp*)(addr);
 
    switch (type->getTypeKind())
    {
    case EngineTypeKindPrimitive:
    {
-#define PRIMTYPE( tp )                                               \
+#define PRIMTYPE( tp )                                                        \
             if( TYPE< tp >() == type )                                        \
             {                                                                 \
-               tp val = getArgValue< tp >( defaultArgs, offset );             \
+               tp val = ADDRESS_TO_TYPE(tp);                                  \
                value = String::ToString( val );                               \
             }
 
@@ -195,9 +194,9 @@ static String getDefaultArgumentValue(const EngineFunctionInfo* function, const 
       PRIMTYPE(F64);
 
       //TODO: for now we store string literals in ASCII; needs to be sorted out
-      if (TYPE< const char* >() == type)
+      if (TYPE< String >() == type || TYPE< const UTF8* >() == type)
       {
-         const char* val = reinterpret_cast<const char*>(defaultArgs->getArgs() + offset);
+         const UTF8* val = *((const UTF8**)(addr));
          value = val;
       }
 
@@ -207,7 +206,7 @@ static String getDefaultArgumentValue(const EngineFunctionInfo* function, const 
 
    case EngineTypeKindEnum:
    {
-      S32 val = getArgValue< S32 >(defaultArgs, offset);
+      S32 val = ADDRESS_TO_TYPE(S32);
       AssertFatal(type->getEnumTable(), "engineXMLExport - Enum type without table!");
 
       const EngineEnumTable& table = *(type->getEnumTable());
@@ -225,7 +224,7 @@ static String getDefaultArgumentValue(const EngineFunctionInfo* function, const 
 
    case EngineTypeKindBitfield:
    {
-      S32 val = getArgValue< S32 >(defaultArgs, offset);
+      S32 val = ADDRESS_TO_TYPE(S32);
       AssertFatal(type->getEnumTable(), "engineXMLExport - Bitfield type without table!");
 
       const EngineEnumTable& table = *(type->getEnumTable());
@@ -247,7 +246,24 @@ static String getDefaultArgumentValue(const EngineFunctionInfo* function, const 
 
    case EngineTypeKindStruct:
    {
-      //TODO: struct type default argument values
+      AssertFatal(type->getFieldTable(), "engineXMLExport - Struct type without table!");
+      const EngineFieldTable* fieldTable = type->getFieldTable();
+      U32 numFields = fieldTable->getNumFields();
+
+
+      for (int i = 0; i < numFields; ++i)
+      {
+         const EngineTypeInfo* fieldType = (*fieldTable)[i].getType();
+         U32 fieldOffset = (*fieldTable)[i].getOffset();
+         AssertFatal((*fieldTable)[i].getNumElements() == 1, "engineXMLExport - numElements != 1 not supported currently.");
+         if (i == 0) {
+            value = getValueForType(fieldType, (void*)((size_t)addr + fieldOffset));
+         }
+         else {
+            value += " " + getValueForType(fieldType, (void*)((size_t)addr + fieldOffset));
+         }
+      }
+
       break;
    }
 
@@ -257,7 +273,7 @@ static String getDefaultArgumentValue(const EngineFunctionInfo* function, const 
       // For these two kinds, we support "null" as the only valid
       // default value.
 
-      const void* ptr = getArgValue< const void* >(defaultArgs, offset);
+      const void* ptr = ADDRESS_TO_TYPE(void*);
       if (!ptr)
          value = "null";
       break;
@@ -267,7 +283,16 @@ static String getDefaultArgumentValue(const EngineFunctionInfo* function, const 
       break;
    }
 
+#undef ADDRESS_TO_TYPE
    return value;
+}
+
+//-----------------------------------------------------------------------------
+
+static String getDefaultArgumentValue(const EngineFunctionInfo* function, const EngineTypeInfo* type, U32 idx)
+{
+   const EngineFunctionDefaultArguments* defaultArgs = function->getDefaultArguments();
+   return getValueForType(type, (void*)(defaultArgs->mFirst + defaultArgs->mOffsets[idx]));
 }
 
 //-----------------------------------------------------------------------------
@@ -295,9 +320,6 @@ static void exportFunction(const EngineFunctionInfo* function, SimXMLDocument* x
    Vector< String > argumentNames = parseFunctionArgumentNames(function);
    const U32 numArgumentNames = argumentNames.size();
 
-   // Accumulated offset in function argument frame vector.
-   U32 argFrameOffset = 0;
-
    for (U32 i = 0; i < numArguments; ++i)
    {
       xml->pushNewElement("EngineFunctionArgument");
@@ -313,21 +335,17 @@ static void exportFunction(const EngineFunctionInfo* function, SimXMLDocument* x
 
       if (i >= firstDefaultArg)
       {
-         String defaultValue = getDefaultArgumentValue(function, type, argFrameOffset);
+         String defaultValue = getDefaultArgumentValue(function, type, i);
          xml->setAttribute("defaultValue", defaultValue);
       }
 
+      // A bit hacky, default arguments have all offsets.
+      if (function->getDefaultArguments() != NULL)
+      {
+         xml->setAttribute("offset", String::ToString(function->getDefaultArguments()->mOffsets[i]));
+      }
+
       xml->popElement();
-
-      if (type->getTypeKind() == EngineTypeKindStruct)
-         argFrameOffset += type->getInstanceSize();
-      else
-         argFrameOffset += type->getValueSize();
-
-#ifdef _PACK_BUG_WORKAROUNDS
-      if (argFrameOffset % 4 > 0)
-         argFrameOffset += 4 - (argFrameOffset % 4);
-#endif
    }
 
    xml->popElement();

--- a/Engine/source/console/fixedTuple.h
+++ b/Engine/source/console/fixedTuple.h
@@ -22,6 +22,9 @@
 
 #ifndef _FIXEDTUPLE_H_
 #define _FIXEDTUPLE_H_
+
+#include "engineTypes.h"
+
 /// @name Fixed-layout tuple definition
 /// These structs and templates serve as a way to pass arguments from external 
 /// applications and into the T3D console system.
@@ -112,6 +115,21 @@ struct fixed_tuple_accessor<0>
       return t.first;
    }
 };
+
+#pragma warning( push )
+#pragma warning( disable : 4267 )
+template <size_t I, class... Ts>
+static U32 fixed_tuple_offset(fixed_tuple<Ts...>& t)
+{
+   return (U32)((size_t)& fixed_tuple_accessor<I>::get(t)) - ((size_t)& t);
+}
+
+template <size_t I, class... Ts>
+static U32 fixed_tuple_offset(const fixed_tuple<Ts...>& t)
+{
+   return (U32)((size_t)& fixed_tuple_accessor<I>::get(t)) - ((size_t)& t);
+}
+#pragma warning(pop)
 
 template< typename T1, typename T2 >
 struct fixed_tuple_mutator {};

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -42,6 +42,7 @@
 #include "persistence/taml/tamlCustom.h"
 
 #include "sim/netObject.h"
+#include "cinterface/cinterface.h"
 
 IMPLEMENT_CONOBJECT( SimObject );
 
@@ -828,6 +829,10 @@ bool SimObject::isMethod( const char* methodName )
 {
    if( !methodName || !methodName[0] )
       return false;
+
+   if (CInterface::isMethod(this->getName(), methodName) || CInterface::isMethod(this->getClassName(), methodName)) {
+      return true;
+   }
 
    StringTableEntry stname = StringTable->insert( methodName );
 

--- a/Engine/source/console/simPersistID.cpp
+++ b/Engine/source/console/simPersistID.cpp
@@ -24,15 +24,25 @@
 #include "console/simObject.h"
 #include "core/util/tDictionary.h"
 #include "core/util/safeDelete.h"
+#include "engineAPI.h"
 
 
 //#define DEBUG_SPEW
 
+IMPLEMENT_CLASS(SimPersistID, "")
+END_IMPLEMENT_CLASS;
 
 SimPersistID::LookupTableType* SimPersistID::smLookupTable;
 
 
 //-----------------------------------------------------------------------------
+
+SimPersistID::SimPersistID()
+{
+   mObject = NULL;
+   mUUID.generate();
+   smLookupTable->insertUnique(mUUID, this);
+}
 
 SimPersistID::SimPersistID( SimObject* object )
    : mObject( object )
@@ -135,4 +145,14 @@ SimPersistID* SimPersistID::findOrCreate( const Torque::UUID& uuid )
    }
       
    return pid;
+}
+
+DefineNewEngineMethod(SimPersistID, getUUID, Torque::UUID, (), , "")
+{
+   return object->getUUID();
+}
+
+DefineNewEngineMethod(SimPersistID, getObject, SimObject*, (), , "")
+{
+   return object->getObject();
 }

--- a/Engine/source/console/simPersistID.h
+++ b/Engine/source/console/simPersistID.h
@@ -30,6 +30,9 @@
    #include "core/util/refBase.h"
 #endif
 
+#ifndef _ENGINEOBJECT_H_
+   #include "console/engineObject.h"
+#endif
 
 /// @file
 /// Persistent IDs for SimObjects.
@@ -40,12 +43,27 @@ template< typename, typename > class HashTable;
 
 
 /// A globally unique persistent ID for a SimObject.
-class SimPersistID : public StrongRefBase
+class SimPersistID : public EngineObject
 {
    public:
+      DECLARE_CLASS(SimPersistID, EngineObject);
    
       typedef void Parent;
       friend class SimObject;
+
+      ///
+      SimPersistID();
+
+      /// Construct a new persistent ID for "object" by generating a fresh
+      /// unique identifier.
+      SimPersistID(SimObject* object);
+
+      /// Construct a persistent ID stub for the given unique identifier.
+      /// The stub remains not bound to any object until it is resolved.
+      SimPersistID(const Torque::UUID& uuid);
+
+      ///
+      ~SimPersistID();
       
    protected:
    
@@ -60,17 +78,6 @@ class SimPersistID : public StrongRefBase
       
       /// Table of persistent object IDs.
       static LookupTableType* smLookupTable;
-
-      /// Construct a new persistent ID for "object" by generating a fresh
-      /// unique identifier.
-      SimPersistID( SimObject* object );
-      
-      /// Construct a persistent ID stub for the given unique identifier.
-      /// The stub remains not bound to any object until it is resolved.
-      SimPersistID( const Torque::UUID& uuid );
-      
-      ///
-      ~SimPersistID();
       
       /// Bind this unresolved PID to the given object.
       void resolve( SimObject* object );

--- a/Engine/source/core/util/tVector.h
+++ b/Engine/source/core/util/tVector.h
@@ -29,6 +29,8 @@
 #include "platform/platform.h"
 #endif
 #include <algorithm>
+#include "console/engineTypes.h"
+#include "console/engineTypeInfo.h"
 
 //-----------------------------------------------------------------------------
 // Helper definitions for the vector class.
@@ -63,6 +65,7 @@ extern bool VectorResize(U32 *aSize, U32 *aCount, void **arrayPtr, U32 newCount,
 template<class T>
 class Vector
 {
+   friend class VectorFieldEngineExport;
   protected:
    U32 mElementCount; ///< Number of elements currently in the Vector.
    U32 mArraySize;    ///< Number of elements allocated for the Vector.
@@ -186,6 +189,29 @@ class Vector
    void reverse();
 
    /// @}
+};
+
+class VectorFieldEngineExport
+{
+public:
+   template <class T>
+   static EngineFieldTable::Field getElementCountField()
+   {
+      typedef Vector<T> ThisType;
+      return _FIELD(mElementCount, elementCount, 1, "");
+   };
+   template <class T>
+   static EngineFieldTable::Field getArraySizeField()
+   {
+      typedef Vector<T> ThisType;
+      return _FIELD(mArraySize, arraySize, 1, "");
+   };
+   template <class T>
+   static EngineFieldTable::Field getArrayField()
+   {
+      typedef Vector<T> ThisType;
+      return _FIELD(mArray, array, 1, "");
+   };
 };
 
 template<class T> inline Vector<T>::~Vector()
@@ -966,7 +992,7 @@ public:
 };
 
 // Include vector specializations
-#ifndef _VECTORSPEC_H_
+#ifndef _TVECTORSPEC_H_
 #include "core/util/tVectorSpecializations.h"
 #endif
 

--- a/Engine/source/core/util/uuid.cpp
+++ b/Engine/source/core/util/uuid.cpp
@@ -68,6 +68,7 @@
 #include <ctype.h>
 
 #include "core/util/md5.h"
+#include "console/enginePrimitives.h"
 
 #if defined (TORQUE_OS_MAC) && defined(TORQUE_CPU_X64)
 typedef unsigned int    unsigned32;
@@ -451,3 +452,42 @@ namespace Torque
       return ( a + b + c + d + e + f[ 0 ] + f[ 1 ] + f[ 2 ] + f[ 3 ] + f[ 4 ] + f[ 5 ] );
    }
 }
+
+EngineFieldTable::Field Torque::UUIDEngineExport::getAField()
+{
+   typedef UUID ThisType;
+   return _FIELD(a, a, 1, "");
+}
+
+EngineFieldTable::Field Torque::UUIDEngineExport::getBField()
+{
+   typedef UUID ThisType;
+   return _FIELD(b, b, 1, "");
+}
+
+EngineFieldTable::Field Torque::UUIDEngineExport::getCField()
+{
+   typedef UUID ThisType;
+   return _FIELD(c, c, 1, "");
+}
+
+EngineFieldTable::Field Torque::UUIDEngineExport::getDField()
+{
+   typedef UUID ThisType;
+   return _FIELD(d, d, 1, "");
+}
+
+EngineFieldTable::Field Torque::UUIDEngineExport::getEField()
+{
+   typedef UUID ThisType;
+   return _FIELD(e, e, 1, "");
+}
+
+EngineFieldTable::Field Torque::UUIDEngineExport::getFField()
+{
+   typedef UUID ThisType;
+   return _FIELD_AS(U8, f, f, 6, "");
+}
+
+
+

--- a/Engine/source/core/util/uuid.h
+++ b/Engine/source/core/util/uuid.h
@@ -26,6 +26,7 @@
 #ifndef _PLATFORM_H_
    #include "platform/platform.h"
 #endif
+#include "console/engineTypeInfo.h"
 
 
 namespace Torque
@@ -33,6 +34,7 @@ namespace Torque
    /// A universally unique identifier.
    class UUID
    {
+      friend class UUIDEngineExport;
       public:
       
          typedef void Parent;
@@ -80,6 +82,17 @@ namespace Torque
          {
             return !( *this == uuid );
          }
+   };
+
+   class UUIDEngineExport
+   {
+   public:
+      static EngineFieldTable::Field getAField();
+      static EngineFieldTable::Field getBField();
+      static EngineFieldTable::Field getCField();
+      static EngineFieldTable::Field getDField();
+      static EngineFieldTable::Field getEField();
+      static EngineFieldTable::Field getFField();
    };
 }
 

--- a/Engine/source/gfx/sim/debugDraw.h
+++ b/Engine/source/gfx/sim/debugDraw.h
@@ -93,6 +93,7 @@ class GFont;
 ///
 class DebugDrawer : public SimObject
 {
+   typedef SimObject Parent;
 public:
    DECLARE_CONOBJECT(DebugDrawer);
 
@@ -162,8 +163,6 @@ public:
 
    /// @}
 private:
-   typedef SimObject Parent;
-
    static DebugDrawer* sgDebugDrawer;
 
    struct DebugPrim

--- a/Engine/source/gui/core/guiScriptNotifyControl.cpp
+++ b/Engine/source/gui/core/guiScriptNotifyControl.cpp
@@ -67,13 +67,13 @@ void GuiScriptNotifyCtrl::initPersistFields()
 {
    // Callbacks Group
    addGroup("Callbacks");
-   addField("onChildAdded", TypeBool, Offset( mOnChildAdded, GuiScriptNotifyCtrl ), "Enables/disables onChildAdded callback" );
-   addField("onChildRemoved", TypeBool, Offset( mOnChildRemoved, GuiScriptNotifyCtrl ), "Enables/disables onChildRemoved callback" );
-   addField("onChildResized", TypeBool, Offset( mOnChildResized, GuiScriptNotifyCtrl ), "Enables/disables onChildResized callback" );
-   addField("onParentResized", TypeBool, Offset( mOnParentResized, GuiScriptNotifyCtrl ), "Enables/disables onParentResized callback" );
-   addField("onResize", TypeBool, Offset( mOnResize, GuiScriptNotifyCtrl ), "Enables/disables onResize callback" );
-   addField("onLoseFirstResponder", TypeBool, Offset( mOnLoseFirstResponder, GuiScriptNotifyCtrl ), "Enables/disables onLoseFirstResponder callback" );
-   addField("onGainFirstResponder", TypeBool, Offset( mOnGainFirstResponder, GuiScriptNotifyCtrl ), "Enables/disables onGainFirstResponder callback" );
+   addField("notifyOnChildAdded", TypeBool, Offset( mOnChildAdded, GuiScriptNotifyCtrl ), "Enables/disables onChildAdded callback" );
+   addField("notifyOnChildRemoved", TypeBool, Offset( mOnChildRemoved, GuiScriptNotifyCtrl ), "Enables/disables onChildRemoved callback" );
+   addField("notifyOnChildResized", TypeBool, Offset( mOnChildResized, GuiScriptNotifyCtrl ), "Enables/disables onChildResized callback" );
+   addField("notifyOnParentResized", TypeBool, Offset( mOnParentResized, GuiScriptNotifyCtrl ), "Enables/disables onParentResized callback" );
+   addField("notifyOnResize", TypeBool, Offset( mOnResize, GuiScriptNotifyCtrl ), "Enables/disables onResize callback" );
+   addField("notifyOnLoseFirstResponder", TypeBool, Offset( mOnLoseFirstResponder, GuiScriptNotifyCtrl ), "Enables/disables onLoseFirstResponder callback" );
+   addField("notifyOnGainFirstResponder", TypeBool, Offset( mOnGainFirstResponder, GuiScriptNotifyCtrl ), "Enables/disables onGainFirstResponder callback" );
    endGroup("Callbacks");
 
    Parent::initPersistFields();

--- a/Engine/source/gui/editor/guiFilterCtrl.cpp
+++ b/Engine/source/gui/editor/guiFilterCtrl.cpp
@@ -89,7 +89,7 @@ DefineEngineStringlyVariadicMethod( GuiFilterCtrl, setValue, void, 3, 20, "(f1, 
 	object->set(filter);
 }
 
-DefineEngineMethod( GuiFilterCtrl, identity, void, (), , "Reset the filtering."
+DefineEngineMethod( GuiFilterCtrl, resetFiltering, void, (), , "Reset the filtering."
 			  "@internal")
 {
    object->identity();

--- a/Engine/source/math/mMatrix.cpp
+++ b/Engine/source/math/mMatrix.cpp
@@ -26,6 +26,8 @@
 #include "math/mMatrix.h"
 #include "console/console.h"
 
+#include "console/enginePrimitives.h"
+#include "console/engineTypes.h"
 
 const MatrixF MatrixF::Identity( true );
 
@@ -192,4 +194,10 @@ void MatrixF::dumpMatrix(const char *caption /* =NULL */) const
    Con::printf("%s   | %-8.4f %-8.4f %-8.4f %-8.4f |", spacerRef,  m[idx(1,0)], m[idx(1, 1)], m[idx(1, 2)], m[idx(1, 3)]);
    Con::printf("%s   | %-8.4f %-8.4f %-8.4f %-8.4f |", spacerRef,  m[idx(2,0)], m[idx(2, 1)], m[idx(2, 2)], m[idx(2, 3)]);
    Con::printf("%s   | %-8.4f %-8.4f %-8.4f %-8.4f |", spacerRef,  m[idx(3,0)], m[idx(3, 1)], m[idx(3, 2)], m[idx(3, 3)]);
+}
+
+EngineFieldTable::Field MatrixFEngineExport::getMatrixField()
+{
+   typedef MatrixF ThisType;
+   return _FIELD_AS(F32, m, m, 16, "");
 }

--- a/Engine/source/math/mMatrix.h
+++ b/Engine/source/math/mMatrix.h
@@ -35,12 +35,18 @@
 #include "math/mPoint4.h"
 #endif
 
+#ifndef _ENGINETYPEINFO_H_
+#include "console/engineTypeInfo.h"
+#endif
+
+
 /// 4x4 Matrix Class
 ///
 /// This runs at F32 precision.
 
 class MatrixF
 {
+   friend class MatrixFEngineExport;
 private:
    F32 m[16];     ///< Note: Torque uses row-major matrices
 
@@ -222,6 +228,12 @@ public:
 
    // Static identity matrix
    const static MatrixF Identity;
+};
+
+class MatrixFEngineExport
+{
+public:
+   static EngineFieldTable::Field getMatrixField();
 };
 
 

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -88,30 +88,59 @@ END_IMPLEMENT_STRUCT;
 IMPLEMENT_STRUCT( RectI,
    RectI, MathTypes,
    "" )
+
+   FIELD( point,  point,  1, "The XY coordinate of the Rect." )
+   FIELD( extent, extent, 1, "The width and height of the Rect." )
+
 END_IMPLEMENT_STRUCT;
 IMPLEMENT_STRUCT( RectF,
    RectF, MathTypes,
    "" )
+
+   FIELD( point,  point,  1, "The XY coordinate of the Rect.")
+   FIELD( extent, extent, 1, "The width and height of the Rect.")
+
 END_IMPLEMENT_STRUCT;
 IMPLEMENT_STRUCT( MatrixF,
    MatrixF, MathTypes,
    "" )
+
+   MatrixFEngineExport::getMatrixField(),
+
 END_IMPLEMENT_STRUCT;
 IMPLEMENT_STRUCT( AngAxisF,
    AngAxisF, MathTypes,
    "" )
+
+   FIELD( axis,  axis,  1, "")
+   FIELD( angle, angle, 1, "")
+
 END_IMPLEMENT_STRUCT;
 IMPLEMENT_STRUCT( TransformF,
    TransformF, MathTypes,
    "" )
+
+   FIELD(mPosition,    position,    1, "")
+   FIELD(mOrientation, orientation, 1, "")
+   FIELD(mHasRotation, hasRotation, 1, "")
+
 END_IMPLEMENT_STRUCT;
 IMPLEMENT_STRUCT( Box3F,
    Box3F, MathTypes,
    "" )
+
+   FIELD(minExtents, minExtents, 1, "Minimum extents of box")
+   FIELD(maxExtents, maxExtents, 1, "Maximum extents of box")
+
 END_IMPLEMENT_STRUCT;
 IMPLEMENT_STRUCT( EaseF,
    EaseF, MathTypes,
    "" )
+
+   FIELD(mDir, dir, 1, "inout, in, out")
+   FIELD(mType, type, 1, "linear, etc...")
+   FIELD_AS(F32, mParam, type, 2, "optional params")
+
 END_IMPLEMENT_STRUCT;
 IMPLEMENT_STRUCT(RotationF,
    RotationF, MathTypes,

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -139,7 +139,7 @@ IMPLEMENT_STRUCT( EaseF,
 
    FIELD(mDir, dir, 1, "inout, in, out")
    FIELD(mType, type, 1, "linear, etc...")
-   FIELD_AS(F32, mParam, type, 2, "optional params")
+   FIELD_AS(F32, mParam, param, 2, "optional params")
 
 END_IMPLEMENT_STRUCT;
 IMPLEMENT_STRUCT(RotationF,

--- a/Engine/source/module/moduleDefinition.cpp
+++ b/Engine/source/module/moduleDefinition.cpp
@@ -82,8 +82,6 @@ void ModuleDefinition::initPersistFields()
     // Call parent.
     Parent::initPersistFields();
 
-    addProtectedField("ModuleId", TypeString, Offset(mModuleId, ModuleDefinition), &defaultProtectedSetFn, &defaultProtectedGetFn, "");
-
     /// Module configuration.
     addProtectedField( "ModuleId", TypeString, Offset(mModuleId, ModuleDefinition), &setModuleId, &defaultProtectedGetFn, "A unique string Id for the module.  It can contain any characters except a comma or semi-colon (the asset scope character)." );
     addProtectedField( "VersionId", TypeS32, Offset(mVersionId, ModuleDefinition), &setVersionId, &defaultProtectedGetFn, "The version Id.  Breaking changes to a module should use a higher version Id." );

--- a/Engine/source/module/moduleManager.cpp
+++ b/Engine/source/module/moduleManager.cpp
@@ -38,6 +38,8 @@
 #include "console/consoleTypes.h"
 #endif
 
+#include "cinterface/cinterface.h"
+
 // Script bindings.
 #include "moduleManager_ScriptBinding.h"
 
@@ -811,21 +813,19 @@ bool ModuleManager::loadModuleExplicit( const char* pModuleId, const U32 version
             const bool scriptFileExecuted = dAtob( Con::executef("exec", pLoadReadyModuleDefinition->getModuleScriptFilePath() ) );
 
             // Did we execute the script file?
-            if ( scriptFileExecuted )
-            {
-                // Yes, so is the create method available?
-                if ( pScopeSet->isMethod( pLoadReadyModuleDefinition->getCreateFunction() ) )
-                {
-                    // Yes, so call the create method.
-                    Con::executef( pScopeSet, pLoadReadyModuleDefinition->getCreateFunction() );
-                }
-            }
-            else
+            if ( !scriptFileExecuted )
             {
                 // No, so warn.
                 Con::errorf( "Module Manager: Cannot load explicit module Id '%s' at version Id '%d' as it failed to have the script file '%s' loaded.",
                     pLoadReadyModuleDefinition->getModuleId(), pLoadReadyModuleDefinition->getVersionId(), pLoadReadyModuleDefinition->getModuleScriptFilePath() );
             }
+        }
+
+        // Is the create method available?
+        if (pScopeSet->isMethod(pLoadReadyModuleDefinition->getCreateFunction()))
+        {
+           // Yes, so call the create method.
+           Con::executef(pScopeSet, pLoadReadyModuleDefinition->getCreateFunction());
         }
 
         // Raise notifications.

--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -379,7 +379,7 @@ void PostEffect::initPersistFields()
    addField( "allowReflectPass", TypeBool, Offset( mAllowReflectPass, PostEffect ), 
       "Is this effect processed during reflection render passes." );
 
-   addProtectedField( "isEnabled", TypeBool, Offset( mEnabled, PostEffect),
+   addProtectedField( "enabled", TypeBool, Offset( mEnabled, PostEffect),
       &PostEffect::_setIsEnabled, &defaultProtectedGetFn,
       "Is the effect on." );
 

--- a/Engine/source/sfx/sfxDescription.cpp
+++ b/Engine/source/sfx/sfxDescription.cpp
@@ -425,8 +425,8 @@ void SFXDescription::initPersistFields()
       "Reverb echo depth.");
    addField("reverbModTime", TypeF32, Offset(mReverb.flModulationTime, SFXDescription),
       "Reverb Modulation time.");
-   addField("reverbModTime", TypeF32, Offset(mReverb.flModulationDepth, SFXDescription),
-      "Reverb Modulation time.");
+   addField("reverbModDepth", TypeF32, Offset(mReverb.flModulationDepth, SFXDescription),
+      "Reverb Modulation Depth.");
    addField("airAbsorbtionGainHF", TypeF32, Offset(mReverb.flAirAbsorptionGainHF, SFXDescription),
       "High Frequency air absorbtion");
    addField("reverbHFRef", TypeF32, Offset(mReverb.flHFReference, SFXDescription),

--- a/Engine/source/sfx/sfxSource.cpp
+++ b/Engine/source/sfx/sfxSource.cpp
@@ -1532,6 +1532,7 @@ DefineEngineMethod( SFXSource, setPitch, void, ( F32 pitch ),,
 // Need an overload here as we can't use a default parameter to signal omission of the direction argument
 // and we need to properly detect the omission to leave the currently set direction on the source as is.
 
+/* LukasPJ: For now, just use the setTransform with strings as parameters.
 DEFINE_CALLIN( fnSFXSoure_setTransform1, setTransform, SFXSource, void, ( SFXSource* source, const VectorF& position ),,,
    "Set the position of the source's 3D sound.\n\n"
    "@param position The new position in world space.\n"
@@ -1551,6 +1552,7 @@ DEFINE_CALLIN( fnSFXSoure_setTransform2, setTransform, SFXSource, void, ( SFXSou
    mat.setColumn( 1, direction );
    source->setTransform( mat );
 }
+*/
 
 // Console interop version.
 

--- a/Engine/source/util/undo.cpp
+++ b/Engine/source/util/undo.cpp
@@ -565,7 +565,7 @@ DefineEngineMethod(UndoManager, getNextRedoName, const char *, (),, "UndoManager
 
 //-----------------------------------------------------------------------------
 
-DefineEngineMethod( UndoManager, pushCompound, const char*, ( String name ), ("\"\""), "( string name=\"\" ) - Push a CompoundUndoAction onto the compound stack for assembly." )
+DefineEngineMethod( UndoManager, pushCompound, const char*, ( String name ), (""), "( string name=\"\" ) - Push a CompoundUndoAction onto the compound stack for assembly." )
 {
       
    CompoundUndoAction* action = object->pushCompound( name );


### PR DESCRIPTION
# CInterface improvements
 * Expand EngineAPI type definitions (replaces #2241)
 * Fix name-clashing in script-exposed classes (these have not been an issue in TorqueScript because it doesn't fail, it just picks the first definition it finds).
 * Update the EngineAPI, a little bit of simplification over the changes made in #2248 
 * Improve the integration of the CInterface into existing systems
 * Expose SimPersistID to the EngineAPI
 * Improve EngineAPI export, less guess-work and compiler-dependency

# Breaking changes
Name-clash fixes means that some members have been renamed, possibly breaking any scripts using these members.
**AFX Members:**
 * _Method_ `afxPhraseEffectData::addEffect` -> pushEffect
 * _Method_ `afxMagicSpellData::addCastingEffect` -> pushCastingEffect
 * _Method_ `afxMagicSpellData::addLaunchEffect` -> pushLaunchEffect
 * _Method_ `afxMagicSpellData::addDeliveryEffect` -> pushDeliveryEffect
 * _Method_ `afxMagicSpellData::addImpactEffect` -> pushImpactEffect
 * _Method_ `afxEffectronData::addEffect` -> pushEffect
 * _Method_ `afxEffectGroupData::addEffect` -> pushEffect

**Other Members:**
 * _Field_ `GuiSpeedometerHud::mColor` -> mNeedleColor (Maybe we could just use the parent class' mColor here instead?)
 * _Callback_ `TriggerComponent::onEnterViewCmd` ->onEnterView
 * _Callback_ `TriggerComponent::onExitViewCmd` ->onExitView
 * _Callback_ `TriggerComponent::onUpdateInViewCmd` ->onUpdateInView
 * _Callback_ `TriggerComponent::onUpdateOutOfViewCmd` ->onUpdateOutOfView
 * _Field_ `PostEffect::isEnabled` -> enabled
 * _Method_ `GuiFilterCtrl::identity` -> resetFiltering
 * _Field_ `SFXDescription::reverbModTime` -> reverbModDepth (dunno if it pointed to time or depth before, now there is one for each)
 * _Field_ `GuiScriptNotifyCtrl::onChildAdded` -> notifyOnChildAdded
 * _Field_ `GuiScriptNotifyCtrl::onChildRemoved` -> notifyOnChildRemoved
 * _Field_ `GuiScriptNotifyCtrl::onChildResized` -> notifyOnChildResized
 * _Field_ `GuiScriptNotifyCtrl::onParentResized` -> notifyOnParentResized
 * _Field_ `GuiScriptNotifyCtrl::onResize` -> notifyOnResize
 * _Field_ `GuiScriptNotifyCtrl::onLoseFirstResponder` -> notifyOnLoseFirstResponder
 * _Field_ `GuiScriptNotifyCtrl::onGainFirstResponder` -> notifyOnGainFirstResponder

## Other (possibly breaking) changes
I also changed the default value of `UndoManager::pushCompound` from "\"\"" to "". Would like a review of whether this is valid or a misunderstanding on my part.