### PR TITLE
Remove trailing whitespaces from simObject.cpp and fix pointer format

### DIFF
--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -3178,7 +3178,7 @@ DefineEngineMethod( SimObject, getDebugInfo, ArrayObject*, (),,
    ArrayObject* array = new ArrayObject();
    array->registerObject();
 
-   array->push_back( "C++|Address", String::ToString( "0x%x", object ) );
+   array->push_back( "C++|Address", String::ToString( "%p", object ) );
    array->push_back( "C++|Size", String::ToString( object->getClassRep()->getSizeof() ) );
    array->push_back( "Object|Description", object->describeSelf() );
    array->push_back( "Object|FileName", object->getFilename() );

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -151,15 +151,15 @@ void SimObject::initPersistFields()
 
       addProtectedField( "name", TypeName, Offset(mObjectName, SimObject), &setProtectedName, &defaultProtectedGetFn,
          "Optional global name of this object." );
-                  
+
    endGroup( "Ungrouped" );
 
    addGroup( "Object" );
 
-      addField( "internalName", TypeString, Offset(mInternalName, SimObject), 
+      addField( "internalName", TypeString, Offset(mInternalName, SimObject),
          "Optional name that may be used to lookup this object within a SimSet.");
 
-      addProtectedField( "parentGroup", TYPEID< SimObject >(), Offset(mGroup, SimObject), &setProtectedParent, &defaultProtectedGetFn, 
+      addProtectedField( "parentGroup", TYPEID< SimObject >(), Offset(mGroup, SimObject), &setProtectedParent, &defaultProtectedGetFn,
          "Group hierarchy parent of the object." );
 
       addProtectedField( "class", TypeString, Offset(mClassName, SimObject), &setClass, &defaultProtectedGetFn,
@@ -173,31 +173,31 @@ void SimObject::initPersistFields()
          "Script class of object.", AbstractClassRep::FIELD_HideInInspectors );
 
    endGroup( "Object" );
-   
+
    addGroup( "Editing" );
-   
+
       addProtectedField( "hidden", TypeBool, NULL,
          &_setHidden, &_getHidden,
          "Whether the object is visible." );
       addProtectedField( "locked", TypeBool, NULL,
          &_setLocked, &_getLocked,
          "Whether the object can be edited." );
-   
+
    endGroup( "Editing" );
-   
+
    addGroup( "Persistence" );
 
       addProtectedField( "canSave", TypeBool, Offset( mFlags, SimObject ),
          &_setCanSave, &_getCanSave,
          "Whether the object can be saved out. If false, the object is purely transient in nature." );
 
-      addField( "canSaveDynamicFields", TypeBool, Offset(mCanSaveFieldDictionary, SimObject), 
+      addField( "canSaveDynamicFields", TypeBool, Offset(mCanSaveFieldDictionary, SimObject),
          "True if dynamic fields (added at runtime) should be saved. Defaults to true." );
-   
+
       addProtectedField( "persistentId", TypePID, Offset( mPersistentId, SimObject ),
          &_setPersistentID, &defaultProtectedGetFn,
          "The universally unique identifier for the object." );
-   
+
    endGroup( "Persistence" );
 
    Parent::initPersistFields();
@@ -208,7 +208,7 @@ void SimObject::initPersistFields()
 String SimObject::describeSelf() const
 {
    String desc = Parent::describeSelf();
-   
+
    if( mId != 0 )
       desc = avar( "%s|id: %i", desc.c_str(), mId );
    if(mObjectName)
@@ -230,7 +230,7 @@ String SimObject::describeSelf() const
 // Copies dynamic fields from one object to another, optionally limited by the settings for
 // <filter> and <no_replace>. When true, <no_replace> prohibits the replacement of fields that
 // already have a value. When <filter> is specified, only fields with leading characters that
-// exactly match the characters in <filter> are copied. 
+// exactly match the characters in <filter> are copied.
 void SimObject::assignDynamicFieldsFrom(SimObject* from, const char* filter, bool no_replace)
 {
    if (from->mFieldDictionary)
@@ -278,9 +278,9 @@ bool SimObject::writeField(StringTableEntry fieldname, const char* value)
    static StringTableEntry sPersistentId = StringTable->insert( "persistentId" );
    if( fieldname == sPersistentId && ( !value || !value[ 0 ] ) )
       return false;
-      
+
    // Don't write hidden and locked flags if they are at their default value.
-      
+
    static StringTableEntry sHidden = StringTable->insert( "hidden" );
    static StringTableEntry sLocked = StringTable->insert( "locked" );
 
@@ -297,7 +297,7 @@ bool SimObject::writeField(StringTableEntry fieldname, const char* value)
 void SimObject::writeFields(Stream &stream, U32 tabStop)
 {
    // Write static fields.
-   
+
    const AbstractClassRep::FieldList &list = getFieldList();
 
    for(U32 i = 0; i < list.size(); i++)
@@ -353,9 +353,9 @@ void SimObject::writeFields(Stream &stream, U32 tabStop)
          stream.write(dStrlen(expandedBuffer),expandedBuffer);
       }
    }
-   
+
    // Write dynamic fields, if enabled.
-   
+
    if(mFieldDictionary && mCanSaveFieldDictionary)
       mFieldDictionary->writeFields(this, stream, tabStop);
 }
@@ -366,7 +366,7 @@ void SimObject::write(Stream &stream, U32 tabStop, U32 flags)
 {
    if( !getCanSave() && !( flags & IgnoreCanSave ) )
       return;
-      
+
    // Only output selected objects if they want that.
    if((flags & SelectedOnly) && !isSelected())
       return;
@@ -426,8 +426,8 @@ bool SimObject::save(const char *pcFileName, bool bOnlySelected, const char *pre
    }
    stream->write(dStrlen(beginMessage), beginMessage);
    stream->write(2, "\r\n");
-   if ( preappend != NULL )   
-      stream->write(dStrlen(preappend),preappend);   
+   if ( preappend != NULL )
+      stream->write(dStrlen(preappend),preappend);
    write(*stream, 0, writeFlags);
    stream->write(dStrlen(endMessage), endMessage);
    stream->write(2, "\r\n");
@@ -634,10 +634,10 @@ bool SimObject::registerObject()
       dSprintf( mIdString, sizeof( mIdString ), "%u", mId );
    }
 
-   AssertFatal(Sim::gIdDictionary && Sim::gNameDictionary, 
+   AssertFatal(Sim::gIdDictionary && Sim::gNameDictionary,
       "SimObject::registerObject - tried to register an object before Sim::init()!");
 
-   Sim::gIdDictionary->insert(this);   
+   Sim::gIdDictionary->insert(this);
 
    Sim::gNameDictionary->insert(this);
 
@@ -759,7 +759,7 @@ void SimObject::assignName(const char *name)
       Con::errorf( "SimObject::assignName - not allowed to change name of object '%s'", mObjectName);
       return;
    }
-   
+
    // Added this assert 3/30/2007 because it is dumb to try to name
    // a SimObject the same thing as it's class name -patw
    //AssertFatal( dStricmp( getClassName(), name ), "Attempted to assign a name to a SimObject which matches it's type name." );
@@ -780,9 +780,9 @@ void SimObject::assignName(const char *name)
       unlinkNamespaces();
       Sim::gNameDictionary->remove( this );
    }
-      
+
    mObjectName = newName;
-   
+
    if( mGroup )
       mGroup->mNameDictionary.insert( this );
    if( isProperlyAdded() )
@@ -842,13 +842,13 @@ bool SimObject::isMethod( const char* methodName )
 bool SimObject::isField( const char* fieldName, bool includeStatic, bool includeDynamic )
 {
    const char* strFieldName = StringTable->insert( fieldName );
-   
+
    if( includeStatic && getClassRep()->findField( strFieldName ) )
       return true;
-   
+
    if( includeDynamic && getFieldDictionary() && getFieldDictionary()->findDynamicField( strFieldName ) )
       return true;
-   
+
    return false;
 }
 
@@ -870,7 +870,7 @@ void SimObject::assignFieldsFrom(SimObject *parent)
 {
    // Only allow field assigns from objects of the same class or
    // a superclass.
-   
+
    if( getClassRep()->isClass( parent->getClassRep() ) )
    {
       const AbstractClassRep::FieldList &list = parent->getFieldList();
@@ -883,13 +883,13 @@ void SimObject::assignFieldsFrom(SimObject *parent)
          // Skip the special field types.
          if ( f->type >= AbstractClassRep::ARCFirstCustomField )
             continue;
-            
+
          // Skip certain fields that we don't want to see copied so we don't
          // get error messages from their setters.
-            
+
          static StringTableEntry sName = StringTable->insert( "name" );
          static StringTableEntry sPersistentId = StringTable->insert( "persistentId" );
-         
+
          if( f->pFieldname == sName || f->pFieldname == sPersistentId )
             continue;
 
@@ -955,14 +955,14 @@ void SimObject::setDataField(StringTableEntry slotName, const char *array, const
          {
             if (!this->allowSubstitutions())
             {
-               Con::errorf("Substitution Error: %s datablocks do not allow \"$$\" field substitutions. [%s]", 
+               Con::errorf("Substitution Error: %s datablocks do not allow \"$$\" field substitutions. [%s]",
                   this->getClassName(), this->getName());
                return;
             }
 
             if (fld->doNotSubstitute)
             {
-               Con::errorf("Substitution Error: field \"%s\" of datablock %s prohibits \"$$\" field substitutions. [%s]", 
+               Con::errorf("Substitution Error: field \"%s\" of datablock %s prohibits \"$$\" field substitutions. [%s]",
                   slotName, this->getClassName(), this->getName());
                return;
             }
@@ -971,7 +971,7 @@ void SimObject::setDataField(StringTableEntry slotName, const char *array, const
             ((SimDataBlock*)this)->addSubstitution(slotName, array1, value);
             return;
          }
-		 
+
          if(array1 >= 0 && array1 < fld->elementCount && fld->elementCount >= 1)
          {
             // If the set data notify callback returns true, then go ahead and
@@ -1366,7 +1366,7 @@ void SimObject::setDataFieldType(const char *typeName, StringTableEntry slotName
 // This is the copy-constructor used to create temporary datablock clones.
 // The <temp_clone> argument is added to distinguish this copy-constructor
 // from any general-purpose copy-constructor that might be needed in the
-// future. <temp_clone> should always be true when creating temporary 
+// future. <temp_clone> should always be true when creating temporary
 // datablock clones.
 //
 SimObject::SimObject(const SimObject& other, bool temp_clone)
@@ -1418,18 +1418,18 @@ SimObject* SimObject::clone()
 {
    if( !getClassRep() )
       return NULL;
-      
+
    ConsoleObject* conObject = getClassRep()->create();
    if( !conObject )
       return NULL;
-      
+
    SimObject* simObject = dynamic_cast< SimObject* >( conObject );
    if( !simObject )
    {
       delete conObject;
       return NULL;
    }
-   
+
    simObject->assignFieldsFrom( this );
 
    String name = Sim::getUniqueName( getName() );
@@ -1438,10 +1438,10 @@ SimObject* SimObject::clone()
       delete simObject;
       return NULL;
    }
-      
+
    if( getGroup() )
       getGroup()->addObject( simObject );
-   
+
    return simObject;
 }
 
@@ -1567,7 +1567,7 @@ void SimObject::dumpGroupHierarchy()
    String objectName( getName() );
 
    Con::warnf( "[%i] %s - %s ->", getId(), className.c_str(), objectName.c_str() );
-   
+
    if ( mGroup )
       mGroup->dumpGroupHierarchy();
 }
@@ -1883,7 +1883,7 @@ void SimObject::linkNamespaces()
                mSuperClassName,
                getClassName()
             );
-            
+
             // Clear out superclass name so we don't come across it during
             // unlinking.
 
@@ -1970,7 +1970,7 @@ void SimObject::unlinkNamespaces()
       Namespace* superClassNamespace = Con::lookupNamespace( mSuperClassName );
 
       // Make it the parent namespace.
-      
+
       parentNamespace = superClassNamespace;
 
       // Decrease parent refcounts on the superclass hierarchy.
@@ -2018,21 +2018,21 @@ void SimObject::setClassNamespace( const char *classNamespace )
 {
    StringTableEntry oldClassNamespace = mClassName;
    StringTableEntry newClassNamespace = StringTable->insert( classNamespace );
-   
+
    if( oldClassNamespace == newClassNamespace )
       return;
-      
+
    if( isProperlyAdded() )
       unlinkNamespaces();
 
    mClassName = newClassNamespace;
-   
+
    if( isProperlyAdded() )
    {
       linkNamespaces();
-      
+
       // Restore old namespace setup if linkage failed.
-      
+
       if( mClassName != newClassNamespace )
       {
          mClassName = oldClassNamespace;
@@ -2047,21 +2047,21 @@ void SimObject::setSuperClassNamespace( const char *superClassNamespace )
 {
    StringTableEntry oldSuperClassNamespace = mSuperClassName;
    StringTableEntry newSuperClassNamespace = StringTable->insert( superClassNamespace );
-   
+
    if( oldSuperClassNamespace == newSuperClassNamespace )
       return;
-      
+
    if( isProperlyAdded() )
       unlinkNamespaces();
-   
+
    mSuperClassName = newSuperClassNamespace;
-   
+
    if( isProperlyAdded() )
    {
       linkNamespaces();
-      
+
       // Restore old setup if linkage failed.
-      
+
       if( mSuperClassName != newSuperClassNamespace )
       {
          mSuperClassName = oldSuperClassNamespace;
@@ -2133,7 +2133,7 @@ bool SimObject::isSelectedRecursive() const
       walk = walk->getGroup();
    }
 
-   return false;   
+   return false;
 }
 
 //-----------------------------------------------------------------------------
@@ -2215,13 +2215,13 @@ bool SimObject::setProtectedParent( void *obj, const char *index, const char *da
 //-----------------------------------------------------------------------------
 
 bool SimObject::setProtectedName(void *obj, const char *index, const char *data)
-{   
+{
    if (preventNameChanging)
       return false;
    SimObject *object = static_cast<SimObject*>(obj);
-   
+
    if ( object->isProperlyAdded() )
-      object->assignName( data );   
+      object->assignName( data );
 
    // always return false because we assign the name here
    return false;
@@ -2246,13 +2246,13 @@ String SimObject::_getLogMessage(const char* fmt, va_list args) const
    String objClass = "UnknownClass";
    if(getClassRep())
       objClass = getClassRep()->getClassName();
-      
+
    String objName = getName();
    if(objName.isEmpty())
       objName = "Unnamed";
-   
+
    String formattedMessage = String::VToString(fmt, args);
-   return String::ToString("%s - %s(%i) - %s", 
+   return String::ToString("%s - %s(%i) - %s",
       objClass.c_str(), objName.c_str(), getId(), formattedMessage.c_str());
 }
 
@@ -2399,7 +2399,7 @@ static void sEnumCallback( EngineObject* object )
    SimObject* simObject = dynamic_cast< SimObject* >( object );
    if( !simObject )
       return;
-      
+
    Con::evaluatef( "%s( %i );", sEnumCallbackFunction, simObject->getId() );
 }
 
@@ -2543,10 +2543,10 @@ DefineEngineMethod( SimObject, dumpMethods, ArrayObject*, (),,
    Namespace *ns = object->getNamespace();
    if( !ns )
       return 0;
-      
+
    ArrayObject* dictionary = new ArrayObject();
    dictionary->registerObject();
-   
+
    VectorPtr<Namespace::Entry *> vec(__FILE__, __LINE__);
    ns->getEntryList(&vec);
 
@@ -2556,9 +2556,9 @@ DefineEngineMethod( SimObject, dumpMethods, ArrayObject*, (),,
 
       if( e->mType < 0 )
          continue;
-         
+
       StringBuilder str;
-      
+
       str.append( String::ToString( e->mMinArgs ) );
       str.append( '\n' );
       str.append( String::ToString( e->mMaxArgs ) );
@@ -2579,7 +2579,7 @@ DefineEngineMethod( SimObject, dumpMethods, ArrayObject*, (),,
 
       dictionary->push_back( e->mFunctionName, str.end() );
    }
-   
+
    return dictionary;
 }
 
@@ -2593,14 +2593,14 @@ namespace {
 
       return dStricmp(fa->pFieldname, fb->pFieldname);
    }
-   
+
    struct DocString
    {
       char mPadding[ 8 ];
       String mPrototype;
       String mDescription;
       const char* mReturnType;
-      
+
       DocString( Namespace::Entry* entry )
          : mPrototype( entry->getArgumentsString() ),
            mDescription( entry->getBriefDescription() )
@@ -2621,7 +2621,7 @@ namespace {
                   mPadding[ 1 ] = ' ';
                   mPadding[ 2 ] = 0;
                   break;
-                  
+
                case Namespace::Entry::IntCallbackType:
                   mReturnType = "int";
                   mPadding[ 0 ] = ' ';
@@ -2656,7 +2656,7 @@ namespace {
                   mPadding[ 2 ] = ' ';
                   mPadding[ 3 ] = ' ';
                   mPadding[ 4 ] = 0;
-                  break;                  
+                  break;
             }
          }
       }
@@ -2668,7 +2668,7 @@ DefineEngineMethod( SimObject, dump, void, ( bool detailed ), ( false ),
    "@param detailed Whether to print detailed information about members." )
 {
    Con::printf( "Class: %s", object->getClassName() );
-   
+
    const AbstractClassRep::FieldList &list = object->getFieldList();
    char expandedBuffer[4096];
 
@@ -2691,10 +2691,10 @@ DefineEngineMethod( SimObject, dump, void, ( bool detailed ), ( false ),
       for(U32 j = 0; S32(j) < f->elementCount; j++)
       {
          // [neo, 07/05/2007 - #3000]
-         // Some objects use dummy vars and projected fields so make sure we call the get functions 
-         //const char *val = Con::getData(f->type, (void *) (((const char *)object) + f->offset), j, f->table, f->flag);                          
+         // Some objects use dummy vars and projected fields so make sure we call the get functions
+         //const char *val = Con::getData(f->type, (void *) (((const char *)object) + f->offset), j, f->table, f->flag);
          const char *val = (*f->getDataFn)( object, Con::getData(f->type, (void *) (((const char *)object) + f->offset), j, f->table, f->flag) );// + typeSizes[fld.type] * array1));
-         
+
          ConsoleBaseType* conType = ConsoleBaseType::getType( f->type );
          const char* conTypeName = "<unknown>";
          if( conType )
@@ -2708,7 +2708,7 @@ DefineEngineMethod( SimObject, dump, void, ( bool detailed ), ( false ),
             dSprintf( expandedBuffer, sizeof( expandedBuffer ), "  %s %s[ %d ] = \"", conTypeName, f->pFieldname, j );
          expandEscape( expandedBuffer + dStrlen(expandedBuffer), val);
          Con::printf( "%s\"", expandedBuffer );
-         
+
          if( detailed && f->pFieldDocs && f->pFieldDocs[ 0 ] )
             Con::printf( "    %s", f->pFieldDocs );
       }
@@ -2746,7 +2746,7 @@ DefineEngineMethod( SimObject, dump, void, ( bool detailed ), ( false ),
 
       if(e->mType < 0)
          continue;
-         
+
       DocString doc( e );
       Con::printf( "  %s%s%s%s", doc.mReturnType, doc.mPadding, e->mFunctionName, doc.mPrototype.c_str() );
 
@@ -2840,36 +2840,36 @@ DefineEngineMethod( SimObject, getFieldValue, const char*, ( const char* fieldNa
 
    char fieldNameBuffer[ 1024 ];
    char arrayIndexBuffer[ 64 ];
-   
+
    // Parse out index if the field is given in the form of 'name[index]'.
-   
+
    const char* arrayIndex = NULL;
    if( fieldName[ nameLen - 1 ] == ']' )
    {
       const char* leftBracket = dStrchr( fieldName, '[' );
       const char* rightBracket = &fieldName[ nameLen - 1 ];
-      
+
       const U32 fieldNameLen = getMin( U32( leftBracket - fieldName ), sizeof( fieldNameBuffer ) - 1 );
       const U32 arrayIndexLen = getMin( U32( rightBracket - leftBracket - 1 ), sizeof( arrayIndexBuffer ) - 1 );
-      
+
       dMemcpy( fieldNameBuffer, fieldName, fieldNameLen );
       dMemcpy( arrayIndexBuffer, leftBracket + 1, arrayIndexLen );
-      
+
       fieldNameBuffer[ fieldNameLen ] = '\0';
       arrayIndexBuffer[ arrayIndexLen ] = '\0';
-      
+
       fieldName = fieldNameBuffer;
       arrayIndex = arrayIndexBuffer;
    }
 
    fieldName = StringTable->insert( fieldName );
-   
+
    if( index != -1 )
    {
       dSprintf( arrayIndexBuffer, sizeof( arrayIndexBuffer ), "%i", index );
       arrayIndex = arrayIndexBuffer;
    }
-   
+
    return object->getDataField( fieldName, arrayIndex );
 }
 
@@ -2884,25 +2884,25 @@ DefineEngineMethod( SimObject, setFieldValue, bool, ( const char* fieldName, con
 {
    char fieldNameBuffer[ 1024 ];
    char arrayIndexBuffer[ 64 ];
-   
+
    // Parse out index if the field is given in the form of 'name[index]'.
-   
+
    const char* arrayIndex = NULL;
    const U32 nameLen = dStrlen( fieldName );
    if( fieldName[ nameLen - 1 ] == ']' )
    {
       const char* leftBracket = dStrchr( fieldName, '[' );
       const char* rightBracket = &fieldName[ nameLen - 1 ];
-      
+
       const U32 fieldNameLen = getMin( U32( leftBracket - fieldName ), sizeof( fieldNameBuffer ) - 1 );
       const U32 arrayIndexLen = getMin( U32( rightBracket - leftBracket - 1 ), sizeof( arrayIndexBuffer ) - 1 );
-      
+
       dMemcpy( fieldNameBuffer, fieldName, fieldNameLen );
       dMemcpy( arrayIndexBuffer, leftBracket + 1, arrayIndexLen );
-      
+
       fieldNameBuffer[ fieldNameLen ] = '\0';
       arrayIndexBuffer[ arrayIndexLen ] = '\0';
-      
+
       fieldName = fieldNameBuffer;
       arrayIndex = arrayIndexBuffer;
    }
@@ -3013,10 +3013,10 @@ DefineEngineMethod( SimObject, isInNamespaceHierarchy, bool, ( const char* name 
    "@return True if the given namespace name is within the namespace hierarchy of this object." )
 {
    Namespace* nspace = object->getNamespace();
-      
+
    while( nspace && dStricmp( nspace->mName, name ) != 0 )
       nspace = nspace->mParent;
-      
+
    return ( nspace != NULL );
 }
 
@@ -3177,7 +3177,7 @@ DefineEngineMethod( SimObject, getDebugInfo, ArrayObject*, (),,
 {
    ArrayObject* array = new ArrayObject();
    array->registerObject();
-   
+
    array->push_back( "C++|Address", String::ToString( "0x%x", object ) );
    array->push_back( "C++|Size", String::ToString( object->getClassRep()->getSizeof() ) );
    array->push_back( "Object|Description", object->describeSelf() );
@@ -3193,11 +3193,11 @@ DefineEngineMethod( SimObject, getDebugInfo, ArrayObject*, (),,
    array->push_back( "Flag|ModStaticFields", object->canModStaticFields() ? "true" : "false" );
    array->push_back( "Flag|ModDynamicFields", object->canModDynamicFields() ? "true" : "false" );
    array->push_back( "Flag|CanSave", object->getCanSave() ? "true" : "false" );
-   
+
    #ifndef TORQUE_DISABLE_MEMORY_MANAGER
    Memory::Info memInfo;
    Memory::getMemoryInfo( object, memInfo );
-   
+
    array->push_back( "Memory|AllocNumber", String::ToString( memInfo.mAllocNumber ) );
    array->push_back( "Memory|AllocSize", String::ToString( memInfo.mAllocSize ) );
    array->push_back( "Memory|AllocFile", memInfo.mFileName );
@@ -3205,7 +3205,7 @@ DefineEngineMethod( SimObject, getDebugInfo, ArrayObject*, (),,
    array->push_back( "Memory|IsGlobal", memInfo.mIsGlobal ? "true" : "false" );
    array->push_back( "Memory|IsStatic", memInfo.mIsStatic ? "true" : "false" );
    #endif
-   
+
    return array;
 }
 


### PR DESCRIPTION
These are just small changes. 

Trailing whitespaces removal was automatically done in vim
Fixing pointer format in getDebugInfo() helps debugging under gdb.
