### PR TITLE
Fix fatal error in project generation on PHP 7.0+

### DIFF
--- a/Tools/projectGenerator/classes/Solution.php
+++ b/Tools/projectGenerator/classes/Solution.php
@@ -106,7 +106,7 @@ class Solution
 		{
 		    echo( "Solution::generate() - no project refs found for solution: " . $this->name . "\n" );
 		    
-		    continue;
+		    return;
 		}
 		
 		// 


### PR DESCRIPTION
A piece of (probably normally unreachable code) was triggering a fatal error when run with PHP 7.0+, probably because of the optimizer checking it before execution. There was simply a `continue` statement that was not in the scope of a loop or switch statement. The only effect this really has is with fixing generating projects on linux/mac with a newer version of PHP on the system.